### PR TITLE
[fix] Prevent multipe gasket instances from accessing the same data

### DIFF
--- a/packages/gasket-cli/test/unit/scaffold/fetcher.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/fetcher.test.js
@@ -7,7 +7,7 @@ const { homedir } = require('os');
 describe('fetcher', () => {
   let Fetcher;
   let ManagerStub;
-  const stdout = 'what is happening man\nits all good';
+  const stdout = 'example.tr.gz\nits all good';
 
   function makeFetcher(Manager) {
     return proxyquire('../../../src/scaffold/fetcher', {
@@ -23,15 +23,40 @@ describe('fetcher', () => {
     Fetcher = makeFetcher(ManagerStub);
   });
 
-  it('passes npmconfig to npm pack when defined', async () => {
-    const npmconfig = path.join(homedir(), 'whatever', '.npmrc');
-    const packageName = 'whatever';
-    const fetcher = new Fetcher({
-      npmconfig,
-      packageName
+  describe('#fetch', function () {
+    it('passes npmconfig to npm pack when defined', async () => {
+      const npmconfig = path.join(homedir(), 'whatever', '.npmrc');
+      const packageName = 'whatever';
+      const fetcher = new Fetcher({
+        npmconfig,
+        packageName
+      });
+
+      await fetcher.fetch();
+      assume(ManagerStub.spawnNpm.firstCall.args[0]).contains('--userconfig', npmconfig);
     });
 
-    await fetcher.fetch();
-    assume(ManagerStub.spawnNpm.firstCall.args[0]).contains('--userconfig', npmconfig);
+    it('allows the cwd to be configured for package fetching', async () => {
+      const fetcher = new Fetcher({});
+
+      await fetcher.fetch('example', '/foo/bar');
+      assume(ManagerStub.spawnNpm.firstCall.args[1].cwd).equals('/foo/bar');
+    });
+  });
+
+  describe('#clone', function () {
+    it('fetches the package into the tmp dir', async () => {
+      const npmconfig = path.join(homedir(), 'whatever', '.npmrc');
+      const packageName = 'whatever';
+      const fetcher = new Fetcher({
+        npmconfig,
+        packageName
+      });
+
+      fetcher.unpack = sinon.stub().resolves('example');
+      await fetcher.clone();
+
+      assume(ManagerStub.spawnNpm.firstCall.args[1].cwd).includes(fetcher.tmp.dir);
+    });
   });
 });


### PR DESCRIPTION
When you spawn 2 gasket processes they will fight over the downloaded tarbal of the preset they are using. By leveraging a unique folder for the download per gasket instance you can have as many instances running as possible.