### PR TITLE
Fix `initReduxState` from stomping over existing state

### DIFF
--- a/packages/gasket-intl-plugin/CHANGELOG.md
+++ b/packages/gasket-intl-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `@gasket/intl-plugin`
 
+### 4.0.1
+
+- Fix `initReduxState` from stomping over existing state
+
 ### 4.0.0
 
 - Execute `intlLanguage` lifecycle to determine language

--- a/packages/gasket-intl-plugin/lib/index.js
+++ b/packages/gasket-intl-plugin/lib/index.js
@@ -30,6 +30,7 @@ module.exports = {
       const acceptLanguage = (req.headers['accept-language'] || '').split(',')[0];
       const language = await gasket.execWaterfall('intlLanguage', acceptLanguage, req);
       return {
+        ...state,
         intl: {
           language,
           assetPrefix: getAssetPrefix(gasket),


### PR DESCRIPTION
## Summary

In upgrading the canary-app I uncovered this bug where `initReduxState` was wiping out previous set states. This lifecycle is an `execWaterfall` type, and so should carry forward changes to state.

## Changelog

- Fix `initReduxState` from stomping over existing state

## Test Plan

Verified by linking into the canary app and added unit test.