### PR TITLE
Add support to describe Guides

### DIFF
--- a/packages/gasket-plugin-docs/README.md
+++ b/packages/gasket-plugin-docs/README.md
@@ -15,9 +15,9 @@ To be set in under `docs` in the `gasket.config.js`.
 ### docs
 
 The **docs** command, inspired by [cargo doc][rustdoc] from the Rust language,
-allows app developers to generate documentation for their Gasket projects.
-Only those presets and plugins that are configured for a project, will be used
-to determine what documentation is available.
+allows app developers to generate documentation for their Gasket projects. Only
+those presets and plugins that are configured for a project, will be used to
+determine what documentation is available.
 
 When running this command, markdown and other files will gathered from installed
 node modules and collated to the output directory when they can be viewed
@@ -27,10 +27,10 @@ together.
 
 This command will gather info about plugins and modules from their [metadata]
 and [docsSetup], and will assemble a [docsConfig] for each. These configs are
-are organized by type in a [docsConfigSet], which is then used to copy files
-to the outputDir, and perform any [transforms] as needed. An index is generated
-in markdown from docsConfigSet which serves as the entry in the doc files.
-If a plugin is installed that hooks the [docsView] lifecycle, it can serve the
+are organized by type in a [docsConfigSet], which is then used to copy files to
+the outputDir, and perform any [transforms] as needed. An index is generated in
+markdown from docsConfigSet which serves as the entry in the doc files. If a
+plugin is installed that hooks the [docsView] lifecycle, it can serve the
 content in a more viewable fashion for the user.
 
 ## Lifecycles
@@ -91,11 +91,11 @@ module.exports = {
 Transforms can also be added in the docsSetup lifecycle. These are plugins to
 adjust content for files that match the transform's test [RegExp]. By default,
 these will only affect docs collected the plugin's package. If the transform
-should be able affect all collected docs, the global property should be set
-to true.
+should be able affect all collected docs, the global property should be set to
+true.
 
-Additional data is available to handlers to help with transformations which
-can be read about in the [DocsTransformHandler] API.
+Additional data is available to handlers to help with transformations which can
+be read about in the [DocsTransformHandler] API.
 
 #### Modules
 
@@ -103,6 +103,25 @@ Beside docs for the plugin itself, `docsSetup` for supporting modules can also
 be described. For modules from [metadata], if a `docsSetup` is found, the files
 described will be collected, and link for the generated index go to the link
 specified in the `docsSetup`, instead of the module's homepage.
+
+Alternatively, modules can described their own setup in their package.json by
+defining a `gasket.docsSetup` property. However, Being JSON, transforms or other
+setup functions cannot be described this way:
+
+```json
+{
+  "name": "example",
+  "version": "1.2.3",
+  "gasket": {
+    "docsSetup": {
+      "link": "OTHER.md#go-here",
+      "files": [
+        "more-docs/**/*"
+      ]
+    }
+  }
+}
+```
 
 ### docsView
 

--- a/packages/gasket-plugin-docs/lib/types.js
+++ b/packages/gasket-plugin-docs/lib/types.js
@@ -60,6 +60,7 @@
  * @property {ModuleDocsConfig[]} modules - Docs of supporting modules
  * @property {DetailDocsConfig[]} structures - Docs describing structure elements
  * @property {DetailDocsConfig[]} commands - Docs for available commands
+ * @property {DetailDocsConfig[]} guides - Docs for setups and explanations
  * @property {LifecycleDocsConfig[]} lifecycles - Docs for available lifecycles
  * @property {DocsTransform[]} transforms - Global doc transforms
  * @property {string} root - Absolute path to main package

--- a/packages/gasket-plugin-docs/lib/utils/generate-index.js
+++ b/packages/gasket-plugin-docs/lib/utils/generate-index.js
@@ -56,7 +56,7 @@ function generateContent(docsConfigSet) {
     ]);
   };
 
-  // TODO (agerard): add Guides section
+  addSection('Guides', ' Help and explanations docs', docsConfigSet.guides, { includeVersion: false });
   addSection('Commands', 'Available commands', docsConfigSet.commands, { includeVersion: false });
   addSection('Lifecycles', 'Available lifecycles', docsConfigSet.lifecycles, { includeVersion: false });
   addSection('Structures', 'Available structure', docsConfigSet.structures, { includeVersion: false });

--- a/packages/gasket-plugin-docs/test/utils/config-set-builder.test.js
+++ b/packages/gasket-plugin-docs/test/utils/config-set-builder.test.js
@@ -55,6 +55,18 @@ describe('utils - DocsConfigSetBuilder', () => {
       assume(buildDocsConfigSpy).not.calledWith({ name: 'app-two' });
     });
 
+    it('uses custom docsSetup', async () => {
+      const docsSetup = { custom: true };
+      await instance.addApp({ name: 'app-one' }, docsSetup);
+      assume(buildDocsConfigSpy).calledWithMatch(sinon.match.object, docsSetup);
+    });
+
+    it('finds docsSetup from package.json', async () => {
+      const docsSetup = { custom: true };
+      await instance.addApp({ name: 'app-one', package: { gasket: { docsSetup } } });
+      assume(buildDocsConfigSpy).calledWithMatch(sinon.match.object, docsSetup);
+    });
+
     it('uses default docsSetup if not passed', async () => {
       await instance.addApp({ name: 'app-one' });
       assume(buildDocsConfigSpy).calledWithMatch(sinon.match.object, docsSetupDefault);
@@ -93,6 +105,12 @@ describe('utils - DocsConfigSetBuilder', () => {
       const mockDocSetup = { link: 'BOGUS.md' };
       await instance.addPlugin({ name: 'example-plugin' }, mockDocSetup);
       assume(buildDocsConfigSpy).calledWithMatch(sinon.match.object, mockDocSetup);
+    });
+
+    it('finds docsSetup from package.json', async () => {
+      const docsSetup = { custom: true };
+      await instance.addPlugin({ name: 'example-plugin', package: { gasket: { docsSetup } } });
+      assume(buildDocsConfigSpy).calledWithMatch(sinon.match.object, docsSetup);
     });
 
     it('adds targetRoot to overrides', async () => {
@@ -180,6 +198,12 @@ describe('utils - DocsConfigSetBuilder', () => {
       assume(buildDocsConfigSpy).calledWithMatch(sinon.match.object, mockDocSetup);
     });
 
+    it('finds docsSetup from package.json', async () => {
+      const docsSetup = { custom: true };
+      await instance.addPreset({ name: 'example-preset', package: { gasket: { docsSetup } } });
+      assume(buildDocsConfigSpy).calledWithMatch(sinon.match.object, docsSetup);
+    });
+
     it('uses preset-defined docsSetup', async () => {
       const presetDocSetup = { link: 'BOGUS.md' };
       await instance.addPreset({ name: 'example-preset', module: { docsSetup: presetDocSetup } });
@@ -254,6 +278,12 @@ describe('utils - DocsConfigSetBuilder', () => {
       assume(buildDocsConfigSpy).calledWith(sinon.match.object, mockDocSetup);
     });
 
+    it('finds docsSetup from package.json', async () => {
+      const docsSetup = { custom: true };
+      await instance.addModule({ name: 'example-module', package: { gasket: { docsSetup } } });
+      assume(buildDocsConfigSpy).calledWithMatch(sinon.match.object, docsSetup);
+    });
+
     it('adds targetRoot to overrides', async () => {
       await instance.addModule({ name: '@some/example-module' });
       assume(buildDocsConfigSpy).calledWith(sinon.match.object, sinon.match.object, {
@@ -288,6 +318,7 @@ describe('utils - DocsConfigSetBuilder', () => {
         'transforms',
         'structures',
         'lifecycles',
+        'guides',
         'commands'
       ];
       const actual = Object.keys(results);

--- a/packages/gasket-plugin-docs/test/utils/generate-index.test.js
+++ b/packages/gasket-plugin-docs/test/utils/generate-index.test.js
@@ -58,6 +58,11 @@ const fullDocsConfigSet = {
     link: 'README.md#commands',
     targetRoot: '/path/to/app/.docs/test-app/plugins/example-plugin'
   }],
+  guides: [{
+    name: 'Example Guide',
+    link: 'docs/guide.md',
+    targetRoot: '/path/to/app/.docs/test-app/plugins/example-plugin'
+  }],
   lifecycles: [{
     name: 'example-lifecycle',
     link: 'README.md#lifecycles',
@@ -113,7 +118,7 @@ describe('Utils - generateIndex', () => {
         //
         // count the number of ref-style links
         //
-        assume(content.match(/\[.+]:/g) || []).lengthOf(7);
+        assume(content.match(/\[.+]:/g) || []).lengthOf(8);
       });
 
       it('makes unique references', async () => {
@@ -204,6 +209,10 @@ describe('Utils - generateIndex', () => {
 
       describe('structures', () => {
         checkSection('structures', 'Structures');
+      });
+
+      describe('guides', () => {
+        checkSection('guides', 'Guides');
       });
     });
   });

--- a/packages/gasket-plugin-docs/test/utils/sorts.test.js
+++ b/packages/gasket-plugin-docs/test/utils/sorts.test.js
@@ -1,5 +1,5 @@
 const assume = require('assume');
-const { sortModules, sortStructures, sortCommands } = require('../../lib/utils/sorts');
+const { sortModules, sortStructures, sortCommands, sortGuides } = require('../../lib/utils/sorts');
 
 describe('utils - sorts', () => {
 
@@ -7,35 +7,88 @@ describe('utils - sorts', () => {
     it('gasket scope > user scope > no scope > app plugins', () => {
       const begin = [
         'plugins/gasket-plugin-a',
-        '@gasket/plugin-c',
+        '@gasket/preset-a',
         '@user/gasket-plugin-b',
-        'gasket-plugin-c',
+        'gasket-preset-a',
+        '@gasket/aaa',
         '@gasket/plugin-a',
-        '@user/gasket-plugin-c',
+        '@user/aaa',
+        '@user/gasket-preset-a',
         'gasket-plugin-a',
+        '@gasket/cli',
         '@user/gasket-plugin-a',
         '@gasket/plugin-b',
+        'aaa',
         'plugins/gasket-plugin-b',
         'gasket-plugin-b',
-        'plugins/gasket-plugin-c'
+        'plugins/gasket-preset-a'
       ];
 
       const expected = [
+        '@gasket/preset-a',
         '@gasket/plugin-a',
         '@gasket/plugin-b',
-        '@gasket/plugin-c',
+        '@gasket/aaa',
+        '@gasket/cli',
+        '@user/gasket-preset-a',
         '@user/gasket-plugin-a',
         '@user/gasket-plugin-b',
-        '@user/gasket-plugin-c',
+        '@user/aaa',
+        'gasket-preset-a',
         'gasket-plugin-a',
         'gasket-plugin-b',
-        'gasket-plugin-c',
+        'aaa',
+        'plugins/gasket-preset-a',
         'plugins/gasket-plugin-a',
-        'plugins/gasket-plugin-b',
-        'plugins/gasket-plugin-c'
+        'plugins/gasket-plugin-b'
       ];
 
       const results = sortModules(begin.map(name => ({ name }))).map(p => p.name);
+      assume(results).eqls(expected);
+    });
+  });
+
+  describe('sortGuides', () => {
+    it('gasket/cli > gasket scope > user scope > no scope > app plugins', () => {
+      const begin = [
+        'plugins/gasket-plugin-a',
+        '@gasket/preset-a',
+        '@user/gasket-plugin-b',
+        'gasket-preset-a',
+        '@gasket/aaa',
+        '@gasket/plugin-a',
+        '@user/aaa',
+        '@user/gasket-preset-a',
+        'gasket-plugin-a',
+        '@gasket/cli',
+        '@user/gasket-plugin-a',
+        '@gasket/plugin-b',
+        'aaa',
+        'plugins/gasket-plugin-b',
+        'gasket-plugin-b',
+        'plugins/gasket-preset-a'
+      ];
+
+      const expected = [
+        '@gasket/cli',
+        '@gasket/preset-a',
+        '@gasket/plugin-a',
+        '@gasket/plugin-b',
+        '@gasket/aaa',
+        '@user/gasket-preset-a',
+        '@user/gasket-plugin-a',
+        '@user/gasket-plugin-b',
+        '@user/aaa',
+        'gasket-preset-a',
+        'gasket-plugin-a',
+        'gasket-plugin-b',
+        'aaa',
+        'plugins/gasket-preset-a',
+        'plugins/gasket-plugin-a',
+        'plugins/gasket-plugin-b'
+      ];
+
+      const results = sortGuides(begin.map(from => ({ from }))).map(p => p.from);
       assume(results).eqls(expected);
     });
   });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Guides really need to live with the packages that enable/own them instead of at the top of the monorepo. We then need to surface guides with `gasket docs` so users don't have to dig for them.

Additionally, this PR enables `docsSetup` to be described in `gasket.docsSetup` from a module's package.json.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/plugin-docs**
- Add support to describe Guides
- Support to define docsSetup in package.json

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
- Additional units tests
- Tested locally with npm link