### PR TITLE
chore(deps): Update docsify to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # gasket
 
+- #[#128], [#131] Update to latest `docsify`
+
+## 5.0.0
+
 - Moved test templates to next plugin. Only include devDependencies for relevant frameworks
 - [#101] Add preset authoring guide
 - [#96] Add contribution guidelines
 
 [#96]: https://github.com/godaddy/gasket/pull/96
 [#101]: https://github.com/godaddy/gasket/pull/101
+[#128]: https://github.com/godaddy/gasket/issues/128
+[#131]: https://github.com/godaddy/gasket/pull/131
+

--- a/packages/gasket-plugin-docsify/package.json
+++ b/packages/gasket-plugin-docsify/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/godaddy/gasket/tree/master/packages/gasket-plugin-docsify",
   "dependencies": {
-    "docsify": "^4.9.4",
+    "docsify": "^4.10.2",
     "docsify-cli": "^4.3.0",
     "glob": "^7.1.4",
     "handlebars": "^4.4.3",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

`docsify` depends on `marked` which needs an update. Latest `docsify` was just published with a fix for this.

## Changelog

Done

## Test Plan

Make sure docsify plugin still works as expected

Closes #128 
