### PR TITLE
Fix placeholder reducers never return undefined

### DIFF
--- a/packages/gasket-redux/CHANGELOG.md
+++ b/packages/gasket-redux/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### 3.0.1
+
+- Fix placeholder reducers should never return undefined
+- Fixed make-store export
+
 ### 3.0.0
 
 - Move to monorepo

--- a/packages/gasket-redux/make-store.js
+++ b/packages/gasket-redux/make-store.js
@@ -3,4 +3,4 @@
  * Apps can use custom configurations in which this file will be overridden
  * by webpack alias based the path in on the gasket.config.redux.makeStore
  */
-module.exports = require('./lib/configureMakeStore').default();
+module.exports = require('./lib/configure-make-store').default();

--- a/packages/gasket-redux/src/placeholder-reducers.js
+++ b/packages/gasket-redux/src/placeholder-reducers.js
@@ -12,7 +12,7 @@
  */
 export default function placeholderReducers(reducers = {}, preloadedState = {}) {
   return Object.keys(preloadedState).reduce((acc, cur) => {
-    if (!(cur in reducers)) acc[cur] = f => f || preloadedState[cur];
+    if (!(cur in reducers)) acc[cur] = f => f || preloadedState[cur] || null;
     return acc;
   }, {});
 }

--- a/packages/gasket-redux/test/placeholder-reducers.spec.js
+++ b/packages/gasket-redux/test/placeholder-reducers.spec.js
@@ -46,4 +46,11 @@ describe('placeholdReducers', () => {
     expect(results).not.toEqual('bogus');
     expect(results).toEqual('BOGUS123');
   });
+
+  it('placeholder reducer returns null if initialState is undefined', () => {
+    // eslint-disable-next-line no-undefined
+    mockState.group3 = undefined;
+    results = placeholderReducers(mockReducers, mockState).group3();
+    expect(results).toEqual(null);
+  });
 });


### PR DESCRIPTION

## Summary

Ran into an issue where a redux initial state had a property with an undefined value. This is a safeguard for placeholder reducers to account for.

## Changelog

- Fix placeholder reducers should never return undefined
- Fixed make-store export

## Test Plan

linked and tested against a new `gasket create` app as well as canary-app.