### PR TITLE
Generate Next.js _app for Redux

### DIFF
--- a/packages/gasket-plugin-nextjs/generator/redux/pages/_app.js
+++ b/packages/gasket-plugin-nextjs/generator/redux/pages/_app.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import App from 'next/app';
+import { Provider } from 'react-redux';
+import withRedux from 'next-redux-wrapper';
+import makeStore from '@gasket/redux/make-store';
+
+class MyApp extends App {
+  render() {
+    const { Component, pageProps, store } = this.props;
+    return (
+      <Provider store={ store }>
+        <Component { ...pageProps } />
+      </Provider>
+    );
+  }
+}
+
+export default withRedux(makeStore)(MyApp);

--- a/packages/gasket-plugin-nextjs/index.js
+++ b/packages/gasket-plugin-nextjs/index.js
@@ -8,41 +8,57 @@ module.exports = {
   dependencies: ['@gasket/plugin-webpack'],
   name,
   hooks: {
-    /**
-    * Add files & extend package.json for new apps.
-    *
-    * @param {Gasket} gasket - The Gasket API.
-    * @param {CreateContext} context - Create context
-    * @param {Files} context.files - The Gasket Files API.
-    * @param {PackageJson} context.pkg - The Gasket PackageJson API.
-    * @param {PluginName} context.testPlugin - The name of included test plugins.
-    * @public
-    */
-    create: function create(gasket, context) {
-      const { files, pkg, testPlugin } = context;
+    create: {
+      timing: {
+        after: ['@gasket/redux-plugin']
+      },
+      /**
+       * Add files & extend package.json for new apps.
+       *
+       * @param {Gasket} gasket - The Gasket API.
+       * @param {CreateContext} context - Create context
+       * @param {Files} context.files - The Gasket Files API.
+       * @param {PackageJson} context.pkg - The Gasket PackageJson API.
+       * @param {PluginName} context.testPlugin - The name of included test plugins.
+       * @public
+       */
+      handler: function create(gasket, context) {
+        const { files, pkg, testPlugin } = context;
 
-      files.add(
-        `${__dirname}/generator/app/.*`,
-        `${__dirname}/generator/app/*`,
-        `${__dirname}/generator/app/**/*`
-      );
+        files.add(
+          `${__dirname}/generator/app/.*`,
+          `${__dirname}/generator/app/*`,
+          `${__dirname}/generator/app/**/*`
+        );
 
-      ['jest', 'mocha'].forEach(tester => {
-        if (pluginIdentifier(testPlugin).longName === `@gasket/plugin-${tester}`) {
+        ['jest', 'mocha'].forEach(tester => {
+          if (pluginIdentifier(testPlugin).longName === `@gasket/plugin-${tester}`) {
+            files.add(
+              `${__dirname}/generator/${tester}/*`,
+              `${__dirname}/generator/${tester}/**/*`
+            );
+          }
+        });
+
+        pkg.add('dependencies', {
+          '@gasket/assets': devDependencies['@gasket/assets'],
+          'next': devDependencies.next,
+          'prop-types': devDependencies['prop-types'],
+          'react': devDependencies.react,
+          'react-dom': devDependencies['react-dom']
+        });
+
+        if (pkg.has('@gasket/redux')) {
+          pkg.add('dependencies', {
+            'next-redux-wrapper': devDependencies['next-redux-wrapper']
+          });
+
           files.add(
-            `${__dirname}/generator/${tester}/*`,
-            `${__dirname}/generator/${tester}/**/*`
+            `${__dirname}/generator/redux/*`,
+            `${__dirname}/generator/redux/**/*`
           );
         }
-      });
-
-      pkg.add('dependencies', {
-        '@gasket/assets': devDependencies['@gasket/assets'],
-        'next': devDependencies.next,
-        'prop-types': devDependencies['prop-types'],
-        'react': devDependencies.react,
-        'react-dom': devDependencies['react-dom']
-      });
+      }
     },
     express: async function express(gasket, expressApp) {
       const { exec, command } = gasket;

--- a/packages/gasket-plugin-nextjs/package.json
+++ b/packages/gasket-plugin-nextjs/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-mocha": "^6.0.0",
     "mocha": "^6.2.0",
     "next": "^9.1.2",
+    "next-redux-wrapper": "^4.0.1",
     "nyc": "^14.1.1",
     "prop-types": "^15.6.2",
     "proxyquire": "^2.1.3",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

This will go ahead and generated the `_app.js` file when using redux with Next.js. Ideally, this won't be necessary down the road once Next.js has it's own support for lifecycles: https://github.com/zeit/next.js/issues/9133

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/next-plugin**
- Generate `_app.js` with `next-redux-wrapper` when used with Redux plugin

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
- Unit tests