### PR TITLE
Plugins export package name

### DIFF
--- a/packages/gasket-analyze-plugin/lib/index.js
+++ b/packages/gasket-analyze-plugin/lib/index.js
@@ -7,7 +7,7 @@ const getCommands = require('./get-commands');
  * @type {{hooks: {webpack}}}
  */
 module.exports = {
-  name: 'analyze',
+  name: require('../package').name,
   hooks: {
     webpack,
     getCommands,

--- a/packages/gasket-analyze-plugin/lib/index.spec.js
+++ b/packages/gasket-analyze-plugin/lib/index.spec.js
@@ -7,7 +7,7 @@ describe('Plugin', () => {
   });
 
   it('has expected name', () => {
-    expect(plugin).toHaveProperty('name', 'analyze');
+    expect(plugin).toHaveProperty('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-command-plugin/lib/plugin.js
+++ b/packages/gasket-command-plugin/lib/plugin.js
@@ -4,7 +4,7 @@ const GasketCommand = require('./command');
 const { hoistBaseFlags } = require('./utils');
 
 module.exports = {
-  name: '@gasket/command',
+  name: require('../package').name,
   hooks: {
     /**
      * Gets commands from plugins and injects them to the oclif config.

--- a/packages/gasket-command-plugin/test/plugin.test.js
+++ b/packages/gasket-command-plugin/test/plugin.test.js
@@ -27,7 +27,7 @@ describe('Plugin', () => {
   });
 
   it('has expected name', () => {
-    assume(plugin).to.have.property('name', '@gasket/command');
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-config-plugin/lib/plugin.js
+++ b/packages/gasket-config-plugin/lib/plugin.js
@@ -5,7 +5,7 @@ const mergeRootConfig = require('./merge-root-config');
 const { ENV_CONFIG } = require('./constants');
 
 module.exports = {
-  name: 'config',
+  name: require('../package').name,
   hooks: {
     async preboot(gasket) {
       gasket[ENV_CONFIG] = await gasket.execWaterfall(

--- a/packages/gasket-config-plugin/test/plugin.test.js
+++ b/packages/gasket-config-plugin/test/plugin.test.js
@@ -18,7 +18,7 @@ describe('Plugin', () => {
   });
 
   it('has expected name', () => {
-    expect(plugin).toHaveProperty('name', 'config');
+    expect(plugin).toHaveProperty('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-docs-plugin/lib/index.js
+++ b/packages/gasket-docs-plugin/lib/index.js
@@ -4,7 +4,7 @@ const metadata = require('./metadata');
 const docsSetup = require('./docs-setup');
 
 module.exports = {
-  name: 'docs',
+  name: require('../package').name,
   hooks: {
     configure,
     getCommands,

--- a/packages/gasket-docs-plugin/test/index.test.js
+++ b/packages/gasket-docs-plugin/test/index.test.js
@@ -7,8 +7,8 @@ describe('Plugin', function () {
     assume(plugin).is.an('object');
   });
 
-  it('is named correctly', function () {
-    assume(plugin.name).equals('docs');
+  it('has expected name', () => {
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-docsify-plugin/lib/index.js
+++ b/packages/gasket-docsify-plugin/lib/index.js
@@ -1,7 +1,7 @@
 const docsView = require('./docs-view');
 
 module.exports = {
-  name: 'docsify',
+  name: require('../package').name,
   hooks: {
     docsView
   }

--- a/packages/gasket-docsify-plugin/test/index.test.js
+++ b/packages/gasket-docsify-plugin/test/index.test.js
@@ -7,8 +7,8 @@ describe('Plugin', function () {
     assume(plugin).is.an('object');
   });
 
-  it('is named correctly', function () {
-    assume(plugin.name).equals('docsify');
+  it('has expected name', () => {
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-express-plugin/README.md
+++ b/packages/gasket-express-plugin/README.md
@@ -49,7 +49,6 @@ module.exports = {
 
 ```js
 module.exports = {
-  name: 'express',
   hooks: {
     /**
     * Creates the express app

--- a/packages/gasket-express-plugin/index.js
+++ b/packages/gasket-express-plugin/index.js
@@ -1,7 +1,7 @@
 const debug = require('diagnostics')('gasket:express');
 
 module.exports = {
-  name: 'express',
+  name: require('./package').name,
   hooks: {
     /**
     * Add files & extend package.json for new apps.

--- a/packages/gasket-express-plugin/test/plugin.test.js
+++ b/packages/gasket-express-plugin/test/plugin.test.js
@@ -24,8 +24,8 @@ describe('Plugin', function () {
     assume(plugin).is.an('object');
   });
 
-  it('is named correctly', function () {
-    assume(plugin.name).equals('express');
+  it('has expected name', () => {
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-fastify-plugin/README.md
+++ b/packages/gasket-fastify-plugin/README.md
@@ -49,7 +49,6 @@ module.exports = {
 
 ```js
 module.exports = {
-  name: 'fastify',
   hooks: {
     /**
     * Creates the fastify app

--- a/packages/gasket-fastify-plugin/index.js
+++ b/packages/gasket-fastify-plugin/index.js
@@ -2,7 +2,7 @@ const debug = require('diagnostics')('gasket:fastify');
 const { peerDependencies } = require('./package.json');
 
 module.exports = {
-  name: 'fastify',
+  name: require('./package').name,
   hooks: {
     /**
     * Add files & extend package.json for new apps.

--- a/packages/gasket-fastify-plugin/test/plugin.test.js
+++ b/packages/gasket-fastify-plugin/test/plugin.test.js
@@ -24,8 +24,8 @@ describe('Plugin', function () {
     assume(plugin).is.an('object');
   });
 
-  it('is named correctly', function () {
-    assume(plugin.name).equals('fastify');
+  it('has expected name', () => {
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-git-plugin/lib/index.js
+++ b/packages/gasket-git-plugin/lib/index.js
@@ -9,7 +9,7 @@ const postCreate = require('./post-create');
  * @public
  */
 module.exports = {
-  name: 'git',
+  name: require('../package').name,
   hooks: {
     prompt,
     create,

--- a/packages/gasket-git-plugin/test/index.test.js
+++ b/packages/gasket-git-plugin/test/index.test.js
@@ -2,14 +2,14 @@ const { describe, it } = require('mocha');
 const assume = require('assume');
 const plugin = require('../lib');
 
-describe('plugin', () => {
+describe('Plugin', () => {
 
   it('is an object', () => {
     assume(plugin).is.an('object');
   });
 
   it('has expected name', () => {
-    assume(plugin).to.have.property('name', 'git');
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-https-plugin/index.js
+++ b/packages/gasket-https-plugin/index.js
@@ -121,6 +121,6 @@ async function start(gasket) {
 }
 
 module.exports = {
-  name: 'https',
+  name: require('./package').name,
   hooks: { start }
 };

--- a/packages/gasket-https-plugin/test/index.test.js
+++ b/packages/gasket-https-plugin/test/index.test.js
@@ -26,7 +26,7 @@ describe('Plugin', () => {
   });
 
   it('has expected name', () => {
-    assume(plugin).to.have.property('name', 'https');
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-intl-plugin/lib/index.js
+++ b/packages/gasket-intl-plugin/lib/index.js
@@ -25,7 +25,7 @@ async function build(gasket) {
 
 module.exports = {
   dependencies: ['log'],
-  name: 'intl',
+  name: require('../package').name,
   hooks: {
     init,
     async initReduxState(gasket, state, req) {

--- a/packages/gasket-intl-plugin/lib/index.spec.js
+++ b/packages/gasket-intl-plugin/lib/index.spec.js
@@ -16,7 +16,7 @@ describe('Plugin', () => {
   });
 
   it('has expected name', () => {
-    expect(plugin).toHaveProperty('name', 'intl');
+    expect(plugin).toHaveProperty('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-jest-plugin/index.js
+++ b/packages/gasket-jest-plugin/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  name: 'jest',
+  name: require('./package').name,
   hooks: {
     async create(gasket, { files, pkg }) {
       const path = require('path');

--- a/packages/gasket-jest-plugin/test/index.test.js
+++ b/packages/gasket-jest-plugin/test/index.test.js
@@ -31,7 +31,7 @@ describe('Plugin', () => {
   });
 
   it('has expected name', () => {
-    expect(plugin).toHaveProperty('name', 'jest');
+    expect(plugin).toHaveProperty('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-lifecycle-plugin/index.js
+++ b/packages/gasket-lifecycle-plugin/index.js
@@ -69,7 +69,7 @@ async function init(gasket) {
  * @public
  */
 module.exports = {
-  name: '@gasket/lifecycle',
+  name: require('./package').name,
   hooks: {
     init
   }

--- a/packages/gasket-lifecycle-plugin/test/plugin.test.js
+++ b/packages/gasket-lifecycle-plugin/test/plugin.test.js
@@ -12,7 +12,7 @@ describe('Plugin', function () {
   });
 
   it('has expected name', () => {
-    assume(plugin).to.have.property('name', '@gasket/lifecycle');
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-lint-plugin/index.js
+++ b/packages/gasket-lint-plugin/index.js
@@ -5,7 +5,7 @@
  * @public
  */
 module.exports = {
-  name: 'lint',
+  name: require('./package').name,
   hooks: {
     /**
      * The actual lifecycle hook.

--- a/packages/gasket-lint-plugin/test/plugin.test.js
+++ b/packages/gasket-lint-plugin/test/plugin.test.js
@@ -36,7 +36,7 @@ describe('Plugin', function () {
   });
 
   it('has expected name', () => {
-    assume(plugin).to.have.property('name', 'lint');
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-log-plugin/index.js
+++ b/packages/gasket-log-plugin/index.js
@@ -5,7 +5,7 @@
  * @type {object}
  */
 module.exports = {
-  name: 'log',
+  name: require('./package').name,
   hooks: {
     init: {
       timing: {

--- a/packages/gasket-log-plugin/test/plugin.test.js
+++ b/packages/gasket-log-plugin/test/plugin.test.js
@@ -25,7 +25,7 @@ describe('Plugin', function () {
   });
 
   it('has expected name', () => {
-    assume(Plugin).to.have.property('name', 'log');
+    assume(Plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-manifest-plugin/lib/index.js
+++ b/packages/gasket-manifest-plugin/lib/index.js
@@ -19,7 +19,7 @@ async function gatherManifestData(gasket, req) {
 }
 
 module.exports = {
-  name: 'manifest',
+  name: require('../package').name,
   hooks: {
     /**
      * If configured, serve the resolved manifest.json

--- a/packages/gasket-manifest-plugin/test/index.test.js
+++ b/packages/gasket-manifest-plugin/test/index.test.js
@@ -9,7 +9,7 @@ describe('Plugin', function () {
   });
 
   it('has expected name', () => {
-    assume(plugin).to.have.property('name', 'manifest');
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-metadata-plugin/lib/index.js
+++ b/packages/gasket-metadata-plugin/lib/index.js
@@ -9,7 +9,7 @@ const {
 } = require('./utils');
 
 module.exports = {
-  name: '@gasket/metadata',
+  name: require('../package').name,
   hooks: {
     async init(gasket) {
       const { loader, config } = gasket;

--- a/packages/gasket-metadata-plugin/test/index.test.js
+++ b/packages/gasket-metadata-plugin/test/index.test.js
@@ -76,7 +76,7 @@ const mockLoadedData = {
   plugins: [mockPluginInfo]
 };
 
-describe('Metadata plugin', function () {
+describe('Plugin', function () {
   let gasket, applyStub, handlerStub;
 
   beforeEach(function () {
@@ -117,8 +117,8 @@ describe('Metadata plugin', function () {
     assume(plugin).is.an('object');
   });
 
-  it('has expected name', function () {
-    assume(plugin.name).equals('@gasket/metadata');
+  it('has expected name', () => {
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-metrics-plugin/lib/index.js
+++ b/packages/gasket-metrics-plugin/lib/index.js
@@ -1,7 +1,7 @@
 const Metrics = require('./metrics');
 
 module.exports = {
-  name: 'metrics',
+  name: require('../package').name,
   dependencies: ['metadata'],
   hooks: {
     init: {

--- a/packages/gasket-metrics-plugin/test/index.test.js
+++ b/packages/gasket-metrics-plugin/test/index.test.js
@@ -8,7 +8,7 @@ describe('Plugin', function () {
   });
 
   it('has expected name', () => {
-    assume(plugin).to.have.property('name', 'metrics');
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-mocha-plugin/index.js
+++ b/packages/gasket-mocha-plugin/index.js
@@ -1,7 +1,7 @@
 const { devDependencies } = require('./package.json');
 
 module.exports = {
-  name: 'mocha',
+  name: require('./package').name,
   hooks: {
     async create(gasket, { files, pkg, packageManager = 'npm' }) {
       const runCmd = packageManager === 'npm' ? `npm run` : packageManager;

--- a/packages/gasket-mocha-plugin/test/index.test.js
+++ b/packages/gasket-mocha-plugin/test/index.test.js
@@ -44,8 +44,8 @@ describe('Plugin', () => {
     expect(plugin).is.an('object');
   });
 
-  it('has expected name', function () {
-    expect(plugin.name).equals('mocha');
+  it('has expected name', () => {
+    expect(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-nextjs-plugin/index.js
+++ b/packages/gasket-nextjs-plugin/index.js
@@ -4,7 +4,7 @@ const { createConfig } = require('./config');
 
 module.exports = {
   dependencies: ['webpack'],
-  name: 'nextjs',
+  name: require('./package').name,
   hooks: {
     /**
     * Add files & extend package.json for new apps.

--- a/packages/gasket-nextjs-plugin/test/index.test.js
+++ b/packages/gasket-nextjs-plugin/test/index.test.js
@@ -13,7 +13,7 @@ describe('Plugin', function () {
   });
 
   it('has expected name', () => {
-    assume(plugin).to.have.property('name', 'nextjs');
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-redux-plugin/lib/index.js
+++ b/packages/gasket-redux-plugin/lib/index.js
@@ -8,7 +8,7 @@ const { getReduxConfig } = require('./utils');
  * @type {{hooks: {middleware, webpack}}}
  */
 module.exports = {
-  name: 'redux',
+  name: require('../package').name,
   dependencies: ['log'],
   hooks: {
     async create(gasket, { pkg }) {

--- a/packages/gasket-redux-plugin/lib/index.spec.js
+++ b/packages/gasket-redux-plugin/lib/index.spec.js
@@ -19,7 +19,7 @@ describe('Plugin', () => {
   });
 
   it('has expected name', () => {
-    expect(plugin).toHaveProperty('name', 'redux');
+    expect(plugin).toHaveProperty('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-service-worker-plugin/lib/index.js
+++ b/packages/gasket-service-worker-plugin/lib/index.js
@@ -3,7 +3,7 @@ const middleware = require('./middleware');
 const express = require('./express');
 
 module.exports = {
-  name: 'service-worker',
+  name: require('../package').name,
   hooks: {
     configure,
     middleware,

--- a/packages/gasket-service-worker-plugin/test/index.spec.js
+++ b/packages/gasket-service-worker-plugin/test/index.spec.js
@@ -7,7 +7,7 @@ describe('Plugin', () => {
   });
 
   it('has expected name', () => {
-    expect(plugin).toHaveProperty('name', 'service-worker');
+    expect(plugin).toHaveProperty('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-start-plugin/lib/index.js
+++ b/packages/gasket-start-plugin/lib/index.js
@@ -2,7 +2,7 @@ const create = require('./create');
 const getCommands = require('./get-commands');
 
 module.exports = {
-  name: '@gasket/start',
+  name: require('../package').name,
   hooks: {
     create,
     getCommands

--- a/packages/gasket-start-plugin/test/index.test.js
+++ b/packages/gasket-start-plugin/test/index.test.js
@@ -8,7 +8,7 @@ describe('Plugin', function () {
   });
 
   it('has expected name', () => {
-    assume(plugin).to.have.property('name', '@gasket/start');
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-webpack-plugin/index.js
+++ b/packages/gasket-webpack-plugin/index.js
@@ -43,7 +43,7 @@ function initWebpack(gasket, webpackConfig, data) {
 }
 
 module.exports = {
-  name: 'webpack',
+  name: require('./package').name,
   hooks: {},
   initWebpack
 };

--- a/packages/gasket-webpack-plugin/test/plugin.test.js
+++ b/packages/gasket-webpack-plugin/test/plugin.test.js
@@ -24,7 +24,7 @@ describe('Plugin', () => {
   });
 
   it('has expected name', () => {
-    assume(plugin).to.have.property('name', 'webpack');
+    assume(plugin).to.have.property('name', require('../package').name);
   });
 
   it('has expected hooks', () => {

--- a/packages/gasket-workbox-plugin/lib/index.js
+++ b/packages/gasket-workbox-plugin/lib/index.js
@@ -4,7 +4,7 @@ const express = require('./express');
 const composeServiceWorker = require('./compose-service-worker');
 
 module.exports = {
-  name: 'workbox',
+  name: require('../package').name,
   hooks: {
     configure,
     build,

--- a/packages/gasket-workbox-plugin/test/index.spec.js
+++ b/packages/gasket-workbox-plugin/test/index.spec.js
@@ -6,7 +6,7 @@ describe('Plugin', () => {
   });
 
   it('has expected name', () => {
-    expect(plugin).toHaveProperty('name', 'workbox');
+    expect(plugin).toHaveProperty('name', require('../package').name);
   });
 
   it('has expected hooks', () => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Even though the engine prefers the presetInfo package name over what the module exports, there may be cases where plugins modules are added by `require`, i.e.
```js
// gasket.config.js
const configPlugin = require('@gasket/plugin-config');
module.exports = {
  plugins: {
    add: ['@gasket/https', configPlugin]
  }
}
```

 So, we still need to export the name from the module. This PR ensures the exported name comes from the package name.


<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

- Plugin modules export name from package.json for consistency.

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Unit tests continue to pass