### PR TITLE
Objects not named arrays

### DIFF
--- a/packages/gasket-plugin-analyze/README.md
+++ b/packages/gasket-plugin-analyze/README.md
@@ -21,11 +21,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-analyze'
     ]
-  ]
+  }
 }
 ```
 

--- a/packages/gasket-plugin-config/README.md
+++ b/packages/gasket-plugin-config/README.md
@@ -24,11 +24,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-config'
     ]
-  ]
+  }
 }
 ```
 
@@ -117,10 +117,10 @@ export default PageComponent extends React.Component {
     if (isServer) {
       return {
         flags: req.config.featureFlags
-      };      
+      };
     }
   }
-  
+
   // ...
 }
 ```

--- a/packages/gasket-plugin-docs/README.md
+++ b/packages/gasket-plugin-docs/README.md
@@ -21,11 +21,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-docs'
     ]
-  ]
+  }
 }
 ```
 
@@ -153,7 +153,7 @@ module.exports = {
   hooks: {
     async docsView(gasket, docsConfigSet) {
       const { docsRoot } = docsConfigSet;
-    
+
       await view(docsRoot);
     }
   }

--- a/packages/gasket-plugin-docsify/README.md
+++ b/packages/gasket-plugin-docsify/README.md
@@ -21,12 +21,12 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-docs',
 +      '@gasket/plugin-docsify'
     ]
-  ]
+  }
 }
 ```
 

--- a/packages/gasket-plugin-express/README.md
+++ b/packages/gasket-plugin-express/README.md
@@ -25,11 +25,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-express'
     ]
-  ]
+  }
 }
 ```
 

--- a/packages/gasket-plugin-fastify/README.md
+++ b/packages/gasket-plugin-fastify/README.md
@@ -20,11 +20,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-fastify'
     ]
-  ]
+  }
 }
 ```
 

--- a/packages/gasket-plugin-https/README.md
+++ b/packages/gasket-plugin-https/README.md
@@ -21,11 +21,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-https'
     ]
-  ]
+  }
 }
 ```
 

--- a/packages/gasket-plugin-intl/README.md
+++ b/packages/gasket-plugin-intl/README.md
@@ -20,11 +20,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-intl'
     ]
-  ]
+  }
 }
 ```
 

--- a/packages/gasket-plugin-log/README.md
+++ b/packages/gasket-plugin-log/README.md
@@ -21,11 +21,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-log'
     ]
-  ]
+  }
 }
 ```
 

--- a/packages/gasket-plugin-manifest/README.md
+++ b/packages/gasket-plugin-manifest/README.md
@@ -23,11 +23,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-manifest'
     ]
-  ]
+  }
 }
 ```
 

--- a/packages/gasket-plugin-metrics/README.md
+++ b/packages/gasket-plugin-metrics/README.md
@@ -25,11 +25,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-metrics'
     ]
-  ]
+  }
 }
 ```
 
@@ -60,7 +60,7 @@ module.exports = {
      *
      * @param {Gasket} gasket - The Gasket API
      * @param {Object} data - Collected metrics
-     * @returns {Object} 
+     * @returns {Object}
      */
     async metrics(gasket, data) {
       const url = 'https://some.example.api/endpoint';

--- a/packages/gasket-plugin-nextjs/README.md
+++ b/packages/gasket-plugin-nextjs/README.md
@@ -22,11 +22,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-nextjs'
     ]
-  ]
+  }
 }
 ```
 

--- a/packages/gasket-plugin-redux/README.md
+++ b/packages/gasket-plugin-redux/README.md
@@ -22,11 +22,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-redux'
     ]
-  ]
+  }
 }
 ```
 
@@ -60,7 +60,7 @@ module.exports = {
       }
     }
   },
-  
+
   // You can override initState by environment
   environments: {
     test: {
@@ -100,7 +100,7 @@ async function doSomethingMiddleware(req, res, next) {
     await req.store.dispatch(myActionCreator());
     next();
   } catch(err) {
-    next(err); 
+    next(err);
   }
 }
 ```

--- a/packages/gasket-plugin-service-worker/README.md
+++ b/packages/gasket-plugin-service-worker/README.md
@@ -22,11 +22,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-service-worker'
     ]
-  ]
+  }
 }
 ```
 

--- a/packages/gasket-plugin-webpack/README.md
+++ b/packages/gasket-plugin-webpack/README.md
@@ -20,11 +20,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-webpack'
     ]
-  ]
+  }
 }
 ```
 

--- a/packages/gasket-plugin-workbox/README.md
+++ b/packages/gasket-plugin-workbox/README.md
@@ -29,11 +29,11 @@ Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
 module.exports = {
-  plugins: [
+  plugins: {
     add: [
 +      '@gasket/plugin-workbox'
     ]
-  ]
+  }
 }
 ```
 
@@ -76,10 +76,10 @@ partial which will be deeply merged.
 ```js
 module.exports = {
   hooks: {
-    workbox: function (gasket, config, req) {      
+    workbox: function (gasket, config, req) {
       // the initial `config`
       // `req` allows rules based on headers, cookies, etc.
-      
+
       // return a config partial which will be merged
       return {
         runtimeCaching: [{


### PR DESCRIPTION
A direct copy and paste from these guides would have given you a syntax error, because we're using `[]` instead of `{}`.

## Summary

```diff
+  plugins: {
-  plugins: [

+ }
- ]
```

## Changelog

Fixing widespread documentation errors
