### PR TITLE
Only include doc files with extensions by default

### DIFF
--- a/packages/gasket-plugin-docs/README.md
+++ b/packages/gasket-plugin-docs/README.md
@@ -76,7 +76,7 @@ module.exports = {
         link: 'OTHER.md',
         files: [
           'API.md',
-          'docs/**/*'
+          'docs/**/*.md'
         ],
         transforms: [{
           test: /\.md$/,
@@ -89,7 +89,7 @@ module.exports = {
           },
           'another-module': {
             link: 'README.md#go-here',
-            files: ['html/**/*'],
+            files: ['html/**/*.html'],
             transforms: [{
                test: /\.html$/,
                handler: content => content.replace(/everything/g, 'nothing')
@@ -132,7 +132,7 @@ setup functions cannot be described this way:
     "docsSetup": {
       "link": "OTHER.md#go-here",
       "files": [
-        "more-docs/**/*"
+        "more-docs/**/*.*"
       ]
     }
   }
@@ -203,7 +203,7 @@ module.exports = {
   require,
   docsSetup: {
     link: 'OTHER.md#go-here',
-    files: ['more-docs/**/*'],
+    files: ['more-docs/**/*.*'],
   }
 }
 ```

--- a/packages/gasket-plugin-docs/lib/utils/config-set-builder.js
+++ b/packages/gasket-plugin-docs/lib/utils/config-set-builder.js
@@ -37,7 +37,7 @@ const detailDocsTypes = Object.keys(detailDocsHelpers);
  *
  * @type {{link: string, files: array}}
  */
-const docsSetupDefault = Object.freeze({ link: 'README.md', files: ['docs/**/*'] });
+const docsSetupDefault = Object.freeze({ link: 'README.md', files: ['docs/**/*.*'] });
 
 /**
  * Returns a filename with the hash removed


### PR DESCRIPTION
## Summary

The previous default glob rules would also try to file copy nested directories. This change expects files to have an extension. This should capture the majority of use cases, which plugins can continue to tune via `docsSetup` if needed.

## Changelog

**@gasket/plugin-docs**
- Only include doc files with extensions by default

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
- Local integration test