### PR TITLE
global CLI version checks and warnings

### DIFF
--- a/packages/gasket-cli/src/commands/create.js
+++ b/packages/gasket-cli/src/commands/create.js
@@ -10,6 +10,7 @@ const makeCreateContext = require('../scaffold/create-context');
 const {
   mkDir,
   loadPreset,
+  cliVersion,
   globalPrompts,
   setupPkg,
   writePkg,
@@ -51,6 +52,7 @@ class CreateCommand extends Command {
     try {
       if (bootstrap !== false) {
         await loadPreset(context);
+        cliVersion(context);
         applyPresetConfig(context);
         await globalPrompts(context);
         await mkDir(context);

--- a/packages/gasket-cli/src/scaffold/actions/cli-version.js
+++ b/packages/gasket-cli/src/scaffold/actions/cli-version.js
@@ -1,0 +1,81 @@
+const semver = require('semver');
+const action = require('../action-wrapper');
+const pkgVersion = require('../../../package.json').version;
+const pkgVersionCompatible = `^${pkgVersion}`;
+
+/**
+ * Helper to check if a module version is a file path
+ *
+ * @param {string} v - Version to check
+ * @returns {Boolean} result
+ */
+const isFile = v => v && v.includes('file:');
+
+/**
+ * Determines the active cli version, and the version required to be installed for app.
+ *
+ * @param {CreateContext} context - Create context
+ * @param {Spinner} spinner - Spinner
+ */
+function resolveCliVersion(context, spinner) {
+  const { presetPkgs, warnings } = context;
+
+  //
+  // Gather presets with cli dependencies
+  //
+  const cliPresets = presetPkgs.filter(p => p.dependencies && p.dependencies['@gasket/cli']);
+
+  //
+  // Find the preset with minimum cli version required.
+  // File paths are always preferred; for integration tests and local development
+  //
+  const minPreset = cliPresets.reduce((acc, cur) => {
+    const nextVersion = cur.dependencies['@gasket/cli'];
+    const prevVersion = acc && acc.dependencies['@gasket/cli'];
+    if (isFile(nextVersion)) return cur;
+    if (isFile(prevVersion)) return acc;
+    return !acc || semver.gt(semver.coerce(prevVersion), semver.coerce(nextVersion)) ? cur : acc;
+  }, null);
+
+  const requiredVersion = minPreset && minPreset.dependencies['@gasket/cli'];
+
+  //
+  // Issue warnings if determined cli version does not meet a preset's requirements
+  //
+  if (requiredVersion && !isFile(requiredVersion)) {
+    let hasWarning = false;
+    cliPresets.forEach(p => {
+      const v = p.dependencies['@gasket/cli'];
+      // installed version mismatch
+      if (!semver.satisfies(semver.coerce(v).version, requiredVersion)) {
+        warnings.push(
+          `Installed @gasket/cli@${requiredVersion} for ${minPreset.name}@${minPreset.version} ` +
+          `which does not satisfy version (${v}) ` +
+          `required by ${p.name}@${p.version}`
+        );
+        hasWarning = true;
+      }
+    });
+
+    //
+    // Issue warnings if globally installed version mismatch with app installed
+    //
+    if (!semver.satisfies(pkgVersion, requiredVersion)) {
+      warnings.push(
+        `Installed @gasket/cli@${requiredVersion} ` +
+        `which is not compatible with global version (${pkgVersion}) ` +
+        `used to execute \`gasket create\``
+      );
+      hasWarning = true;
+    }
+
+    if (hasWarning) spinner.warn('CLI version mismatch');
+  }
+
+  Object.assign(context, {
+    cliVersion: pkgVersion,
+    cliVersionRequired: requiredVersion || pkgVersionCompatible
+  });
+}
+
+module.exports = action('Resolve CLI versions', resolveCliVersion, { startSpinner: false });

--- a/packages/gasket-cli/src/scaffold/actions/index.js
+++ b/packages/gasket-cli/src/scaffold/actions/index.js
@@ -1,6 +1,7 @@
 
 const mkDir = require('./mkdir');
 const loadPreset = require('./load-preset');
+const cliVersion = require('./cli-version');
 const globalPrompts = require('./global-prompts');
 const setupPkg = require('./setup-pkg');
 const writePkg = require('./write-pkg');
@@ -18,6 +19,7 @@ const printReport = require('./print-report');
 module.exports = {
   mkDir,
   loadPreset,
+  cliVersion,
   globalPrompts,
   setupPkg,
   writePkg,

--- a/packages/gasket-cli/src/scaffold/actions/setup-pkg.js
+++ b/packages/gasket-cli/src/scaffold/actions/setup-pkg.js
@@ -1,81 +1,16 @@
-const semver = require('semver');
 const action = require('../action-wrapper');
 const ConfigBuilder = require('../config-builder');
 const { addPluginsToPkg } = require('../plugin-utils');
 const { presetIdentifier } = require('../package-identifier');
-const pkgVersion = require('../../../package.json').version;
-const pkgVersionCompatible = `^${pkgVersion}`;
-const actionLabel = 'Set up package.json';
-/**
- * Helper to check if a module version is a file path
- *
- * @param {string} v - Version to check
- * @returns {Boolean} result
- */
-const isFile = v => v && v.includes('file:');
 
 /**
  * Initializes the ConfigBuilder builder and adds to context.
  *
  * @param {CreateContext} context - Create context
- * @param {Spinner} spinner - Spinner
  * @returns {Promise} promise
  */
-async function setupPkg(context, spinner) {
-  const { appName, appDescription, rawPresets, presetPkgs, rawPlugins = [], warnings } = context;
-
-  //
-  // Gather presets with cli dependencies
-  //
-  const cliPresets = presetPkgs.filter(p => p.dependencies && p.dependencies['@gasket/cli']);
-
-  //
-  // Find the preset with minimum cli version required.
-  // File paths are always preferred; for integration tests and local development
-  //
-  const minPreset = cliPresets.reduce((acc, cur) => {
-    const nextVersion = cur.dependencies['@gasket/cli'];
-    const prevVersion = acc && acc.dependencies['@gasket/cli'];
-    if (isFile(nextVersion)) return cur;
-    if (isFile(prevVersion)) return acc;
-    return !acc || semver.gt(semver.coerce(prevVersion), semver.coerce(nextVersion)) ? cur : acc;
-  }, null);
-
-  const cliVersion = minPreset && minPreset.dependencies['@gasket/cli'];
-
-  //
-  // Issue warnings if determined cli version does not meet a preset's requirements
-  //
-  if (!isFile(cliVersion)) {
-    let hasWarning = false;
-    cliPresets.forEach(p => {
-      const v = p.dependencies['@gasket/cli'];
-      // installed version mismatch
-      if (!semver.satisfies(semver.coerce(v).version, cliVersion)) {
-        warnings.push(
-          `Installed @gasket/cli@${cliVersion} for ${minPreset.name}@${minPreset.version} ` +
-          `which does not satisfy version (${v}) ` +
-          `required by ${p.name}@${p.version}`
-        );
-        hasWarning = true;
-      }
-    });
-
-    //
-    // Issue warnings if globally installed version mismatch with app installed
-    //
-    console.log(pkgVersion, cliVersion, semver.satisfies(pkgVersion, cliVersion));
-    if (!semver.satisfies(pkgVersion, cliVersion)) {
-      warnings.push(
-        `Installed @gasket/cli@${cliVersion} ` +
-        `which is not compatible with global version (${pkgVersion}) ` +
-        `used to execute \`gasket create\``
-      );
-      hasWarning = true;
-    }
-
-    if (hasWarning) spinner.warn(actionLabel + ' (cli version mismatch)');
-  }
+async function setupPkg(context) {
+  const { appName, appDescription, rawPresets, presetPkgs, rawPlugins = [], cliVersionRequired } = context;
 
   const pkg = ConfigBuilder.createPackageJson({
     name: appName,
@@ -92,11 +27,11 @@ async function setupPkg(context, spinner) {
     acc[fullName] = version;
     return acc;
   }, {
-    '@gasket/cli': cliVersion || pkgVersionCompatible
+    '@gasket/cli': cliVersionRequired
   }));
   addPluginsToPkg(rawPlugins, pkg);
 
   Object.assign(context, { pkg });
 }
 
-module.exports = action(actionLabel, setupPkg, { startSpinner: false });
+module.exports = action('Set up package.json', setupPkg, { startSpinner: false });

--- a/packages/gasket-cli/src/scaffold/create-context.js
+++ b/packages/gasket-cli/src/scaffold/create-context.js
@@ -93,6 +93,11 @@ function flatten(acc, values) {
  * @property {Object[]} presetPkgs - Contents of the preset's package.json
  * @property {PluginName[]} presetPlugins - All the plugins which are dependencies of the preset
  *
+ * -- Added by `cli-version`
+ *
+ * @property {string} cliVersion - Version of current CLI used to issue `create` command
+ * @property {string} cliVersionRequired - Version of CLI to install, either current or min compatible version required by preset(s)
+ *
  * -- Added by `setup-pkg`
  *
  * @property {ConfigBuilder} pkg - package.json builder

--- a/packages/gasket-cli/test/unit/commands/create.test.js
+++ b/packages/gasket-cli/test/unit/commands/create.test.js
@@ -18,6 +18,7 @@ describe('create', function () {
     actionStubs = {
       mkDir: sandbox.stub(),
       loadPreset: sandbox.stub(),
+      cliVersion: sandbox.stub(),
       globalPrompts: sandbox.stub(),
       setupPkg: sandbox.stub(),
       writePkg: sandbox.stub(),

--- a/packages/gasket-cli/test/unit/scaffold/actions/cli-version.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/cli-version.test.js
@@ -1,0 +1,194 @@
+/* eslint-disable max-statements */
+const sinon = require('sinon');
+const assume = require('assume');
+const proxyquire = require('proxyquire');
+const pkgVersion = require('../../../../package.json').version;
+
+describe('cliVersion', () => {
+  let sandbox, mockContext, cliVersion;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    cliVersion = proxyquire('../../../../src/scaffold/actions/cli-version', {
+      '../action-wrapper': require('../../../helpers').mockActionWrapper
+    });
+
+    mockContext = {
+      appName: 'my-app',
+      appDescription: 'my cool app',
+      rawPresets: ['@gasket/bogus-preset'],
+      presetPkgs: [{
+        name: '@gasket/bogus-preset',
+        version: '3.2.1'
+      }],
+      warnings: []
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('is decorated action', async () => {
+    assume(cliVersion).property('wrapped');
+  });
+
+  it('adds active cliVersion to context', async () => {
+    await cliVersion(mockContext);
+    assume(mockContext).property('cliVersion');
+  });
+
+  it('adds cliVersionRequired to context', async () => {
+    await cliVersion(mockContext);
+    assume(mockContext).property('cliVersionRequired');
+  });
+
+  it('derives active cliVersion from own package', async () => {
+    await cliVersion(mockContext);
+    assume(mockContext).property('cliVersion', pkgVersion);
+  });
+
+  it('derives cliVersionRequired from own package', async () => {
+    await cliVersion(mockContext);
+    assume(mockContext).property('cliVersionRequired', `^${pkgVersion}`);
+  });
+
+  it('uses own cli version if not specified in preset', async () => {
+    mockContext.presetPkgs = [{
+      name: '@gasket/bogus-preset',
+      version: '30.20.10',
+      dependencies: {}
+    }];
+    await cliVersion(mockContext);
+    assume(mockContext).property('cliVersionRequired', `^${pkgVersion}`);
+  });
+
+  it('derives cli version from preset', async () => {
+    mockContext.presetPkgs = [{
+      name: '@gasket/bogus-preset',
+      version: '30.20.10',
+      dependencies: { '@gasket/cli': '^1.2.3' }
+    }];
+    await cliVersion(mockContext);
+    assume(mockContext).property('cliVersionRequired', `^1.2.3`);
+  });
+
+  it('derives minimum cli version from multiple presets', async () => {
+    mockContext.presetPkgs = [{
+      name: '@gasket/bogus-a-preset',
+      version: '10.20.30',
+      dependencies: { '@gasket/cli': '^1.3.4' }
+    }, {
+      name: '@gasket/bogus-b-preset',
+      version: '10.20.30',
+      dependencies: { '@gasket/cli': '^2.9.9' }
+    }, {
+      name: '@gasket/bogus-c-preset',
+      version: '30.20.10',
+      dependencies: { '@gasket/cli': '^1.2.3' }
+    }];
+    await cliVersion(mockContext);
+    assume(mockContext).property('cliVersionRequired', `^1.2.3`);
+  });
+
+  it('issues warning if global cli is not compatible with installed version', async () => {
+    mockContext.presetPkgs = [{
+      name: '@gasket/bogus-a-preset',
+      version: '10.20.30',
+      dependencies: { '@gasket/cli': '^1.2.3' }
+    }];
+    await cliVersion(mockContext);
+    assume(mockContext.warnings).atleast(1);
+    assume(mockContext.warnings).includes(
+      `Installed @gasket/cli@^1.2.3 ` +
+      `which is not compatible with global version (${pkgVersion}) ` +
+      `used to execute \`gasket create\``
+    );
+  });
+
+  it('does not issue warning if global cli is compatible with installed version', async () => {
+    mockContext.presetPkgs = [{
+      name: '@gasket/bogus-a-preset',
+      version: '10.20.30',
+      dependencies: { '@gasket/cli': '^2.2.0' }
+    }];
+    await cliVersion(mockContext);
+    assume(mockContext.warnings).length(0);
+  });
+
+  it('issues warning if cli version does not satisfy a preset', async () => {
+    mockContext.presetPkgs = [{
+      name: '@gasket/bogus-a-preset',
+      version: '10.20.30',
+      dependencies: { '@gasket/cli': '^2.3.4' }
+    }, {
+      name: '@gasket/bogus-b-preset',
+      version: '10.20.30',
+      dependencies: { '@gasket/cli': '^8.9.9' }
+    }, {
+      name: '@gasket/bogus-c-preset',
+      version: '30.20.10',
+      dependencies: { '@gasket/cli': '^2.1.2' }
+    }];
+    await cliVersion(mockContext);
+    assume(mockContext.warnings).atleast(1);
+    assume(mockContext.warnings).includes(
+      'Installed @gasket/cli@^2.1.2 for @gasket/bogus-c-preset@30.20.10 ' +
+      'which does not satisfy version (^8.9.9) ' +
+      'required by @gasket/bogus-b-preset@10.20.30'
+    );
+  });
+
+  it('does not issue warning if cli version does satisfy a preset', async () => {
+    mockContext.presetPkgs = [{
+      name: '@gasket/bogus-a-preset',
+      version: '10.20.30',
+      dependencies: { '@gasket/cli': '^2.3.4' }
+    }, {
+      name: '@gasket/bogus-b-preset',
+      version: '10.20.30',
+      dependencies: { '@gasket/cli': '^2.9.9' }
+    }, {
+      name: '@gasket/bogus-c-preset',
+      version: '30.20.10',
+      dependencies: { '@gasket/cli': '^2.1.2' }
+    }];
+    await cliVersion(mockContext);
+    assume(mockContext.warnings).length(0);
+  });
+
+  it('supports file path for preset cli version', async () => {
+    mockContext.presetPkgs = [{
+      name: '@gasket/bogus-a-preset',
+      version: '10.20.30',
+      dependencies: { '@gasket/cli': 'file:../../../gasket-cli' }
+    }, {
+      name: '@gasket/bogus-b-preset',
+      version: '10.20.30',
+      dependencies: { '@gasket/cli': '^2.9.9' }
+    }];
+    await cliVersion(mockContext);
+    assume(mockContext).property('cliVersionRequired', `file:../../../gasket-cli`);
+  });
+
+  it('shows warning spinner for any warnings', async () => {
+    const warnStub = sinon.stub();
+    mockContext.presetPkgs = [{
+      name: '@gasket/bogus-a-preset',
+      version: '10.20.30',
+      dependencies: { '@gasket/cli': '^2.3.4' }
+    }, {
+      name: '@gasket/bogus-b-preset',
+      version: '10.20.30',
+      dependencies: { '@gasket/cli': '^8.9.9' }
+    }, {
+      name: '@gasket/bogus-c-preset',
+      version: '30.20.10',
+      dependencies: { '@gasket/cli': '^2.1.2' }
+    }];
+    await cliVersion.wrapped(mockContext, { warn: warnStub });
+    assume(mockContext.warnings).atleast(1);
+    assume(warnStub).calledWith('CLI version mismatch');
+  });
+});

--- a/packages/gasket-cli/test/unit/scaffold/actions/index.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/index.test.js
@@ -7,6 +7,7 @@ describe('index', () => {
     const expected = [
       'mkDir',
       'loadPreset',
+      'cliVersion',
       'globalPrompts',
       'setupPkg',
       'writePkg',


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Addressing https://github.com/godaddy/gasket/pull/34#issuecomment-516903748 as separate PR. We will issue a warning (both early in CLI steps, and verbose in results report) if there is a mismatch between required versions of presets and/or the CLI used to issue `gasket create`.

Also, I separated the cli version check to it's own action, for code quality and also will allow us to add a _prompt to continue_ later if we find it necessary.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

- Issue warnings if installed CLI is not compatible with global CLI or a preset's

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Added additional unit tests.

Example output from testing locally, where a preset requires an incompatible version:
```bash
/path/to/gasket/packages/gasket-cli/bin/run create myapp --preset-path /path/to/bad-preset`
```

```
✔ Load presets
⚠ CLI version mismatch
? What is your app description? A basic gasket app
? Which packager would you like to use? npm
? Choose your unit test suite none (not recommended)
✔ Make directory: ./myapp
✔ Write package.json
✔ Install node modules
? What header do you want? internal
? Do you want to use the GoDark theme? Yes
? Do you want a git repo to be initialized? Yes
✔ Execute create hooks
⚠ Generate app contents
✔ Write gasket config
✔ Update package.json
✔ Update node modules
✔ Execute postCreate hooks
✨Success!
  
Finished with 2 warnings and 0 errors using
    _____         __       __
   / ___/__ ____ / /_____ / /_
  / (_ / _ `(_-</  '_/ -_) __/
  \___/\_,_/___/_/\_\\__/\__/

Warnings
  Installed @gasket/cli@^1.15.4 which is not compatible with global version (2.2.0) used to execute `gasket create`
```