### PR TITLE
Fix for new apps with intl v4

### DIFF
--- a/packages/gasket-intl-plugin/CHANGELOG.md
+++ b/packages/gasket-intl-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `@gasket/intl-plugin`
 
+### 4.0.2
+
+- Create new apps with `@gasket/intl@4`
+
 ### 4.0.1
 
 - Fix `initReduxState` from stomping over existing state

--- a/packages/gasket-intl-plugin/lib/index.js
+++ b/packages/gasket-intl-plugin/lib/index.js
@@ -47,7 +47,7 @@ module.exports = {
       );
 
       pkg.add('dependencies', {
-        '@gasket/intl': '^3.0.0'
+        '@gasket/intl': '^4.0.0'
       });
     },
     build,

--- a/packages/gasket-intl-plugin/lib/index.spec.js
+++ b/packages/gasket-intl-plugin/lib/index.spec.js
@@ -135,7 +135,7 @@ describe('plugin (index.js)', () => {
 
     it('adds the appropriate dependencies', expectCreatedWith(({ pkg }) => {
       expect(pkg.add).toHaveBeenCalledWith('dependencies', {
-        '@gasket/intl': '^3.0.0'
+        '@gasket/intl': '^4.0.0'
       });
     }));
   });

--- a/packages/gasket-intl/CHANGELOG.md
+++ b/packages/gasket-intl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `@gasket/intl`
 
+### 4.0.1
+
+- Adjust peer dependencies for v4
+
 ### 4.0.0
 
 - Uses intl.language from redux state instead of market cookie

--- a/packages/gasket-intl/package.json
+++ b/packages/gasket-intl/package.json
@@ -68,7 +68,7 @@
     "redux-mock-store": "^1.5.1"
   },
   "peerDependencies": {
-    "@gasket/intl-plugin": "^3.0.0",
+    "@gasket/intl-plugin": "^4.0.0",
     "react-redux": ">=5.0.0 <8.0.0"
   }
 }


### PR DESCRIPTION


## Changelog

- New apps should be created with v4 of `@gasket/intl`
- Adjust peer dependency of `@gasket/intl`

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Testing against new app with `gasket create`