### PR TITLE
Add support to define metadata in package.json

### DIFF
--- a/packages/gasket-plugin-metadata/README.md
+++ b/packages/gasket-plugin-metadata/README.md
@@ -1,16 +1,16 @@
 # `@gasket/plugin-metadata`
 
-Metadata is the information about the register plugins and presets, available
-to plugin lifecycle hooks. This data can be used in various was for plugins,
-most notably the [@gasket/plugin-docs] which uses it to collate docs for an app.
+Metadata is the information about the register plugins and presets, available to
+plugin lifecycle hooks. This data can be used in various was for plugins, most
+notably the [@gasket/plugin-docs] which uses it to collate docs for an app.
 
 ## Overview
 
-Metadata begins with the info objects from the `Loader` of [@gasket/resolve]
-and builds data objects for [plugins][PluginData], and [presets][PresetData],
-and supporting [modules][ModuleData]. Any functions preset will be **redacted**,
-as metadata is not intended to be executed, but rather to is made available to
-read and inform plugins. This data can be added to, by hooking the [metadata]
+Metadata begins with the info objects from the `Loader` of [@gasket/resolve] and
+builds data objects for [plugins][PluginData], and [presets][PresetData], and
+supporting [modules][ModuleData]. Any functions preset will be **redacted**, as
+metadata is not intended to be executed, but rather to is made available to read
+and inform plugins. This data can be added to, by hooking the [metadata]
 lifecycle in a plugin.
 
 Metadata provides insights to a plugin's shape and package information.
@@ -28,9 +28,9 @@ available from `gasket.metadata.modules`.
 
 ### metadata
 
-This plugin implements the `metadata` lifecycle, which plugins can use to
-modify it's own metadata at runtime. Whatever is returned will replace the
-existing metadata.
+This plugin implements the `metadata` lifecycle, which plugins can use to modify
+it's own metadata at runtime. Whatever is returned will replace the existing
+metadata.
 
 ```js
 // example-plugin.js
@@ -93,8 +93,33 @@ module.exports = {
 }
 ```
 
-<!-- LINKS -->
+## Modules
 
+Lastly, modules can described metadata by defining a `gasket.metadata` property
+in the package.json which will get expanded to the [ModuleData]:
+
+```json
+{
+  "name": "example",
+  "version": "1.2.3",
+  "gasket": {
+    "metadata": {
+      "guides": [{
+        "name": "Example Guide",
+        "description": "How to do something",
+        "link": "docs/example.md"
+      }]
+    }
+  }
+}
+```
+
+This is especially useful to surface guides with
+[Gasket docs][@gasket/plugin-docs] for supporting packages that are intended to
+be used with Gasket, but are not plugins.
+
+
+<!-- LINKS -->
 [metadata]: #metadata
 [ModuleData]: docs/api.md#ModuleData
 [PluginData]: docs/api.md#PluginData

--- a/packages/gasket-plugin-metadata/lib/index.js
+++ b/packages/gasket-plugin-metadata/lib/index.js
@@ -5,7 +5,8 @@ const {
   loadPluginModules,
   flattenPluginModules,
   fixupPresetHierarchy,
-  expandPresetMetadata
+  expandPresetMetadata,
+  expandPackageMetadata
 } = require('./utils');
 
 module.exports = {
@@ -31,6 +32,8 @@ module.exports = {
 
       loadAppModules(loader, app, modules);
       expandPresetMetadata(presets);
+      expandPackageMetadata([app]);
+      expandPackageMetadata(plugins);
 
       //
       // Allow plugins to tune their own metadata via lifecycle
@@ -46,6 +49,8 @@ module.exports = {
         // eslint-disable-next-line require-atomic-updates
         plugins[idx] = pluginData;
       });
+
+      expandPackageMetadata(modules);
     },
     metadata(gasket, meta) {
       return {
@@ -56,7 +61,10 @@ module.exports = {
           description: 'Allows plugins to adjust their metadata',
           link: 'README.md#metadata',
           parent: 'init'
-        }]
+        }],
+        modules: [
+          '@gasket/cli'
+        ]
       };
     }
   }

--- a/packages/gasket-plugin-metadata/lib/utils.js
+++ b/packages/gasket-plugin-metadata/lib/utils.js
@@ -146,6 +146,24 @@ function expandPresetMetadata(presets) {
       expandPresetMetadata(preset.presets);
     }
   });
+  expandPackageMetadata(presets);
+}
+
+/**
+ * Expands metadata for modules if gasket.metadata property defined in package.json
+ *
+ * @param {ModuleData[]} modules - Modules to expand
+ * @private
+ */
+function expandPackageMetadata(modules) {
+  (modules).forEach(module => {
+    if (module.package && module.package.gasket && module.package.gasket.metadata) {
+      Object.keys(module.package.gasket.metadata).reduce((acc, cur) => {
+        acc[cur] = acc[cur] || module.package.gasket.metadata[cur];
+        return acc;
+      }, module);
+    }
+  });
 }
 
 module.exports = {
@@ -155,5 +173,6 @@ module.exports = {
   loadPluginModules,
   flattenPluginModules,
   fixupPresetHierarchy,
-  expandPresetMetadata
+  expandPresetMetadata,
+  expandPackageMetadata
 };

--- a/packages/gasket-plugin-metadata/test/utils.test.js
+++ b/packages/gasket-plugin-metadata/test/utils.test.js
@@ -275,7 +275,14 @@ describe('Utils', () => {
       };
       mockPresetTwo = {
         name: '@gasket/two-preset',
-        module: {}
+        module: {},
+        package: {
+          gasket: {
+            metadata: {
+              fromPackage: true
+            }
+          }
+        }
       };
       mockPresetThree = {
         name: '@gasket/three-preset',
@@ -305,6 +312,11 @@ describe('Utils', () => {
       assume(mockPresetOne).property('extra', true);
     });
 
+    it('augments properties from package.json gasket.metadata', async function () {
+      expandPresetMetadata([mockPresetTwo]);
+      assume(mockPresetTwo).property('fromPackage', true);
+    });
+
     it('overrides metadata from module.metadata', async function () {
       mockPresetOne.metadataKey = 'oldMetadataValue';
       mockPresetOne.module.metadata = { metadataKey: 'metadataValue' };
@@ -332,6 +344,42 @@ describe('Utils', () => {
       assume(mockPresetOne).property('extra', 1);
       assume(mockPresetTwo).property('extra', 2);
       assume(mockPresetThree).property('extra', 3);
+    });
+  });
+
+  describe('expandPackageMetadata', () => {
+    let mockPresetOne;
+
+    beforeEach(() => {
+      mockPresetOne = {
+        name: '@gasket/one-preset',
+        package: {
+          gasket: {
+            metadata: {
+              fromPackage: true
+            }
+          }
+        }
+      };
+    });
+
+    it('does nothing if no package', async function () {
+      delete mockPresetOne.package;
+      expandPresetMetadata([mockPresetOne]);
+      assume(mockPresetOne).deep.equals({
+        name: '@gasket/one-preset'
+      });
+    });
+
+    it('augments properties with gasket.metadata from package.json', async function () {
+      expandPresetMetadata([mockPresetOne]);
+      assume(mockPresetOne).property('fromPackage', true);
+    });
+
+    it('does not override existing metadata', async function () {
+      mockPresetOne.package.gasket.metadata.fromPackage = 'Okay!';
+      expandPresetMetadata([mockPresetOne]);
+      assume(mockPresetOne).property('fromPackage', 'Okay!');
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

While finding a suitable home to describe the `plugins/` structure with `gasket docs`, it seemed best to keep with the `@gasket/cli` which enables the feature. The problem is there's no way to surface that metadata structure.

For packages that are intended to be used with Gasket, but which are not plugins or presets, we need another way for them to augment metadata. This PRs goes back to an older idea of defining gasket attributes in the package.json, which works well for this use case.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/plugin-metadata**
- Add support to define metadata in package.json

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
- Additional units tests
- Tested locally with npm link