### PR TITLE
Handle Windows paths

### DIFF
--- a/packages/gasket-resolve/lib/loader.js
+++ b/packages/gasket-resolve/lib/loader.js
@@ -38,7 +38,7 @@ const { pluginIdentifier, presetIdentifier } = require('./package-identifier');
  * @type {RegExp}
  * @private
  */
-const isModulePath = /^[/.]|node_modules/;
+const isModulePath = /^[/.]|^[a-zA-Z]:\\|node_modules/;
 
 /**
  * Utility to load plugins, presets, and other modules with associated metadata
@@ -67,7 +67,8 @@ class Loader extends Resolver {
       ...meta
     };
 
-    const pkgPath = this.tryResolve(`${moduleName}/package.json`);
+    const tryPath = isModulePath.test(moduleName) ? path.join(moduleName, 'package.json') : `${moduleName}/package.json`;
+    const pkgPath = this.tryResolve(tryPath);
     if (pkgPath) {
       info.path = path.dirname(pkgPath);
       info.package = this.require(pkgPath);

--- a/packages/gasket-resolve/test/helpers.js
+++ b/packages/gasket-resolve/test/helpers.js
@@ -14,11 +14,14 @@ function makeRequire(modules) {
   const _paths = {};
   const _modules = {};
   Object.keys(modules).forEach(name => {
-    const p = isModulePath.test(name) ? name : '/path/to/node_modules/' + name;
-    _paths[name] = p;
-    _paths[p] = p;
+    const pth = isModulePath.test(name) ? name : '/path/to/node_modules/' + name;
+    const windowsPth = isModulePath.test(name) ? name : 'C:\\path\\to\\node_modules\\' + name.replace('/', '\\');
+    _paths[name] = pth;
+    _paths[pth] = pth;
+    _paths[windowsPth] = pth;
     _modules[name] = modules[name];
-    _modules[p] = modules[name];
+    _modules[pth] = modules[name];
+    _modules[windowsPth] = modules[name];
   });
 
   _paths.broken = '/path/to/node_modules/broken';

--- a/packages/gasket-resolve/test/loader.test.js
+++ b/packages/gasket-resolve/test/loader.test.js
@@ -121,8 +121,16 @@ describe('Loader', () => {
       }));
     });
 
-    it('updates name and version if package resolves', () => {
+    it('updates name and version if package path resolves', () => {
       const results = loader.getModuleInfo(pluginOne, '/path/to/node_modules/@gasket/one-plugin', { extra: true });
+      expect(results).toEqual(expect.objectContaining({
+        name: '@gasket/one-plugin',
+        version: '1.2.3'
+      }));
+    });
+
+    it('updates name and version if package path resolves on windows', () => {
+      const results = loader.getModuleInfo(pluginOne, 'C:\\path\\to\\node_modules\\@gasket\\one-plugin', { extra: true });
       expect(results).toEqual(expect.objectContaining({
         name: '@gasket/one-plugin',
         version: '1.2.3'
@@ -250,6 +258,15 @@ describe('Loader', () => {
 
     it('supports module paths', () => {
       const results = loader.loadPreset('/path/to/node_modules/@gasket/one-preset');
+      expect(results).toEqual(expect.objectContaining({
+        name: '@gasket/one-preset',
+        module: presetOne,
+        package: presetOnePkg
+      }));
+    });
+
+    it('supports module paths on Windows', () => {
+      const results = loader.loadPreset('C:\\path\\to\\node_modules\\@gasket\\one-preset');
       expect(results).toEqual(expect.objectContaining({
         name: '@gasket/one-preset',
         module: presetOne,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Loading presets during `gasket create` on Windows was breaking due to path differences.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

- Fix to support Windows paths when resolving

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Unit tested 