### PR TITLE
[doc fix] only use one set of backticks

### DIFF
--- a/packages/gasket-plugin-service-worker/README.md
+++ b/packages/gasket-plugin-service-worker/README.md
@@ -94,7 +94,7 @@ module.exports = {
 
       // `req` allows SW content based on hostname, cookie, etc.
 
-      return content.concat(```
+      return content.concat(`
 self.addEventListener('push', (event) => {
   const title = 'My App Notification';
   const options = {
@@ -102,7 +102,7 @@ self.addEventListener('push', (event) => {
   };
   event.waitUntil(self.registration.showNotification(title, options));
 });
-```   )
+`)
     }
   }
 }


### PR DESCRIPTION
# Before

<img width="829" alt="Screen Shot 2019-12-04 at 9 10 48 AM" src="https://user-images.githubusercontent.com/6868877/70164453-0ab7ef80-1676-11ea-9c43-bd6b92106ced.png">

# After

<img width="820" alt="Screen Shot 2019-12-04 at 9 10 59 AM" src="https://user-images.githubusercontent.com/6868877/70164465-10add080-1676-11ea-9127-ca483f72088c.png">
