### PR TITLE
Docsify plugin to render simplified slugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
   <script src="//cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
   <script src="//unpkg.com/docsify/lib/plugins/ga.min.js"></script>
   <script src="packages/gasket-plugin-docsify/generator/scripts/toc-link-plugin.js"></script>
+  <script src="packages/gasket-plugin-docsify/generator/scripts/simple-slugs-plugin.js"></script>
   <script src="packages/gasket-plugin-docsify/generator/scripts/mermaid-setup.js"></script>
   <script src="site/cover-plugin.js"></script>
 </body>

--- a/packages/gasket-plugin-docsify/generator/scripts/simple-slugs-plugin.js
+++ b/packages/gasket-plugin-docsify/generator/scripts/simple-slugs-plugin.js
@@ -1,0 +1,21 @@
+//
+// Table of contents may be authored in markdown with heading links suitable
+// for viewing on various git platforms. This plugin simplifies ids from slugs
+// allowing TOC links to also work when viewed with Docsify.
+//
+
+function install(hook) {
+  hook.afterEach(function (html, next) {
+    const nextHtml = html.replace(/(id="?)([^"]+)"/g, (match, p1, p2) => {
+      const fixed = p2
+        .replace(/%\w+/g, '')
+        .replace(/[^a-z0-9- _]/g, '')
+        .replace(/--+/g, '-');
+
+      return p1 + fixed + '"';
+    });
+    next(nextHtml);
+  });
+}
+
+window.$docsify.plugins = [].concat(install, window.$docsify.plugins);

--- a/packages/gasket-plugin-docsify/lib/generate-content.js
+++ b/packages/gasket-plugin-docsify/lib/generate-content.js
@@ -47,6 +47,7 @@ async function generateContent(docsifyConfig, docsConfigSet) {
     '//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js',
     '//cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js',
     'scripts/toc-link-plugin.js',
+    'scripts/simple-slugs-plugin.js',
     'scripts/mermaid-setup.js',
     ...(docsifyConfig.scripts || [])
   ];

--- a/packages/gasket-plugin-docsify/test/setup.js
+++ b/packages/gasket-plugin-docsify/test/setup.js
@@ -2,3 +2,6 @@ const assume = require('assume');
 const assumeSinon = require('assume-sinon');
 
 assume.use(assumeSinon);
+
+global.window = {};
+global.window.$docsify = {};

--- a/packages/gasket-plugin-docsify/test/simple-slugs-plugin.test.js
+++ b/packages/gasket-plugin-docsify/test/simple-slugs-plugin.test.js
@@ -1,0 +1,62 @@
+const assume = require('assume');
+const sinon = require('sinon');
+const path = require('path');
+
+const setup = () => {
+  const file = path.join(__dirname, '..', 'generator', 'scripts', 'simple-slugs-plugin.js');
+  //
+  // we need a fresh require each time
+  //
+  delete require.cache[file];
+  require(file);
+
+  const hooks = {};
+  function afterEach(fn) {
+    hooks.afterEach = fn;
+  }
+
+  global.window.$docsify.plugins[0]({ afterEach });
+  return hooks;
+};
+
+describe('simple-slugs-plugin', () => {
+  afterEach(() => {
+    global.window.$docsify = {};
+  });
+
+  it('installs the plugin', () => {
+    assume(global.window.$docsify).not.property('plugins');
+    setup();
+    assume(global.window.$docsify).property('plugins');
+    global.window.$docsify = {};
+  });
+
+  describe('afterEach', () => {
+    let hooks, nextStub;
+
+    beforeEach(() => {
+      hooks = setup();
+      nextStub = sinon.stub();
+    });
+
+    it('does not modify basic slugs', () => {
+      hooks.afterEach('<h1 id="basic-slug"/>', nextStub);
+      assume(nextStub).calledWith('<h1 id="basic-slug"/>');
+    });
+
+    it('removes encoded text', () => {
+      hooks.afterEach('<h1 id="slug-with-%encoded-data"/>', nextStub);
+      assume(nextStub).calledWith('<h1 id="slug-with-data"/>');
+    });
+
+    it('removes non-basic characters', () => {
+      hooks.afterEach('<h1 id="slug-with-⇒-|-more-data"/>', nextStub);
+      assume(nextStub).calledWith('<h1 id="slug-with-more-data"/>');
+    });
+
+    it('reduces dash groups to single', () => {
+      hooks.afterEach('<h1 id="slug-with--lots---of-------dashes"/>', nextStub);
+      assume(nextStub).calledWith('<h1 id="slug-with-lots-of-dashes"/>');
+    });
+  });
+});

--- a/packages/gasket-plugin-docsify/test/toc-link-plugin.test.js
+++ b/packages/gasket-plugin-docsify/test/toc-link-plugin.test.js
@@ -1,0 +1,32 @@
+const assume = require('assume');
+const sinon = require('sinon');
+const path = require('path');
+
+const setup = () => {
+  const file = path.join(__dirname, '..', 'generator', 'scripts', 'toc-link-plugin.js');
+  window.Docsify = { dom: { create: sinon.stub() } };
+  delete require.cache[file];
+  require(file);
+
+  const hooks = {};
+  function doneEach(fn) {
+    hooks.doneEach = fn;
+  }
+
+  global.window.$docsify.plugins[0]({ doneEach }, {});
+  return hooks;
+};
+
+describe('toc-link-plugin', () => {
+  afterEach(() => {
+    global.window.$docsify = {};
+    delete global.window.Docsify;
+  });
+
+  it('installs the plugin', () => {
+    assume(global.window.$docsify).not.property('plugins');
+    setup();
+    assume(global.window.$docsify).property('plugins');
+    global.window.$docsify = {};
+  });
+});


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

We generally author tables of contents in markdown to work with GitHub heading links. However, Docsify generates slugs for headings different, causing table of contents links to be incompatible. The differences are subtle, so we can simply update the slugs ids before rendering with a Docsify plugin.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

- Add simple slugs plugin for Docsify

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

Units tests and local integration test.