### PR TITLE
(fix) Fix stylelint generator to output properly quoted glob pattern,…

### DIFF
--- a/packages/gasket-cli/CHANGELOG.md
+++ b/packages/gasket-cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/cli`
 
+- Fix package.json scripts to wrap glob patterns in double-quotes
+
 ### 3.1.0
 
 - Load config defined by presets ([#86])

--- a/packages/gasket-cli/package.json
+++ b/packages/gasket-cli/package.json
@@ -23,10 +23,10 @@
     "manifest": "cross-env FAUX_ROOT='/path/to/your/app' oclif-dev manifest",
     "readme": "cross-env FAUX_ROOT='/path/to/your/app' oclif-dev readme",
     "test:clean": "rimraf ./test/fixtures/create/myapp",
-    "test:integration": "mocha --require test/setup.js --recursive 'test/integration/**/*.test.js'",
+    "test:integration": "mocha --require test/setup.js --recursive \"test/integration/**/*.test.js\"",
     "test:integration:coverage": "nyc --reporter=text --reporter=json-summary --all run-s test:integration",
-    "test:mocha": "mocha --require test/setup.js --recursive 'test/**/*.test.js'",
-    "test:unit": "mocha --require test/setup.js --recursive 'test/unit/**/*.test.js'",
+    "test:mocha": "mocha --require test/setup.js --recursive \"test/**/*.test.js\"",
+    "test:unit": "mocha --require test/setup.js --recursive \"test/unit/**/*.test.js\"",
     "test:unit:coverage": "nyc --reporter=text --reporter=lcov --all run-s test:unit",
     "version": "npm run readme && git add README.md"
   },

--- a/packages/gasket-intl/CHANGELOG.md
+++ b/packages/gasket-intl/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/intl`
 
+- Fix package.json scripts to wrap glob patterns in double-quotes
+
 ### 4.2.0
 
 - Select language from state for IntlProvider

--- a/packages/gasket-intl/package.json
+++ b/packages/gasket-intl/package.json
@@ -12,7 +12,7 @@
     "test:watch": "jest --watchAll",
     "test:coverage": "jest --coverage",
     "posttest": "npm run lint",
-    "build": "babel src -d lib --ignore '**/*.spec.js'",
+    "build": "babel src -d lib --ignore \"**/*.spec.js\"",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/packages/gasket-jest-plugin/CHANGELOG.md
+++ b/packages/gasket-jest-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/jest-plugin`
 
+- Fix package.json scripts to wrap glob patterns in double-quotes
+
 ### 1.2.0
 
 - Align package structure and dependencies

--- a/packages/gasket-jest-plugin/package.json
+++ b/packages/gasket-jest-plugin/package.json
@@ -4,7 +4,7 @@
   "description": "Integrated jest into your application.",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint *.js generator/*.js generator/**/*.js",
+    "lint": "eslint *.js \"generator/**/*.js\"",
     "lint:fix": "npm run lint -- --fix",
     "test": "jest",
     "test:watch": "jest --watchAll",

--- a/packages/gasket-lint-plugin/CHANGELOG.md
+++ b/packages/gasket-lint-plugin/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
+- Fix package.json scripts to wrap glob patterns in double-quotes
+- Change output for `stylelint` script to have the glob pattern be double-quoted
+
 ### 1.7.0
+
 - Changed package manager install to support both npm and yarn
 
 ### 1.6.0

--- a/packages/gasket-lint-plugin/README.md
+++ b/packages/gasket-lint-plugin/README.md
@@ -19,7 +19,7 @@ For example, in the example commands below `npm run lint` will run eslint on you
   "scripts": {
     "lint": "eslint --ext .js,.jsx .",
     "lint:fix": "npm run lint -- --fix",
-    "stylelint": "stylelint **/*.scss",
+    "stylelint": "stylelint \"**/*.scss\"",
     "pretest": "npm run lint && npm run stylelint"
   },
   ...

--- a/packages/gasket-lint-plugin/index.js
+++ b/packages/gasket-lint-plugin/index.js
@@ -34,7 +34,7 @@ module.exports = {
       pkg.add('scripts', {
         'lint': 'eslint --ext .js,.jsx .',
         'lint:fix': `${runCmd} lint -- --fix`,
-        'stylelint': 'stylelint **/*.scss',
+        'stylelint': 'stylelint "**/*.scss"',
         'pretest': `${runCmd} lint && ${runCmd} stylelint`
       });
 

--- a/packages/gasket-lint-plugin/test/plugin.test.js
+++ b/packages/gasket-lint-plugin/test/plugin.test.js
@@ -72,7 +72,7 @@ describe('Plugin', function () {
     assume(pkg.add).calledWith('scripts', {
       'lint': 'eslint --ext .js,.jsx .',
       'lint:fix': `${expected} lint -- --fix`,
-      'stylelint': 'stylelint **/*.scss',
+      'stylelint': 'stylelint "**/*.scss"',
       'pretest': `${expected} lint && ${expected} stylelint`
     });
   }));

--- a/packages/gasket-mocha-plugin/CHANGELOG.md
+++ b/packages/gasket-mocha-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/mocha-plugin`
 
+- Fix package.json scripts to wrap glob patterns in double-quotes
+
 ### 1.4.0
 
 - Align package structure and dependencies

--- a/packages/gasket-mocha-plugin/package.json
+++ b/packages/gasket-mocha-plugin/package.json
@@ -4,7 +4,7 @@
   "description": "Integrates mocha based testing in to your Gasket application",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint index.js test/*.js generator/**/**/*.js",
+    "lint": "eslint index.js \"{test,generator}/**/*.js\"",
     "lint:fix": "npm run lint -- --fix",
     "test": "npm run test:runner",
     "test:runner": "mocha --require setup-env --recursive \"test/**/*.*(test|spec).js\"",

--- a/packages/gasket-mocha-plugin/test/pages/index.test.js
+++ b/packages/gasket-mocha-plugin/test/pages/index.test.js
@@ -1,9 +1,9 @@
-import { shallow, render, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import React from 'react';
 
-function IndexPage(props) {
+function IndexPage() {
   return (
     <div>
       This is my example page

--- a/packages/gasket-nextjs-plugin/CHANGELOG.md
+++ b/packages/gasket-nextjs-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/nextjs-plugin`
 
+- Fix package.json scripts to wrap glob patterns in double-quotes
+
 ### 2.3.0
 
 - Support `gasket.command` interface change ([#75])

--- a/packages/gasket-nextjs-plugin/package.json
+++ b/packages/gasket-nextjs-plugin/package.json
@@ -4,10 +4,10 @@
   "description": "Adds Next support to your application",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint './**/*.js' 'test/**/*.js'",
+    "lint": "eslint *.js \"{test,generator}/**/*.js\"",
     "lint:fix": "npm run lint -- --fix",
     "test": "npm run test:runner",
-    "test:runner": "mocha --require ./setup.js 'test/**/*.test.js'",
+    "test:runner": "mocha --require ./setup.js \"test/**/*.test.js\"",
     "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",
     "posttest": "npm run lint",
     "report": "nyc report --reporter=lcov"

--- a/packages/gasket-redux/CHANGELOG.md
+++ b/packages/gasket-redux/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/redux`
 
+- Fix package.json scripts to wrap glob patterns in double-quotes
+
 ### 3.2.0
 
 - Add support to customize thunk middleware ([#80])

--- a/packages/gasket-redux/package.json
+++ b/packages/gasket-redux/package.json
@@ -12,7 +12,7 @@
     "test:watch": "jest --watchAll",
     "test:coverage": "jest --coverage",
     "posttest": "npm run lint",
-    "build": "babel src -d lib --ignore '**/*.spec.js'",
+    "build": "babel src -d lib --ignore \"**/*.spec.js\"",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/packages/gasket-webpack-plugin/CHANGELOG.md
+++ b/packages/gasket-webpack-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/webpack-plugin`
 
+- Fix package.json scripts to wrap glob patterns in double-quotes
+
 ### 1.1.0
 
 - Align package structure and dependencies

--- a/packages/gasket-webpack-plugin/package.json
+++ b/packages/gasket-webpack-plugin/package.json
@@ -4,10 +4,10 @@
   "description": "Adds webpack support to your application",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint *.js `test/**/*.js`",
+    "lint": "eslint *.js \"test/**/*.js\"",
     "lint:fix": "npm run lint -- --fix",
     "test": "npm run test:runner",
-    "test:runner": "mocha --require ./setup.js `test/**/*.test.js`",
+    "test:runner": "mocha --require ./setup.js \"test/**/*.test.js\"",
     "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",
     "posttest": "npm run lint",
     "report": "nyc report --reporter=lcov"


### PR DESCRIPTION
… also fix various package.json scripts to wrap glob patterns in double-quotes

## Summary

When using gasket to generate a nextjs app, I found that the generated `stylelint` npm script included a glob pattern that wasn't properly quoted.  As such it'd use the OS to expand the files rather than `glob`, resulting in potentially missed files.  While making the change, also noticed that `gasket` itself had some missing quoted glob patterns so I fixed those as well.  I also updated a bunch to use double quotes `"` rather than single quotes `'` so that it could work on windows systems as well.

## Changelog

- Fix package.json scripts to wrap glob patterns in double-quotes
- Change output for `stylelint` script to have the glob pattern be double-quoted

## Test Plan

- I ran `npm run eslint:fix:all` from the root. ✅ 
- I ran `npm test` from `packages/gasket-lint-plugin` where there were test changes.
- I ran `npm test` from `packages/gasket-mocha-plugin` where there were some test changes due to new eslint failures as some files weren't being properly covered by eslint.
