### PR TITLE
Clean markdown from jsdocs

### DIFF
--- a/packages/gasket-plugin-command/CHANGELOG.md
+++ b/packages/gasket-plugin-command/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-command`
 
+- Clean markdown from jsdocs ([#141])
+
 ### 5.0.0
 
 - Open Source Release
@@ -37,3 +39,4 @@
 [#52]: https://github.com/godaddy/gasket/pull/52
 [#74]: https://github.com/godaddy/gasket/pull/74
 [#94]: https://github.com/godaddy/gasket/pull/94
+[#141]: https://github.com/godaddy/gasket/pull/141

--- a/packages/gasket-plugin-command/docs/api.md
+++ b/packages/gasket-plugin-command/docs/api.md
@@ -1,84 +1,93 @@
-<a name="GasketCommand"></a>
 
 ## GasketCommand
+
 The GasketCommand can be extended to allow plugins to introduce new CLI
 commands to invoke Gasket lifecycles.
 
 **Kind**: global class  
 
-* [GasketCommand](#GasketCommand)
+* [GasketCommand]
     * _instance_
-        * [.gasket](#GasketCommand+gasket) : <code>Gasket</code>
-        * [.parsed](#GasketCommand+parsed) : <code>ParserOutput</code>
-        * *[.gasketRun()](#GasketCommand+gasketRun)*
-        * [.gasketConfigure(gasketConfig)](#GasketCommand+gasketConfigure) ⇒ <code>Object</code>
+        * [.gasket]
+        * [.parsed]
+        * *[.gasketRun()]*
+        * [.gasketConfigure(gasketConfig)]
     * _static_
-        * [.flags](#GasketCommand.flags) : <code>Object</code>
+        * [.flags]
 
-<a name="GasketCommand+gasket"></a>
 
-### gasketCommand.gasket : <code>Gasket</code>
+### gasketCommand.gasket
+
 Gasket Plugin engine instance with details of session
 
-**Kind**: instance property of [<code>GasketCommand</code>](#GasketCommand)  
+**Kind**: instance property of [`GasketCommand`]  
 **Properties**
 
 | Name | Type | Description |
 | --- | --- | --- |
-| command | <code>Object</code> | Details of command |
-| command.id | <code>String</code> | Name of command |
-| command.flags | <code>Object</code> | Flags |
-| command.argv | <code>Array</code> | Ordered Arguments |
-| command.args | <code>Object</code> | Named arguments |
-| config | <code>Object</code> | Loaded and modified configuration |
-| config.env | <code>String</code> | Environment set by command flags |
+| command | `object` | Details of command |
+| command.id | `string` | Name of command |
+| command.flags | `object` | Flags |
+| command.argv | `Array.<string>` | Ordered Arguments |
+| command.args | `object` | Named arguments |
+| config | `object` | Loaded and modified configuration |
+| config.env | `string` | Environment set by command flags |
 
-<a name="GasketCommand+parsed"></a>
 
-### gasketCommand.parsed : <code>ParserOutput</code>
+### gasketCommand.parsed
+
 Flags and arguments passed with CLI command.
 
-**Kind**: instance property of [<code>GasketCommand</code>](#GasketCommand)  
+**Kind**: instance property of [`GasketCommand`]  
 **Properties**
 
 | Name | Type | Description |
 | --- | --- | --- |
-| parsed.flags | <code>Object</code> | Flags |
-| parsed.argv | <code>Array</code> | Ordered Arguments |
-| parsed.args | <code>Object</code> | Named arguments |
+| parsed.flags | `object` | Flags |
+| parsed.argv | `Array.<string>` | Ordered Arguments |
+| parsed.args | `object` | Named arguments |
 
-<a name="GasketCommand+gasketRun"></a>
 
 ### *gasketCommand.gasketRun()*
+
 Abstract method which must be implemented by subclasses, used to execute
 Gasket lifecycles, following the `init` and `configure` Gasket lifecycles.
 
-**Kind**: instance abstract method of [<code>GasketCommand</code>](#GasketCommand)  
-<a name="GasketCommand+gasketConfigure"></a>
+**Kind**: instance abstract method of [`GasketCommand`]  
 
-### gasketCommand.gasketConfigure(gasketConfig) ⇒ <code>Object</code>
+### gasketCommand.gasketConfigure(gasketConfig)
+
 Virtual method which may be overridden by subclasses, to adjust the
 Gasket Config before env overrides are applied.
 
-**Kind**: instance method of [<code>GasketCommand</code>](#GasketCommand)  
-**Returns**: <code>Object</code> - gasketConfig  
+**Kind**: instance method of [`GasketCommand`]  
+**Returns**: `object` - gasketConfig  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| gasketConfig | <code>Object</code> | Gasket configurations |
+| gasketConfig | `object` | Gasket configurations |
 
-<a name="GasketCommand.flags"></a>
 
-### GasketCommand.flags : <code>Object</code>
+### GasketCommand.flags
+
 These are required for all gasket commands, required by the CLI for loading
 the appropriate gasket.config file and environment.
 
-**Kind**: static property of [<code>GasketCommand</code>](#GasketCommand)  
+**Kind**: static property of [`GasketCommand`]  
 **Properties**
 
 | Name | Type | Description |
 | --- | --- | --- |
-| config | <code>string</code> | Fully qualified gasket config to load (default: `'gasket.config'`) |
-| root | <code>string</code> | Top-level app directory (default: `process.cwd()`) |
-| env | <code>string</code> | Target runtime environment (default: `NODE_ENV` or `'development'`) |
+| config | `string` | Fully qualified gasket config to load (default: `'gasket.config'`) |
+| root | `string` | Top-level app directory (default: `process.cwd()`) |
+| env | `string` | Target runtime environment (default: `NODE_ENV` or `'development'`) |
 
+<!-- LINKS -->
+
+[GasketCommand]:#gasketcommand
+[.gasket]:#gasketcommandgasket
+[.parsed]:#gasketcommandparsed
+[.gasketRun()]:#gasketcommandgasketrun
+[.gasketConfigure(gasketConfig)]:#gasketcommandgasketconfiguregasketconfig
+[.flags]:#gasketcommandflags
+[`GasketCommand`]:#gasketcommand

--- a/packages/gasket-plugin-command/lib/command.js
+++ b/packages/gasket-plugin-command/lib/command.js
@@ -21,8 +21,8 @@ class GasketCommand extends Command {
    * Virtual method which may be overridden by subclasses, to adjust the
    * Gasket Config before env overrides are applied.
    *
-   * @param {Object} gasketConfig - Gasket configurations
-   * @returns {Object} gasketConfig
+   * @param {object} gasketConfig - Gasket configurations
+   * @returns {object} gasketConfig
    * @async
    */
   async gasketConfigure(gasketConfig) { return gasketConfig; }
@@ -53,13 +53,13 @@ class GasketCommand extends Command {
      * Gasket Plugin engine instance with details of session
      *
      * @type {Gasket} gasket
-     * @property {Object} command - Details of command
-     * @property {String} command.id - Name of command
-     * @property {Object} command.flags - Flags
-     * @property {Array} command.argv - Ordered Arguments
-     * @property {Object} command.args - Named arguments
-     * @property {Object} config - Loaded and modified configuration
-     * @property {String} config.env - Environment set by command flags
+     * @property {object} command - Details of command
+     * @property {string} command.id - Name of command
+     * @property {object} command.flags - Flags
+     * @property {string[]} command.argv - Ordered Arguments
+     * @property {object} command.args - Named arguments
+     * @property {object} config - Loaded and modified configuration
+     * @property {string} config.env - Environment set by command flags
      */
     this.gasket = this.config.gasket;
 
@@ -67,9 +67,9 @@ class GasketCommand extends Command {
      * Flags and arguments passed with CLI command.
      *
      * @type {ParserOutput} parsed - Parsed flags and args
-     * @property {Object} parsed.flags - Flags
-     * @property {Array} parsed.argv - Ordered Arguments
-     * @property {Object} parsed.args - Named arguments
+     * @property {object} parsed.flags - Flags
+     * @property {string[]} parsed.argv - Ordered Arguments
+     * @property {object} parsed.args - Named arguments
      */
     this.parsed = this.parse(this.constructor);
     const parsedFlags = this.parsed.flags = this.parsed.flags || {};
@@ -103,7 +103,7 @@ class GasketCommand extends Command {
  * These are required for all gasket commands, required by the CLI for loading
  * the appropriate gasket.config file and environment.
  *
- * @type {Object} flags
+ * @type {object} flags
  * @property {string} config - Fully qualified gasket config to load (default: `'gasket.config'`)
  * @property {string} root - Top-level app directory (default: `process.cwd()`)
  * @property {string} env - Target runtime environment (default: `NODE_ENV` or `'development'`)

--- a/packages/gasket-plugin-command/lib/plugin.js
+++ b/packages/gasket-plugin-command/lib/plugin.js
@@ -10,8 +10,8 @@ module.exports = {
      * Gets commands from plugins and injects them to the oclif config.
      *
      * @param {Gasket} gasket - Gasket API
-     * @param {Object} data - init data
-     * @param {Object} data.oclifConfig - oclif configuration
+     * @param {object} data - init data
+     * @param {object} data.oclifConfig - oclif configuration
      * @async
      */
     async initOclif(gasket, { oclifConfig }) {

--- a/packages/gasket-plugin-command/package.json
+++ b/packages/gasket-plugin-command/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",
     "posttest": "npm run lint",
     "prepack": "npm run docs",
-    "docs": "jsdoc2md lib/*.js > docs/api.md"
+    "docs": "jsdoc2md --plugin @godaddy/dmd --files lib/*.js > docs/api.md"
   },
   "repository": {
     "type": "git",
@@ -40,6 +40,7 @@
     "@gasket/utils": "^5.0.2"
   },
   "devDependencies": {
+    "@godaddy/dmd": "^1.0.0",
     "@oclif/config": "^1.13.0",
     "@oclif/errors": "^1.1.2",
     "assume": "^2.2.0",

--- a/packages/gasket-plugin-docs/CHANGELOG.md
+++ b/packages/gasket-plugin-docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-docs`
 
+- Clean markdown from jsdocs ([#141])
+
 ### 5.0.2
 
 - Only include doc files with extensions by default ([#139])
@@ -19,3 +21,4 @@
 
 [#82]:https://github.com/godaddy/gasket/pull/82
 [#139]:https://github.com/godaddy/gasket/pull/139
+[#141]: https://github.com/godaddy/gasket/pull/141

--- a/packages/gasket-plugin-docs/docs/api.md
+++ b/packages/gasket-plugin-docs/docs/api.md
@@ -1,35 +1,20 @@
+
 ## Typedefs
 
-<dl>
-<dt><a href="#DocsSetup">DocsSetup</a> : <code>Object</code></dt>
-<dd><p>Setup object to describe docs configuration for a module</p>
-</dd>
-<dt><a href="#DocsConfig">DocsConfig</a> : <code>Object</code></dt>
-<dd><p>Base docs configuration</p>
-</dd>
-<dt><a href="#ModuleDocsConfig">ModuleDocsConfig</a> : <code><a href="#DocsConfig">DocsConfig</a></code></dt>
-<dd><p>Docs configuration for a module</p>
-</dd>
-<dt><a href="#DetailDocsConfig">DetailDocsConfig</a> : <code><a href="#DocsConfig">DocsConfig</a></code></dt>
-<dd><p>Docs configuration for members of a plugin</p>
-</dd>
-<dt><a href="#LifecycleDocsConfig">LifecycleDocsConfig</a> : <code><a href="#DetailDocsConfig">DetailDocsConfig</a></code></dt>
-<dd><p>Docs configuration with specifics for plugin lifecycles</p>
-</dd>
-<dt><a href="#DocsConfigSet">DocsConfigSet</a> : <code>Object</code></dt>
-<dd><p>Set of docs configurations for the app</p>
-</dd>
-<dt><a href="#DocsTransform">DocsTransform</a> : <code>Object</code></dt>
-<dd><p>Transform content of doc files matching test pattern</p>
-</dd>
-<dt><a href="#DocsTransformHandler">DocsTransformHandler</a> ⇒ <code>string</code></dt>
-<dd><p>Handler to modify file contents for a DocsTransform</p>
-</dd>
-</dl>
+Name | Description
+------ | -----------
+[DocsSetup] | Setup object to describe docs configuration for a module
+[DocsConfig] | Base docs configuration
+[ModuleDocsConfig] | Docs configuration for a module
+[DetailDocsConfig] | Docs configuration for members of a plugin
+[LifecycleDocsConfig] | Docs configuration with specifics for plugin lifecycles
+[DocsConfigSet] | Set of docs configurations for the app
+[DocsTransform] | Transform content of doc files matching test pattern
+[DocsTransformHandler] | Handler to modify file contents for a DocsTransform
 
-<a name="DocsSetup"></a>
 
-## DocsSetup : <code>Object</code>
+## DocsSetup
+
 Setup object to describe docs configuration for a module
 
 **Kind**: global typedef  
@@ -37,14 +22,14 @@ Setup object to describe docs configuration for a module
 
 | Name | Type | Description |
 | --- | --- | --- |
-| link | <code>string</code> | Markdown link relative to package root |
-| [files] | <code>Array.&lt;glob&gt;</code> | Names and/or patterns of files to collect |
-| [transforms] | [<code>Array.&lt;DocsTransform&gt;</code>](#DocsTransform) | Transforms to apply to collected files |
-| [modules] | <code>Object.&lt;string, DocsSetup&gt;</code> | Setup object for supporting modules |
+| link | `string` | Markdown link relative to package root |
+| \[files\] | `Array.<glob>` | Names and/or patterns of files to collect |
+| \[transforms\] | `Array.<DocsTransform>` | Transforms to apply to collected files |
+| \[modules\] | `Object.<string, DocsSetup>` | Setup object for supporting modules |
 
-<a name="DocsConfig"></a>
 
-## DocsConfig : <code>Object</code>
+## DocsConfig
+
 Base docs configuration
 
 **Kind**: global typedef  
@@ -52,15 +37,15 @@ Base docs configuration
 
 | Name | Type | Description |
 | --- | --- | --- |
-| name | <code>string</code> | Name of the the module or element |
-| [description] | <code>string</code> | Description of the module or element |
-| [link] | <code>string</code> | Relative path to a doc from the module's package |
-| sourceRoot | <code>string</code> | Absolute path to the module's package |
-| targetRoot | <code>string</code> | Absolute path to output dir for the module |
+| name | `string` | Name of the the module or element |
+| \[description\] | `string` | Description of the module or element |
+| \[link\] | `string` | Relative path to a doc from the module's package |
+| sourceRoot | `string` | Absolute path to the module's package |
+| targetRoot | `string` | Absolute path to output dir for the module |
 
-<a name="ModuleDocsConfig"></a>
 
-## ModuleDocsConfig : [<code>DocsConfig</code>](#DocsConfig)
+## ModuleDocsConfig
+
 Docs configuration for a module
 
 **Kind**: global typedef  
@@ -68,13 +53,13 @@ Docs configuration for a module
 
 | Name | Type | Description |
 | --- | --- | --- |
-| files | <code>Array.&lt;String&gt;</code> | Resolved files from docsSetup |
-| transforms | [<code>Array.&lt;DocsTransform&gt;</code>](#DocsTransform) | Local doc transforms |
-| metadata | <code>ModuleData</code> | Originating metadata for this module |
+| files | `Array.<string>` | Resolved files from docsSetup |
+| transforms | `Array.<DocsTransform>` | Local doc transforms |
+| metadata | `ModuleData` | Originating metadata for this module |
 
-<a name="DetailDocsConfig"></a>
 
-## DetailDocsConfig : [<code>DocsConfig</code>](#DocsConfig)
+## DetailDocsConfig
+
 Docs configuration for members of a plugin
 
 **Kind**: global typedef  
@@ -82,11 +67,11 @@ Docs configuration for members of a plugin
 
 | Name | Type | Description |
 | --- | --- | --- |
-| from | <code>string</code> | Name from the parent ModuleDocsConfig |
+| from | `string` | Name from the parent ModuleDocsConfig |
 
-<a name="LifecycleDocsConfig"></a>
 
-## LifecycleDocsConfig : [<code>DetailDocsConfig</code>](#DetailDocsConfig)
+## LifecycleDocsConfig
+
 Docs configuration with specifics for plugin lifecycles
 
 **Kind**: global typedef  
@@ -94,13 +79,13 @@ Docs configuration with specifics for plugin lifecycles
 
 | Name | Type | Description |
 | --- | --- | --- |
-| method | <code>string</code> | Executing method from the engine |
-| [parent] | <code>string</code> | Lifecycle from which this one is invoked |
-| [command] | <code>string</code> | Command from which this lifecycle is invoked |
+| method | `string` | Executing method from the engine |
+| \[parent\] | `string` | Lifecycle from which this one is invoked |
+| \[command\] | `string` | Command from which this lifecycle is invoked |
 
-<a name="DocsConfigSet"></a>
 
-## DocsConfigSet : <code>Object</code>
+## DocsConfigSet
+
 Set of docs configurations for the app
 
 **Kind**: global typedef  
@@ -108,21 +93,21 @@ Set of docs configurations for the app
 
 | Name | Type | Description |
 | --- | --- | --- |
-| app | [<code>ModuleDocsConfig</code>](#ModuleDocsConfig) | Docs from the main package |
-| plugins | [<code>Array.&lt;ModuleDocsConfig&gt;</code>](#ModuleDocsConfig) | Docs for all configured plugins |
-| presets | [<code>Array.&lt;ModuleDocsConfig&gt;</code>](#ModuleDocsConfig) | Docs for all configured presets |
-| modules | [<code>Array.&lt;ModuleDocsConfig&gt;</code>](#ModuleDocsConfig) | Docs of supporting modules |
-| structures | [<code>Array.&lt;DetailDocsConfig&gt;</code>](#DetailDocsConfig) | Docs describing structure elements |
-| commands | [<code>Array.&lt;DetailDocsConfig&gt;</code>](#DetailDocsConfig) | Docs for available commands |
-| guides | [<code>Array.&lt;DetailDocsConfig&gt;</code>](#DetailDocsConfig) | Docs for setups and explanations |
-| lifecycles | [<code>Array.&lt;LifecycleDocsConfig&gt;</code>](#LifecycleDocsConfig) | Docs for available lifecycles |
-| transforms | [<code>Array.&lt;DocsTransform&gt;</code>](#DocsTransform) | Global doc transforms |
-| root | <code>string</code> | Absolute path to main package |
-| docsRoot | <code>string</code> | Absolute path to output directory |
+| app | [`ModuleDocsConfig`] | Docs from the main package |
+| plugins | `Array.<ModuleDocsConfig>` | Docs for all configured plugins |
+| presets | `Array.<ModuleDocsConfig>` | Docs for all configured presets |
+| modules | `Array.<ModuleDocsConfig>` | Docs of supporting modules |
+| structures | `Array.<DetailDocsConfig>` | Docs describing structure elements |
+| commands | `Array.<DetailDocsConfig>` | Docs for available commands |
+| guides | `Array.<DetailDocsConfig>` | Docs for setups and explanations |
+| lifecycles | `Array.<LifecycleDocsConfig>` | Docs for available lifecycles |
+| transforms | `Array.<DocsTransform>` | Global doc transforms |
+| root | `string` | Absolute path to main package |
+| docsRoot | `string` | Absolute path to output directory |
 
-<a name="DocsTransform"></a>
 
-## DocsTransform : <code>Object</code>
+## DocsTransform
+
 Transform content of doc files matching test pattern
 
 **Kind**: global typedef  
@@ -130,23 +115,36 @@ Transform content of doc files matching test pattern
 
 | Name | Type | Description |
 | --- | --- | --- |
-| [global] | <code>Boolean</code> | If true, will be applied to all files, otherwise to only files in module. |
-| test | <code>RegExp</code> | Expression to test against the full source filename |
-| handler | [<code>DocsTransformHandler</code>](#DocsTransformHandler) | Function to modify matching files' contents |
+| \[global\] | `boolean` | If true, will be applied to all files, otherwise to only files in module. |
+| test | `RegExp` | Expression to test against the full source filename |
+| handler | [`DocsTransformHandler`] | Function to modify matching files' contents |
 
-<a name="DocsTransformHandler"></a>
 
-## DocsTransformHandler ⇒ <code>string</code>
+## DocsTransformHandler
+
 Handler to modify file contents for a DocsTransform
 
 **Kind**: global typedef  
-**Returns**: <code>string</code> - transformed content  
+**Returns**: `string` - transformed content  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| content | <code>String</code> | Doc file content to transform |
-| data | <code>Object</code> | Additional details relating to the doc file being handled |
-| data.filename | <code>String</code> | Relative path of this filename |
-| data.docsConfig | [<code>ModuleDocsConfig</code>](#ModuleDocsConfig) | Docs config for this file's module |
-| data.docsConfigSet | [<code>DocsConfigSet</code>](#DocsConfigSet) | Set of configs for the app |
+| content | `string` | Doc file content to transform |
+| data | `object` | Additional details relating to the doc file being handled |
+| data.filename | `string` | Relative path of this filename |
+| data.docsConfig | [`ModuleDocsConfig`] | Docs config for this file's module |
+| data.docsConfigSet | [`DocsConfigSet`] | Set of configs for the app |
 
+<!-- LINKS -->
+
+[DocsSetup]:#docssetup
+[DocsConfig]:#docsconfig
+[ModuleDocsConfig]:#moduledocsconfig
+[DetailDocsConfig]:#detaildocsconfig
+[LifecycleDocsConfig]:#lifecycledocsconfig
+[DocsConfigSet]:#docsconfigset
+[DocsTransform]:#docstransform
+[DocsTransformHandler]:#docstransformhandler
+[`ModuleDocsConfig`]:#moduledocsconfig
+[`DocsTransformHandler`]:#docstransformhandler
+[`DocsConfigSet`]:#docsconfigset

--- a/packages/gasket-plugin-docs/lib/configure.js
+++ b/packages/gasket-plugin-docs/lib/configure.js
@@ -8,8 +8,8 @@ const defaultConfig = {
  * Configure lifecycle to set up SW config with defaults
  *
  * @param {Gasket} gasket - Gasket
- * @param {Object} baseConfig - Base gasket config
- * @returns {Object} config
+ * @param {object} baseConfig - Base gasket config
+ * @returns {object} config
  */
 module.exports = function configureHook(gasket, baseConfig = {}) {
   const userConfig = baseConfig.docs || {};

--- a/packages/gasket-plugin-docs/lib/metadata.js
+++ b/packages/gasket-plugin-docs/lib/metadata.js
@@ -2,8 +2,8 @@
  * Attach additional metadata to pluginData
  *
  * @param {Gasket} gasket - Gasket
- * @param {Object} meta - Initial meta data
- * @returns {Object} Additional meta data
+ * @param {object} meta - Initial meta data
+ * @returns {object} Additional meta data
  */
 module.exports = function metadata(gasket, meta) {
   const { outputDir } = gasket.config.docs || require('./configure').defaultConfig;

--- a/packages/gasket-plugin-docs/lib/types.js
+++ b/packages/gasket-plugin-docs/lib/types.js
@@ -1,7 +1,7 @@
 /**
  * Setup object to describe docs configuration for a module
  *
- * @typedef {Object} DocsSetup
+ * @typedef {object} DocsSetup
  *
  * @property {string} link - Markdown link relative to package root
  * @property {glob[]} [files] - Names and/or patterns of files to collect
@@ -12,7 +12,7 @@
 /**
  * Base docs configuration
  *
- * @typedef {Object} DocsConfig
+ * @typedef {object} DocsConfig
  *
  * @property {string} name - Name of the the module or element
  * @property {string} [description] - Description of the module or element
@@ -26,7 +26,7 @@
  *
  * @typedef {DocsConfig} ModuleDocsConfig
  *
- * @property {String[]} files - Resolved files from docsSetup
+ * @property {string[]} files - Resolved files from docsSetup
  * @property {DocsTransform[]} transforms - Local doc transforms
  * @property {ModuleData} metadata - Originating metadata for this module
  */
@@ -52,7 +52,7 @@
 /**
  * Set of docs configurations for the app
  *
- * @typedef {Object} DocsConfigSet
+ * @typedef {object} DocsConfigSet
  *
  * @property {ModuleDocsConfig} app - Docs from the main package
  * @property {ModuleDocsConfig[]} plugins - Docs for all configured plugins
@@ -70,9 +70,9 @@
 /**
  * Transform content of doc files matching test pattern
  *
- * @typedef {Object} DocsTransform
+ * @typedef {object} DocsTransform
  *
- * @property {Boolean} [global] - If true, will be applied to all files, otherwise to only files in module.
+ * @property {boolean} [global] - If true, will be applied to all files, otherwise to only files in module.
  * @property {RegExp} test - Expression to test against the full source filename
  * @property {DocsTransformHandler} handler - Function to modify matching files' contents
  */
@@ -80,11 +80,11 @@
 /**
  * Handler to modify file contents for a DocsTransform
  *
- * @typedef {Function} DocsTransformHandler
+ * @typedef {function} DocsTransformHandler
  *
- * @param {String} content - Doc file content to transform
- * @param {Object} data - Additional details relating to the doc file being handled
- * @param {String} data.filename - Relative path of this filename
+ * @param {string} content - Doc file content to transform
+ * @param {object} data - Additional details relating to the doc file being handled
+ * @param {string} data.filename - Relative path of this filename
  * @param {ModuleDocsConfig} data.docsConfig - Docs config for this file's module
  * @param {DocsConfigSet} data.docsConfigSet - Set of configs for the app
  * @returns {string} transformed content

--- a/packages/gasket-plugin-docs/lib/utils/config-set-builder.js
+++ b/packages/gasket-plugin-docs/lib/utils/config-set-builder.js
@@ -139,7 +139,7 @@ class DocsConfigSetBuilder {
    *
    * @param {ModuleData} moduleData - Metadata for a module
    * @param {DocsSetup} docsSetup - Files to include and transforms
-   * @param {Object} overrides - Pre-configured properties
+   * @param {object} overrides - Pre-configured properties
    * @returns {DocsConfig} docsConfigs
    * @private
    */

--- a/packages/gasket-plugin-docs/lib/utils/transforms.js
+++ b/packages/gasket-plugin-docs/lib/utils/transforms.js
@@ -96,7 +96,7 @@ const txAbsoluteLinks = {
   /**
    * @type {DocsTransformHandler}
    * @param {string} content - Markdown content
-   * @param {String} filename - Relative package filename
+   * @param {string} filename - Relative package filename
    * @param {ModuleDocsConfig} docsConfig - Docs config for this file's module
    * @returns {string} transformed content
    */

--- a/packages/gasket-plugin-docs/package.json
+++ b/packages/gasket-plugin-docs/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "nyc --reporter=text --reporter=lcov --all npm run test:runner",
     "posttest": "npm run lint",
     "prepack": "npm run docs",
-    "docs": "jsdoc2md lib/*.js > docs/api.md"
+    "docs": "jsdoc2md --plugin @godaddy/dmd --files lib/*.js > docs/api.md"
   },
   "repository": {
     "type": "git",
@@ -40,6 +40,7 @@
     "rimraf": "^3.0.0"
   },
   "devDependencies": {
+    "@godaddy/dmd": "^1.0.0",
     "assume": "^2.2.0",
     "eslint": "^6.1.0",
     "eslint-config-godaddy": "^4.0.0",

--- a/packages/gasket-plugin-metadata/CHANGELOG.md
+++ b/packages/gasket-plugin-metadata/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-metadata`
 
+- Clean markdown from jsdocs ([#141])
+
 ### 5.0.0
 
 - Open Source Release
@@ -20,8 +22,9 @@
 
 [#51]: https://github.com/godaddy/gasket/pull/51
 [#64]: https://github.com/godaddy/gasket/pull/64
+[#141]: https://github.com/godaddy/gasket/pull/141
 
-[Loader]:/packages/gasket-resolve/docs/api.md#Loader
-[PluginInfo]:/packages/gasket-resolve/docs/api.md#PluginInfo
-[PresetInfo]:/packages/gasket-resolve/docs/api.md#PresetInfo
-[ModuleInfo]:/packages/gasket-resolve/docs/api.md#ModuleInfo
+[Loader]:/packages/gasket-resolve/docs/api.md#loader
+[PluginInfo]:/packages/gasket-resolve/docs/api.md#plugininfo
+[PresetInfo]:/packages/gasket-resolve/docs/api.md#presetinfo
+[ModuleInfo]:/packages/gasket-resolve/docs/api.md#moduleinfo

--- a/packages/gasket-plugin-metadata/docs/api.md
+++ b/packages/gasket-plugin-metadata/docs/api.md
@@ -1,32 +1,19 @@
+
 ## Typedefs
 
-<dl>
-<dt><a href="#ModuleData">ModuleData</a> : <code>Object</code></dt>
-<dd><p>Module with meta data</p>
-</dd>
-<dt><a href="#AppData">AppData</a> : <code><a href="#ModuleData">ModuleData</a></code></dt>
-<dd><p>App module with meta data</p>
-</dd>
-<dt><a href="#PluginData">PluginData</a> : <code><a href="#ModuleData">ModuleData</a></code></dt>
-<dd><p>Plugin module with meta data</p>
-</dd>
-<dt><a href="#PresetData">PresetData</a> : <code><a href="#ModuleData">ModuleData</a></code></dt>
-<dd><p>Preset module with meta data</p>
-</dd>
-<dt><a href="#DetailData">DetailData</a> : <code>Object</code></dt>
-<dd><p>Metadata for details of a plugin</p>
-</dd>
-<dt><a href="#LifecycleData">LifecycleData</a> : <code><a href="#DetailData">DetailData</a></code></dt>
-<dd><p>Metadata with specifics details for plugin lifecycles</p>
-</dd>
-<dt><a href="#Metadata">Metadata</a> : <code>Object</code></dt>
-<dd><p>Collection data for modules configured for app</p>
-</dd>
-</dl>
+Name | Description
+------ | -----------
+[ModuleData] | Module with meta data
+[AppData] | App module with meta data
+[PluginData] | Plugin module with meta data
+[PresetData] | Preset module with meta data
+[DetailData] | Metadata for details of a plugin
+[LifecycleData] | Metadata with specifics details for plugin lifecycles
+[Metadata] | Collection data for modules configured for app
 
-<a name="ModuleData"></a>
 
-## ModuleData : <code>Object</code>
+## ModuleData
+
 Module with meta data
 
 **Kind**: global typedef  
@@ -34,18 +21,18 @@ Module with meta data
 
 | Name | Type | Description |
 | --- | --- | --- |
-| name | <code>String</code> | Name of preset |
-| module | <code>String</code> | Actual module content |
-| [package] | <code>String</code> | Package.json contents |
-| [version] | <code>String</code> | Resolved version |
-| [path] | <code>String</code> | Path to the root of package |
-| [from] | <code>String</code> | Name of module which requires this module |
-| [range] | <code>String</code> | Range by which this module was required |
-| [link] | <code>string</code> | Path to a doc file or URL |
+| name | `string` | Name of preset |
+| module | `string` | Actual module content |
+| \[package\] | `string` | Package.json contents |
+| \[version\] | `string` | Resolved version |
+| \[path\] | `string` | Path to the root of package |
+| \[from\] | `string` | Name of module which requires this module |
+| \[range\] | `string` | Range by which this module was required |
+| \[link\] | `string` | Path to a doc file or URL |
 
-<a name="AppData"></a>
 
-## AppData : [<code>ModuleData</code>](#ModuleData)
+## AppData
+
 App module with meta data
 
 **Kind**: global typedef  
@@ -53,11 +40,11 @@ App module with meta data
 
 | Name | Type | Description |
 | --- | --- | --- |
-| [modules] | [<code>Array.&lt;DetailData&gt;</code>](#DetailData) | Description of modules supporting this plugin |
+| \[modules\] | `Array.<DetailData>` | Description of modules supporting this plugin |
 
-<a name="PluginData"></a>
 
-## PluginData : [<code>ModuleData</code>](#ModuleData)
+## PluginData
+
 Plugin module with meta data
 
 **Kind**: global typedef  
@@ -65,14 +52,14 @@ Plugin module with meta data
 
 | Name | Type | Description |
 | --- | --- | --- |
-| [commands] | [<code>Array.&lt;DetailData&gt;</code>](#DetailData) | Commands enabled by this plugin |
-| [structures] | [<code>Array.&lt;DetailData&gt;</code>](#DetailData) | App files and directories used by plugin |
-| [lifecycles] | [<code>Array.&lt;DetailData&gt;</code>](#DetailData) | Description of lifecycles invoked by plugin |
-| [modules] | [<code>Array.&lt;DetailData&gt;</code>](#DetailData) | Description of modules supporting this plugin |
+| \[commands\] | `Array.<DetailData>` | Commands enabled by this plugin |
+| \[structures\] | `Array.<DetailData>` | App files and directories used by plugin |
+| \[lifecycles\] | `Array.<DetailData>` | Description of lifecycles invoked by plugin |
+| \[modules\] | `Array.<DetailData>` | Description of modules supporting this plugin |
 
-<a name="PresetData"></a>
 
-## PresetData : [<code>ModuleData</code>](#ModuleData)
+## PresetData
+
 Preset module with meta data
 
 **Kind**: global typedef  
@@ -80,12 +67,12 @@ Preset module with meta data
 
 | Name | Type | Description |
 | --- | --- | --- |
-| presets | [<code>Array.&lt;PresetData&gt;</code>](#PresetData) | Presets that this preset extends |
-| plugins | [<code>Array.&lt;PluginData&gt;</code>](#PluginData) | Plugins this preset uses |
+| presets | `Array.<PresetData>` | Presets that this preset extends |
+| plugins | `Array.<PluginData>` | Plugins this preset uses |
 
-<a name="DetailData"></a>
 
-## DetailData : <code>Object</code>
+## DetailData
+
 Metadata for details of a plugin
 
 **Kind**: global typedef  
@@ -93,13 +80,13 @@ Metadata for details of a plugin
 
 | Name | Type | Description |
 | --- | --- | --- |
-| name | <code>string</code> | Name of the the module or element |
-| [description] | <code>string</code> | Description of the module or element |
-| [link] | <code>string</code> | Path to a doc file or URL |
+| name | `string` | Name of the the module or element |
+| \[description\] | `string` | Description of the module or element |
+| \[link\] | `string` | Path to a doc file or URL |
 
-<a name="LifecycleData"></a>
 
-## LifecycleData : [<code>DetailData</code>](#DetailData)
+## LifecycleData
+
 Metadata with specifics details for plugin lifecycles
 
 **Kind**: global typedef  
@@ -107,13 +94,13 @@ Metadata with specifics details for plugin lifecycles
 
 | Name | Type | Description |
 | --- | --- | --- |
-| method | <code>string</code> | Executing method from the engine |
-| [parent] | <code>string</code> | Lifecycle from which this one is invoked |
-| [command] | <code>string</code> | Command from which this lifecycle is invoked |
+| method | `string` | Executing method from the engine |
+| \[parent\] | `string` | Lifecycle from which this one is invoked |
+| \[command\] | `string` | Command from which this lifecycle is invoked |
 
-<a name="Metadata"></a>
 
-## Metadata : <code>Object</code>
+## Metadata
+
 Collection data for modules configured for app
 
 **Kind**: global typedef  
@@ -121,8 +108,17 @@ Collection data for modules configured for app
 
 | Name | Type | Description |
 | --- | --- | --- |
-| app | [<code>Array.&lt;AppData&gt;</code>](#AppData) | App and main package data |
-| presets | [<code>Array.&lt;PresetData&gt;</code>](#PresetData) | Preset data with dependency hierarchy |
-| plugins | [<code>Array.&lt;PluginData&gt;</code>](#PluginData) | Flat list of registered plugin data |
-| modules | [<code>Array.&lt;ModuleData&gt;</code>](#ModuleData) | Supporting module data |
+| app | `Array.<AppData>` | App and main package data |
+| presets | `Array.<PresetData>` | Preset data with dependency hierarchy |
+| plugins | `Array.<PluginData>` | Flat list of registered plugin data |
+| modules | `Array.<ModuleData>` | Supporting module data |
 
+<!-- LINKS -->
+
+[ModuleData]:#moduledata
+[AppData]:#appdata
+[PluginData]:#plugindata
+[PresetData]:#presetdata
+[DetailData]:#detaildata
+[LifecycleData]:#lifecycledata
+[Metadata]:#metadata

--- a/packages/gasket-plugin-metadata/lib/types.js
+++ b/packages/gasket-plugin-metadata/lib/types.js
@@ -1,15 +1,15 @@
 /**
  * Module with meta data
  *
- * @typedef {Object} ModuleData
+ * @typedef {object} ModuleData
  *
- * @property {String} name - Name of preset
- * @property {String} module - Actual module content
- * @property {String} [package] - Package.json contents
- * @property {String} [version] - Resolved version
- * @property {String} [path] - Path to the root of package
- * @property {String} [from] - Name of module which requires this module
- * @property {String} [range] - Range by which this module was required
+ * @property {string} name - Name of preset
+ * @property {string} module - Actual module content
+ * @property {string} [package] - Package.json contents
+ * @property {string} [version] - Resolved version
+ * @property {string} [path] - Path to the root of package
+ * @property {string} [from] - Name of module which requires this module
+ * @property {string} [range] - Range by which this module was required
  * @property {string} [link] - Path to a doc file or URL
  */
 
@@ -41,7 +41,7 @@
 /**
  * Metadata for details of a plugin
  *
- * @typedef {Object} DetailData
+ * @typedef {object} DetailData
  *
  * @property {string} name - Name of the the module or element
  * @property {string} [description] - Description of the module or element
@@ -61,7 +61,7 @@
 /**
  * Collection data for modules configured for app
  *
- * @typedef {Object} Metadata
+ * @typedef {object} Metadata
  * @property {AppData[]} app - App and main package data
  * @property {PresetData[]} presets - Preset data with dependency hierarchy
  * @property {PluginData[]} plugins - Flat list of registered plugin data

--- a/packages/gasket-plugin-metadata/lib/utils.js
+++ b/packages/gasket-plugin-metadata/lib/utils.js
@@ -10,8 +10,8 @@ const isPreset = name => presetIdentifier.isValidFullName(name);
  * Recurse through an object or array, and transforms, by mutation,
  * any functions to be empty.
  *
- * @param {Object|Array} value - Item to consider
- * @returns {Object|Array} transformed result
+ * @param {object|object[]} value - Item to consider
+ * @returns {object|object[]} transformed result
  * @private
  */
 function sanitize(value) {
@@ -37,8 +37,8 @@ function sanitize(value) {
 /**
  * Add keys to from other object to the target if not present
  *
- * @param {Object} target - Object to mutate
- * @param {Object} other - Object to pull from
+ * @param {object} target - Object to mutate
+ * @param {object} other - Object to pull from
  * @private
  */
 function safeAssign(target, other) {

--- a/packages/gasket-plugin-metadata/package.json
+++ b/packages/gasket-plugin-metadata/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",
     "posttest": "npm run lint",
     "prepack": "npm run docs",
-    "docs": "jsdoc2md lib/*.js > docs/api.md"
+    "docs": "jsdoc2md --plugin @godaddy/dmd --files lib/*.js > docs/api.md"
   },
   "repository": {
     "type": "git",
@@ -39,6 +39,7 @@
     "lodash.isobject": "^3.0.2"
   },
   "devDependencies": {
+    "@godaddy/dmd": "^1.0.0",
     "assume": "^2.2.0",
     "eslint": "^6.1.0",
     "eslint-config-godaddy": "^4.0.0",

--- a/packages/gasket-resolve/CHANGELOG.md
+++ b/packages/gasket-resolve/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/resolve`
 
+- Clean markdown from jsdocs ([#141])
+
 ### 5.0.0
 
 - Open Source Release
@@ -44,5 +46,6 @@
 [#64]: https://github.com/godaddy/gasket/pull/64
 [#93]: https://github.com/godaddy/gasket/pull/93
 [#105]: https://github.com/godaddy/gasket/pull/105
+[#141]: https://github.com/godaddy/gasket/pull/141
 
-[Loader]:/packages/gasket-resolve/README.md#Loader
+[Loader]:/packages/gasket-resolve/docs/api.md#loader

--- a/packages/gasket-resolve/docs/api.md
+++ b/packages/gasket-resolve/docs/api.md
@@ -56,9 +56,9 @@ Loads a module with additional metadata
 
 | Param | Type | Description |
 | --- | --- | --- |
-| module | `String` | Module content |
-| moduleName | `String` | Name of module to load |
-| \[meta\] | `Object` | Additional meta data |
+| module | `string` | Module content |
+| moduleName | `string` | Name of module to load |
+| \[meta\] | `object` | Additional meta data |
 
 
 ### loader.loadModule(moduleName, \[meta\])
@@ -70,8 +70,8 @@ Loads a module with additional metadata
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | `String` | Name of module to load |
-| \[meta\] | `Object` | Additional meta data |
+| moduleName | `string` | Name of module to load |
+| \[meta\] | `object` | Additional meta data |
 
 
 ### loader.loadPlugin(module, \[meta\])
@@ -84,7 +84,7 @@ Loads a plugin with additional metadata.
 | Param | Type | Description |
 | --- | --- | --- |
 | module | [`PluginName`] \| `Object` | Name of module to load (or module content) |
-| \[meta\] | `Object` | Additional meta data |
+| \[meta\] | `object` | Additional meta data |
 
 
 ### loader.loadPreset(module, \[meta\], \[options\])
@@ -97,9 +97,9 @@ Loads a preset with additional metadata
 | Param | Type | Description |
 | --- | --- | --- |
 | module | [`PresetName`] | Name of module to load |
-| \[meta\] | `Object` | Additional meta data |
-| \[options\] | `Boolean` | Loading options |
-| \[options.shallow\] | `Boolean` | Do not recursively load dependencies |
+| \[meta\] | `object` | Additional meta data |
+| \[options\] | `boolean` | Loading options |
+| \[options.shallow\] | `boolean` | Do not recursively load dependencies |
 
 
 ### loader.loadConfigured(config)
@@ -113,7 +113,7 @@ Plugins will be filtered and ordered as configuration with priority of:
 
 | Param | Type | Description |
 | --- | --- | --- |
-| config | `Object` | Presets and plugins to load |
+| config | `object` | Presets and plugins to load |
 | config.presets | `Array.<PresetName>` | Presets to load and add plugins from |
 | config.add | `Array.<PluginName>` \| `Array.<module>` | Names of plugins to load |
 | config.remove | `Array.<string>` | Names of plugins to remove (from presets) |
@@ -125,11 +125,11 @@ Returns the resolved module filename
 
 **Kind**: instance method of [`Loader`]  
 **Overrides**: `resolve`  
-**Returns**: `String` - filename of the module  
+**Returns**: `string` - filename of the module  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | `String` | name of the module |
+| moduleName | `string` | name of the module |
 
 
 ### loader.require(moduleName)
@@ -138,11 +138,11 @@ Returns the required module
 
 **Kind**: instance method of [`Loader`]  
 **Overrides**: `require`  
-**Returns**: `Object` - module contents  
+**Returns**: `object` - module contents  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | `String` | name of the module |
+| moduleName | `string` | name of the module |
 
 
 ### loader.tryResolve(moduleName)
@@ -151,11 +151,11 @@ Returns the resolved module filename, or null if not found
 
 **Kind**: instance method of [`Loader`]  
 **Overrides**: `tryResolve`  
-**Returns**: `String` ⎮ `null` - filename of the module  
+**Returns**: `string` ⎮ `null` - filename of the module  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | `String` | name of the module |
+| moduleName | `string` | name of the module |
 
 
 ### loader.tryRequire(moduleName)
@@ -164,11 +164,11 @@ Returns the required module, or null if not found
 
 **Kind**: instance method of [`Loader`]  
 **Overrides**: `tryRequire`  
-**Returns**: `Object` ⎮ `null` - module contents  
+**Returns**: `object` ⎮ `null` - module contents  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | `String` | name of the module |
+| moduleName | `string` | name of the module |
 
 
 ## PackageIdentifier
@@ -310,8 +310,8 @@ Utility to help resolve and require modules
 
 | Param | Type | Description |
 | --- | --- | --- |
-| options | `Object` | Options |
-| \[options.resolveFrom\] | `String` \| `Array.<String>` | Path(s) to resolve modules from |
+| options | `object` | Options |
+| \[options.resolveFrom\] | `string` \| `Array.<String>` | Path(s) to resolve modules from |
 | \[options.require\] | `require` | Require instance to use |
 
 
@@ -320,11 +320,11 @@ Utility to help resolve and require modules
 Returns the resolved module filename
 
 **Kind**: instance method of [`Resolver`]  
-**Returns**: `String` - filename of the module  
+**Returns**: `string` - filename of the module  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | `String` | name of the module |
+| moduleName | `string` | name of the module |
 
 
 ### resolver.require(moduleName)
@@ -332,11 +332,11 @@ Returns the resolved module filename
 Returns the required module
 
 **Kind**: instance method of [`Resolver`]  
-**Returns**: `Object` - module contents  
+**Returns**: `object` - module contents  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | `String` | name of the module |
+| moduleName | `string` | name of the module |
 
 
 ### resolver.tryResolve(moduleName)
@@ -344,11 +344,11 @@ Returns the required module
 Returns the resolved module filename, or null if not found
 
 **Kind**: instance method of [`Resolver`]  
-**Returns**: `String` ⎮ `null` - filename of the module  
+**Returns**: `string` ⎮ `null` - filename of the module  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | `String` | name of the module |
+| moduleName | `string` | name of the module |
 
 
 ### resolver.tryRequire(moduleName)
@@ -356,11 +356,11 @@ Returns the resolved module filename, or null if not found
 Returns the required module, or null if not found
 
 **Kind**: instance method of [`Resolver`]  
-**Returns**: `Object` ⎮ `null` - module contents  
+**Returns**: `object` ⎮ `null` - module contents  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | `String` | name of the module |
+| moduleName | `string` | name of the module |
 
 
 ## pluginIdentifier()
@@ -440,13 +440,13 @@ Module with meta data
 
 | Name | Type | Description |
 | --- | --- | --- |
-| name | `String` | Name of preset |
-| module | `String` | Actual module content |
-| \[package\] | `String` | Package.json contents |
-| \[version\] | `String` | Resolved version |
-| \[path\] | `String` | Path to the root of package |
-| \[from\] | `String` | Name of module which requires this module |
-| \[range\] | `String` | Range by which this module was required |
+| name | `string` | Name of preset |
+| module | `string` | Actual module content |
+| \[package\] | `string` | Package.json contents |
+| \[version\] | `string` | Resolved version |
+| \[path\] | `string` | Path to the root of package |
+| \[from\] | `string` | Name of module which requires this module |
+| \[range\] | `string` | Range by which this module was required |
 
 
 ## PluginInfo
@@ -477,8 +477,8 @@ Create a new PackageIdentifier instance
 
 | Param | Type | Description |
 | --- | --- | --- |
-| rawName | `String` | Original input name of a package |
-| \[options\] | `Object` | Options |
+| rawName | `string` | Original input name of a package |
+| \[options\] | `object` | Options |
 | \[options.prefixed\] | `boolean` | Set this to force prefixed/postfixed format for short names |
 
 

--- a/packages/gasket-resolve/docs/api.md
+++ b/packages/gasket-resolve/docs/api.md
@@ -1,265 +1,203 @@
+
 ## Classes
 
-<dl>
-<dt><a href="#Loader">Loader</a> : <code><a href="#Loader">Loader</a></code></dt>
-<dd><p>Utility to load plugins, presets, and other modules with associated metadata</p>
-</dd>
-<dt><a href="#PackageIdentifier">PackageIdentifier</a> : <code><a href="#PackageIdentifier">PackageIdentifier</a></code></dt>
-<dd><p>Utility class for working with package names and versions</p>
-</dd>
-<dt><a href="#Resolver">Resolver</a> : <code><a href="#Resolver">Resolver</a></code></dt>
-<dd><p>Utility to help resolve and require modules</p>
-</dd>
-</dl>
+Name | Description
+------ | -----------
+[Loader] | Utility to load plugins, presets, and other modules with associated metadata
+[PackageIdentifier] | Utility class for working with package names and versions
+[Resolver] | Utility to help resolve and require modules
 
 ## Functions
 
-<dl>
-<dt><a href="#pluginIdentifier">pluginIdentifier()</a> : <code><a href="#createPackageIdentifier">createPackageIdentifier</a></code></dt>
-<dd><p>Create package identifiers for Gasket plugins</p>
-</dd>
-<dt><a href="#presetIdentifier">presetIdentifier()</a> : <code><a href="#createPackageIdentifier">createPackageIdentifier</a></code></dt>
-<dd><p>Create package identifiers for Gasket presets</p>
-</dd>
-</dl>
+Name | Description
+------ | -----------
+[pluginIdentifier()] | Create package identifiers for Gasket plugins
+[presetIdentifier()] | Create package identifiers for Gasket presets
 
 ## Typedefs
 
-<dl>
-<dt><a href="#PluginDesc">PluginDesc</a> : <code>String</code></dt>
-<dd><p>The package name with or without version of a plugin.</p>
-<p>For example:</p>
-<ul>
-<li>@gasket/plugin-https        - fullName</li>
-<li>@gasket/https               - shortName</li>
-<li>@gasket/plugin-https@^1.2.3 - full with version</li>
-<li>@gasket/https@^1.2.3        - short with version</li>
-<li>gasket-plugin-https         - user fullName</li>
-<li>https                       - user shortName</li>
-</ul>
-<p>Not intended for use with non-plugin package descriptions.
-For example, the following patterns will not work:</p>
-<ul>
-<li>@gasket/https</li>
-</ul>
-</dd>
-<dt><a href="#PresetDesc">PresetDesc</a> : <code>String</code></dt>
-<dd><p>The package name with or without version of a preset.</p>
-<p>For example:</p>
-<ul>
-<li>@gasket/preset-nextjs        - fullName</li>
-<li>@gasket/nextjs               - shortName</li>
-<li>@gasket/preset-nextjs@^1.2.3 - full with version</li>
-<li>@gasket/nextjs@^1.2.3        - short with version</li>
-<li>gasket-preset-nextjs         - user fullName</li>
-<li>nextjs                       - user shortName</li>
-</ul>
-</dd>
-<dt><a href="#PluginName">PluginName</a> : <code>String</code></dt>
-<dd><p>The package name only of a plugin.</p>
-<p>For example:</p>
-<ul>
-<li>@gasket/plugin-https        - fullName</li>
-<li>@gasket/https               - shortName</li>
-<li>gasket-plugin-https         - user fullName</li>
-<li>https                       - user shortName</li>
-</ul>
-</dd>
-<dt><a href="#PresetName">PresetName</a> : <code>String</code></dt>
-<dd><p>The package name only of a preset.</p>
-<p>For example:</p>
-<ul>
-<li>@gasket/preset-nextjs        - fullName</li>
-<li>@gasket/nextjs               - shortName</li>
-<li>gasket-preset-nextjs         - user fullName</li>
-<li>nextjs                       - user shortName</li>
-</ul>
-</dd>
-<dt><a href="#ModuleInfo">ModuleInfo</a> : <code>Object</code></dt>
-<dd><p>Module with meta data</p>
-</dd>
-<dt><a href="#PluginInfo">PluginInfo</a> : <code><a href="#ModuleInfo">ModuleInfo</a></code></dt>
-<dd><p>Plugin module with meta data</p>
-</dd>
-<dt><a href="#PresetInfo">PresetInfo</a> : <code><a href="#ModuleInfo">ModuleInfo</a></code></dt>
-<dd><p>Preset module with meta data</p>
-</dd>
-<dt><a href="#createPackageIdentifier">createPackageIdentifier</a> ⇒ <code><a href="#PackageIdentifier">PackageIdentifier</a></code></dt>
-<dd><p>Create a new PackageIdentifier instance</p>
-</dd>
-</dl>
+Name | Description
+------ | -----------
+[PluginDesc] | The package name with or without version of a plugin.
+[PresetDesc] | The package name with or without version of a preset.
+[PluginName] | The package name only of a plugin.
+[PresetName] | The package name only of a preset.
+[ModuleInfo] | Module with meta data
+[PluginInfo] | Plugin module with meta data
+[PresetInfo] | Preset module with meta data
+[createPackageIdentifier] | Create a new PackageIdentifier instance
 
-<a name="Loader"></a>
 
-## Loader : [<code>Loader</code>](#Loader)
+## Loader : [`Loader`]
+
 Utility to load plugins, presets, and other modules with associated metadata
 
 **Kind**: global class  
-**Extends**: [<code>Resolver</code>](#Resolver)  
+**Extends**: [`Resolver`]  
 
-* [Loader](#Loader) : [<code>Loader</code>](#Loader)
-    * [.getModuleInfo(module, moduleName, [meta])](#Loader+getModuleInfo) ⇒ [<code>ModuleInfo</code>](#ModuleInfo)
-    * [.loadModule(moduleName, [meta])](#Loader+loadModule) ⇒ [<code>ModuleInfo</code>](#ModuleInfo)
-    * [.loadPlugin(module, [meta])](#Loader+loadPlugin) ⇒ [<code>PluginInfo</code>](#PluginInfo)
-    * [.loadPreset(module, [meta], [options])](#Loader+loadPreset) ⇒ [<code>PresetInfo</code>](#PresetInfo)
-    * [.loadConfigured(config)](#Loader+loadConfigured) ⇒ <code>Object</code>
-    * [.resolve(moduleName)](#Resolver+resolve) ⇒ <code>String</code>
-    * [.require(moduleName)](#Resolver+require) ⇒ <code>Object</code>
-    * [.tryResolve(moduleName)](#Resolver+tryResolve) ⇒ <code>String</code> \| <code>null</code>
-    * [.tryRequire(moduleName)](#Resolver+tryRequire) ⇒ <code>Object</code> \| <code>null</code>
+* [Loader]
+    * [.getModuleInfo(module, moduleName, [meta])][1]
+    * [.loadModule(moduleName, [meta])][2]
+    * [.loadPlugin(module, [meta])][3]
+    * [.loadPreset(module, [meta], [options])][4]
+    * [.loadConfigured(config)]
+    * [.resolve(moduleName)]
+    * [.require(moduleName)]
+    * [.tryResolve(moduleName)]
+    * [.tryRequire(moduleName)]
 
-<a name="Loader+getModuleInfo"></a>
 
-### loader.getModuleInfo(module, moduleName, [meta]) ⇒ [<code>ModuleInfo</code>](#ModuleInfo)
+### loader.getModuleInfo(module, moduleName, [meta]) ⇒ `ModuleInfo`
+
 Loads a module with additional metadata
 
-**Kind**: instance method of [<code>Loader</code>](#Loader)  
-**Returns**: [<code>ModuleInfo</code>](#ModuleInfo) - module  
+**Kind**: instance method of [`Loader`]  
+**Returns**: [`ModuleInfo`] - module  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| module | <code>String</code> | Module content |
-| moduleName | <code>String</code> | Name of module to load |
-| [meta] | <code>Object</code> | Additional meta data |
+| module | `String` | Module content |
+| moduleName | `String` | Name of module to load |
+| \[meta\] | `Object` | Additional meta data |
 
-<a name="Loader+loadModule"></a>
 
-### loader.loadModule(moduleName, [meta]) ⇒ [<code>ModuleInfo</code>](#ModuleInfo)
+### loader.loadModule(moduleName, [meta]) ⇒ `ModuleInfo`
+
 Loads a module with additional metadata
 
-**Kind**: instance method of [<code>Loader</code>](#Loader)  
-**Returns**: [<code>ModuleInfo</code>](#ModuleInfo) - module  
+**Kind**: instance method of [`Loader`]  
+**Returns**: [`ModuleInfo`] - module  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | <code>String</code> | Name of module to load |
-| [meta] | <code>Object</code> | Additional meta data |
+| moduleName | `String` | Name of module to load |
+| \[meta\] | `Object` | Additional meta data |
 
-<a name="Loader+loadPlugin"></a>
 
-### loader.loadPlugin(module, [meta]) ⇒ [<code>PluginInfo</code>](#PluginInfo)
+### loader.loadPlugin(module, [meta]) ⇒ `PluginInfo`
+
 Loads a plugin with additional metadata.
 
-**Kind**: instance method of [<code>Loader</code>](#Loader)  
-**Returns**: [<code>PluginInfo</code>](#PluginInfo) - module  
+**Kind**: instance method of [`Loader`]  
+**Returns**: [`PluginInfo`] - module  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| module | [<code>PluginName</code>](#PluginName) \| <code>Object</code> | Name of module to load (or module content) |
-| [meta] | <code>Object</code> | Additional meta data |
+| module | [`PluginName`] \| `Object` | Name of module to load (or module content) |
+| \[meta\] | `Object` | Additional meta data |
 
-<a name="Loader+loadPreset"></a>
 
-### loader.loadPreset(module, [meta], [options]) ⇒ [<code>PresetInfo</code>](#PresetInfo)
+### loader.loadPreset(module, [meta], [options]) ⇒ `PresetInfo`
+
 Loads a preset with additional metadata
 
-**Kind**: instance method of [<code>Loader</code>](#Loader)  
-**Returns**: [<code>PresetInfo</code>](#PresetInfo) - module  
+**Kind**: instance method of [`Loader`]  
+**Returns**: [`PresetInfo`] - module  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| module | [<code>PresetName</code>](#PresetName) | Name of module to load |
-| [meta] | <code>Object</code> | Additional meta data |
-| [options] | <code>Boolean</code> | Loading options |
-| [options.shallow] | <code>Boolean</code> | Do not recursively load dependencies |
+| module | [`PresetName`] | Name of module to load |
+| \[meta\] | `Object` | Additional meta data |
+| \[options\] | `Boolean` | Loading options |
+| \[options.shallow\] | `Boolean` | Do not recursively load dependencies |
 
-<a name="Loader+loadConfigured"></a>
 
-### loader.loadConfigured(config) ⇒ <code>Object</code>
+### loader.loadConfigured(config) ⇒ `Object`
+
 Loads presets and plugins as configured.
 Plugins will be filtered and ordered as configuration with priority of:
  - added plugins > preset plugins > nested preset plugins
 
-**Kind**: instance method of [<code>Loader</code>](#Loader)  
-**Returns**: <code>Object</code> - results  
+**Kind**: instance method of [`Loader`]  
+**Returns**: `Object` - results  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| config | <code>Object</code> | Presets and plugins to load |
-| config.presets | [<code>Array.&lt;PresetName&gt;</code>](#PresetName) | Presets to load and add plugins from |
-| config.add | [<code>Array.&lt;PluginName&gt;</code>](#PluginName) \| <code>Array.&lt;module&gt;</code> | Names of plugins to load |
-| config.remove | <code>Array.&lt;string&gt;</code> | Names of plugins to remove (from presets) |
+| config | `Object` | Presets and plugins to load |
+| config.presets | `Array.<PresetName>` | Presets to load and add plugins from |
+| config.add | `Array.<PluginName>` \| `Array.<module>` | Names of plugins to load |
+| config.remove | `Array.<string>` | Names of plugins to remove (from presets) |
 
-<a name="Resolver+resolve"></a>
 
-### loader.resolve(moduleName) ⇒ <code>String</code>
+### loader.resolve(moduleName) ⇒ `String`
+
 Returns the resolved module filename
 
-**Kind**: instance method of [<code>Loader</code>](#Loader)  
-**Overrides**: [<code>resolve</code>](#Resolver+resolve)  
-**Returns**: <code>String</code> - filename of the module  
+**Kind**: instance method of [`Loader`]  
+**Overrides**: `resolve`  
+**Returns**: `String` - filename of the module  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | <code>String</code> | name of the module |
+| moduleName | `String` | name of the module |
 
-<a name="Resolver+require"></a>
 
-### loader.require(moduleName) ⇒ <code>Object</code>
+### loader.require(moduleName) ⇒ `Object`
+
 Returns the required module
 
-**Kind**: instance method of [<code>Loader</code>](#Loader)  
-**Overrides**: [<code>require</code>](#Resolver+require)  
-**Returns**: <code>Object</code> - module contents  
+**Kind**: instance method of [`Loader`]  
+**Overrides**: `require`  
+**Returns**: `Object` - module contents  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | <code>String</code> | name of the module |
+| moduleName | `String` | name of the module |
 
-<a name="Resolver+tryResolve"></a>
 
-### loader.tryResolve(moduleName) ⇒ <code>String</code> \| <code>null</code>
+### loader.tryResolve(moduleName) ⇒ `String` ⎮ `null`
+
 Returns the resolved module filename, or null if not found
 
-**Kind**: instance method of [<code>Loader</code>](#Loader)  
-**Overrides**: [<code>tryResolve</code>](#Resolver+tryResolve)  
-**Returns**: <code>String</code> \| <code>null</code> - filename of the module  
+**Kind**: instance method of [`Loader`]  
+**Overrides**: `tryResolve`  
+**Returns**: `String` ⎮ `null` - filename of the module  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | <code>String</code> | name of the module |
+| moduleName | `String` | name of the module |
 
-<a name="Resolver+tryRequire"></a>
 
-### loader.tryRequire(moduleName) ⇒ <code>Object</code> \| <code>null</code>
+### loader.tryRequire(moduleName) ⇒ `Object` ⎮ `null`
+
 Returns the required module, or null if not found
 
-**Kind**: instance method of [<code>Loader</code>](#Loader)  
-**Overrides**: [<code>tryRequire</code>](#Resolver+tryRequire)  
-**Returns**: <code>Object</code> \| <code>null</code> - module contents  
+**Kind**: instance method of [`Loader`]  
+**Overrides**: `tryRequire`  
+**Returns**: `Object` ⎮ `null` - module contents  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | <code>String</code> | name of the module |
+| moduleName | `String` | name of the module |
 
-<a name="PackageIdentifier"></a>
 
-## PackageIdentifier : [<code>PackageIdentifier</code>](#PackageIdentifier)
+## PackageIdentifier : [`PackageIdentifier`]
+
 Utility class for working with package names and versions
 
 **Kind**: global class  
 
-* [PackageIdentifier](#PackageIdentifier) : [<code>PackageIdentifier</code>](#PackageIdentifier)
-    * [.rawName](#PackageIdentifier+rawName) ⇒ <code>string</code>
-    * [.fullName](#PackageIdentifier+fullName) ⇒ <code>string</code>
-    * [.longName](#PackageIdentifier+longName) ⇒ <code>string</code>
-    * [.shortName](#PackageIdentifier+shortName) ⇒ <code>string</code>
-    * [.name](#PackageIdentifier+name) ⇒ <code>string</code>
-    * [.version](#PackageIdentifier+version) ⇒ <code>string</code>
-    * [.full](#PackageIdentifier+full) ⇒ <code>string</code>
-    * [.withVersion([defaultVersion])](#PackageIdentifier+withVersion) ⇒ [<code>PackageIdentifier</code>](#PackageIdentifier)
-    * [.nextFormat()](#PackageIdentifier+nextFormat) ⇒ [<code>PackageIdentifier</code>](#PackageIdentifier) \| <code>null</code>
+* [PackageIdentifier]
+    * [.rawName]
+    * [.fullName]
+    * [.longName]
+    * [.shortName]
+    * [.name]
+    * [.version]
+    * [.full]
+    * [.withVersion([defaultVersion])][5]
+    * [.nextFormat()]
 
-<a name="PackageIdentifier+rawName"></a>
 
-### packageIdentifier.rawName ⇒ <code>string</code>
+### packageIdentifier.rawName ⇒ `string`
+
 Get the package name as provided to the identifier
 
-**Kind**: instance property of [<code>PackageIdentifier</code>](#PackageIdentifier)  
-**Returns**: <code>string</code> - rawName  
-<a name="PackageIdentifier+fullName"></a>
+**Kind**: instance property of [`PackageIdentifier`]  
+**Returns**: `string` - rawName  
 
-### packageIdentifier.fullName ⇒ <code>string</code>
+### packageIdentifier.fullName ⇒ `string`
+
 Get the long package name
 
 Examples:
@@ -268,18 +206,18 @@ Examples:
 - @user/https -> @user/gasket-plugin-https
 - https -> gasket-plugin-https
 
-**Kind**: instance property of [<code>PackageIdentifier</code>](#PackageIdentifier)  
-**Returns**: <code>string</code> - fullName  
-<a name="PackageIdentifier+longName"></a>
+**Kind**: instance property of [`PackageIdentifier`]  
+**Returns**: `string` - fullName  
 
-### packageIdentifier.longName ⇒ <code>string</code>
+### packageIdentifier.longName ⇒ `string`
+
 Alias to this.fullName
 
-**Kind**: instance property of [<code>PackageIdentifier</code>](#PackageIdentifier)  
-**Returns**: <code>string</code> - fullName  
-<a name="PackageIdentifier+shortName"></a>
+**Kind**: instance property of [`PackageIdentifier`]  
+**Returns**: `string` - fullName  
 
-### packageIdentifier.shortName ⇒ <code>string</code>
+### packageIdentifier.shortName ⇒ `string`
+
 Get the short package name
 
 Examples:
@@ -287,60 +225,60 @@ Examples:
 - @user/gasket-plugin-https -> @user/https
 - gasket-plugin-https@1.2.3 -> https
 
-**Kind**: instance property of [<code>PackageIdentifier</code>](#PackageIdentifier)  
-**Returns**: <code>string</code> - fullName  
-<a name="PackageIdentifier+name"></a>
+**Kind**: instance property of [`PackageIdentifier`]  
+**Returns**: `string` - fullName  
 
-### packageIdentifier.name ⇒ <code>string</code>
+### packageIdentifier.name ⇒ `string`
+
 Get only the package name
 
 Examples:
 - @gasket/plugin-https@1.2.3 -> @gasket/plugin-https
 - https@1.2.3 -> https
 
-**Kind**: instance property of [<code>PackageIdentifier</code>](#PackageIdentifier)  
-**Returns**: <code>string</code> - fullName  
-<a name="PackageIdentifier+version"></a>
+**Kind**: instance property of [`PackageIdentifier`]  
+**Returns**: `string` - fullName  
 
-### packageIdentifier.version ⇒ <code>string</code>
+### packageIdentifier.version ⇒ `string`
+
 Get only the package version
 
 Examples:
 - @gasket/plugin-https@1.2.3 -> 1.2.3
 - @gasket/plugin-https -> ''
 
-**Kind**: instance property of [<code>PackageIdentifier</code>](#PackageIdentifier)  
-**Returns**: <code>string</code> - fullName  
-<a name="PackageIdentifier+full"></a>
+**Kind**: instance property of [`PackageIdentifier`]  
+**Returns**: `string` - fullName  
 
-### packageIdentifier.full ⇒ <code>string</code>
+### packageIdentifier.full ⇒ `string`
+
 Get the full package name with version
 
 Examples:
 - @gasket/plugin-https@1.2.3 -> @gasket/plugin-https@1.2.3
 - https@1.2.3 -> @gasket/plugin-https@1.2.3
 
-**Kind**: instance property of [<code>PackageIdentifier</code>](#PackageIdentifier)  
-**Returns**: <code>string</code> - fullName  
-<a name="PackageIdentifier+withVersion"></a>
+**Kind**: instance property of [`PackageIdentifier`]  
+**Returns**: `string` - fullName  
 
-### packageIdentifier.withVersion([defaultVersion]) ⇒ [<code>PackageIdentifier</code>](#PackageIdentifier)
+### packageIdentifier.withVersion([defaultVersion]) ⇒ `PackageIdentifier`
+
 Returns new PackageIdentifier with version added to desc if missing
 
 Examples:
 - @gasket/plugin-https@1.2.3 -> @gasket/plugin-https@1.2.3
 - @gasket/plugin-https -> @gasket/plugin-https@latest
 
-**Kind**: instance method of [<code>PackageIdentifier</code>](#PackageIdentifier)  
-**Returns**: [<code>PackageIdentifier</code>](#PackageIdentifier) - identifier  
+**Kind**: instance method of [`PackageIdentifier`]  
+**Returns**: [`PackageIdentifier`] - identifier  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| [defaultVersion] | <code>string</code> | <code>&quot;latest&quot;</code> | the version name to add if missing |
+| \[defaultVersion\] | `string` | `'latest'` | the version name to add if missing |
 
-<a name="PackageIdentifier+nextFormat"></a>
 
-### packageIdentifier.nextFormat() ⇒ [<code>PackageIdentifier</code>](#PackageIdentifier) \| <code>null</code>
+### packageIdentifier.nextFormat() ⇒ `PackageIdentifier` ⎮ `null`
+
 If the rawName is a short name, get a new identifier, cycling through
 formats which can be used to attempt to resolve packages by different
 name pattern.
@@ -350,95 +288,95 @@ Examples:
 - @gasket/example -> @gasket/plugin-example > @gasket/example-plugin
 - @user/example -> @user/gasket-plugin-example > @user/example-gasket-plugin
 
-**Kind**: instance method of [<code>PackageIdentifier</code>](#PackageIdentifier)  
-**Returns**: [<code>PackageIdentifier</code>](#PackageIdentifier) \| <code>null</code> - identifier  
-<a name="Resolver"></a>
+**Kind**: instance method of [`PackageIdentifier`]  
+**Returns**: [`PackageIdentifier`] ⎮ `null` - identifier  
 
-## Resolver : [<code>Resolver</code>](#Resolver)
+## Resolver : [`Resolver`]
+
 Utility to help resolve and require modules
 
 **Kind**: global class  
 
-* [Resolver](#Resolver) : [<code>Resolver</code>](#Resolver)
-    * [new Resolver(options)](#new_Resolver_new)
-    * [.resolve(moduleName)](#Resolver+resolve) ⇒ <code>String</code>
-    * [.require(moduleName)](#Resolver+require) ⇒ <code>Object</code>
-    * [.tryResolve(moduleName)](#Resolver+tryResolve) ⇒ <code>String</code> \| <code>null</code>
-    * [.tryRequire(moduleName)](#Resolver+tryRequire) ⇒ <code>Object</code> \| <code>null</code>
+* [Resolver]
+    * [new Resolver(options)]
+    * [.resolve(moduleName)]
+    * [.require(moduleName)]
+    * [.tryResolve(moduleName)]
+    * [.tryRequire(moduleName)]
 
-<a name="new_Resolver_new"></a>
 
 ### new Resolver(options)
 
+
 | Param | Type | Description |
 | --- | --- | --- |
-| options | <code>Object</code> | Options |
-| [options.resolveFrom] | <code>String</code> \| <code>Array.&lt;String&gt;</code> | Path(s) to resolve modules from |
-| [options.require] | <code>require</code> | Require instance to use |
+| options | `Object` | Options |
+| \[options.resolveFrom\] | `String` \| `Array.<String>` | Path(s) to resolve modules from |
+| \[options.require\] | `require` | Require instance to use |
 
-<a name="Resolver+resolve"></a>
 
-### resolver.resolve(moduleName) ⇒ <code>String</code>
+### resolver.resolve(moduleName) ⇒ `String`
+
 Returns the resolved module filename
 
-**Kind**: instance method of [<code>Resolver</code>](#Resolver)  
-**Returns**: <code>String</code> - filename of the module  
+**Kind**: instance method of [`Resolver`]  
+**Returns**: `String` - filename of the module  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | <code>String</code> | name of the module |
+| moduleName | `String` | name of the module |
 
-<a name="Resolver+require"></a>
 
-### resolver.require(moduleName) ⇒ <code>Object</code>
+### resolver.require(moduleName) ⇒ `Object`
+
 Returns the required module
 
-**Kind**: instance method of [<code>Resolver</code>](#Resolver)  
-**Returns**: <code>Object</code> - module contents  
+**Kind**: instance method of [`Resolver`]  
+**Returns**: `Object` - module contents  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | <code>String</code> | name of the module |
+| moduleName | `String` | name of the module |
 
-<a name="Resolver+tryResolve"></a>
 
-### resolver.tryResolve(moduleName) ⇒ <code>String</code> \| <code>null</code>
+### resolver.tryResolve(moduleName) ⇒ `String` ⎮ `null`
+
 Returns the resolved module filename, or null if not found
 
-**Kind**: instance method of [<code>Resolver</code>](#Resolver)  
-**Returns**: <code>String</code> \| <code>null</code> - filename of the module  
+**Kind**: instance method of [`Resolver`]  
+**Returns**: `String` ⎮ `null` - filename of the module  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | <code>String</code> | name of the module |
+| moduleName | `String` | name of the module |
 
-<a name="Resolver+tryRequire"></a>
 
-### resolver.tryRequire(moduleName) ⇒ <code>Object</code> \| <code>null</code>
+### resolver.tryRequire(moduleName) ⇒ `Object` ⎮ `null`
+
 Returns the required module, or null if not found
 
-**Kind**: instance method of [<code>Resolver</code>](#Resolver)  
-**Returns**: <code>Object</code> \| <code>null</code> - module contents  
+**Kind**: instance method of [`Resolver`]  
+**Returns**: `Object` ⎮ `null` - module contents  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| moduleName | <code>String</code> | name of the module |
+| moduleName | `String` | name of the module |
 
-<a name="pluginIdentifier"></a>
 
-## pluginIdentifier() : [<code>createPackageIdentifier</code>](#createPackageIdentifier)
+## pluginIdentifier() : [`createPackageIdentifier`]
+
 Create package identifiers for Gasket plugins
 
 **Kind**: global function  
-<a name="presetIdentifier"></a>
 
-## presetIdentifier() : [<code>createPackageIdentifier</code>](#createPackageIdentifier)
+## presetIdentifier() : [`createPackageIdentifier`]
+
 Create package identifiers for Gasket presets
 
 **Kind**: global function  
-<a name="PluginDesc"></a>
 
-## PluginDesc : <code>String</code>
+## PluginDesc : `String`
+
 The package name with or without version of a plugin.
 
 For example:
@@ -454,9 +392,9 @@ For example, the following patterns will not work:
   - @gasket/https
 
 **Kind**: global typedef  
-<a name="PresetDesc"></a>
 
-## PresetDesc : <code>String</code>
+## PresetDesc : `String`
+
 The package name with or without version of a preset.
 
 For example:
@@ -468,9 +406,9 @@ For example:
   - nextjs                       - user shortName
 
 **Kind**: global typedef  
-<a name="PluginName"></a>
 
-## PluginName : <code>String</code>
+## PluginName : `String`
+
 The package name only of a plugin.
 
 For example:
@@ -480,9 +418,9 @@ For example:
   - https                       - user shortName
 
 **Kind**: global typedef  
-<a name="PresetName"></a>
 
-## PresetName : <code>String</code>
+## PresetName : `String`
+
 The package name only of a preset.
 
 For example:
@@ -492,9 +430,9 @@ For example:
   - nextjs                       - user shortName
 
 **Kind**: global typedef  
-<a name="ModuleInfo"></a>
 
-## ModuleInfo : <code>Object</code>
+## ModuleInfo : `Object`
+
 Module with meta data
 
 **Kind**: global typedef  
@@ -502,23 +440,23 @@ Module with meta data
 
 | Name | Type | Description |
 | --- | --- | --- |
-| name | <code>String</code> | Name of preset |
-| module | <code>String</code> | Actual module content |
-| [package] | <code>String</code> | Package.json contents |
-| [version] | <code>String</code> | Resolved version |
-| [path] | <code>String</code> | Path to the root of package |
-| [from] | <code>String</code> | Name of module which requires this module |
-| [range] | <code>String</code> | Range by which this module was required |
+| name | `String` | Name of preset |
+| module | `String` | Actual module content |
+| \[package\] | `String` | Package.json contents |
+| \[version\] | `String` | Resolved version |
+| \[path\] | `String` | Path to the root of package |
+| \[from\] | `String` | Name of module which requires this module |
+| \[range\] | `String` | Range by which this module was required |
 
-<a name="PluginInfo"></a>
 
-## PluginInfo : [<code>ModuleInfo</code>](#ModuleInfo)
+## PluginInfo : [`ModuleInfo`]
+
 Plugin module with meta data
 
 **Kind**: global typedef  
-<a name="PresetInfo"></a>
 
-## PresetInfo : [<code>ModuleInfo</code>](#ModuleInfo)
+## PresetInfo : [`ModuleInfo`]
+
 Preset module with meta data
 
 **Kind**: global typedef  
@@ -526,31 +464,31 @@ Preset module with meta data
 
 | Name | Type | Description |
 | --- | --- | --- |
-| presets | [<code>Array.&lt;PresetInfo&gt;</code>](#PresetInfo) | Presets that this preset extends |
-| plugins | [<code>Array.&lt;PluginInfo&gt;</code>](#PluginInfo) | Plugins this preset uses |
+| presets | `Array.<PresetInfo>` | Presets that this preset extends |
+| plugins | `Array.<PluginInfo>` | Plugins this preset uses |
 
-<a name="createPackageIdentifier"></a>
 
-## createPackageIdentifier ⇒ [<code>PackageIdentifier</code>](#PackageIdentifier)
+## createPackageIdentifier ⇒ [`PackageIdentifier`]
+
 Create a new PackageIdentifier instance
 
 **Kind**: global typedef  
-**Returns**: [<code>PackageIdentifier</code>](#PackageIdentifier) - instance  
+**Returns**: [`PackageIdentifier`] - instance  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| rawName | <code>String</code> | Original input name of a package |
-| [options] | <code>Object</code> | Options |
-| [options.prefixed] | <code>boolean</code> | Set this to force prefixed/postfixed format for short names |
+| rawName | `String` | Original input name of a package |
+| \[options\] | `Object` | Options |
+| \[options.prefixed\] | `boolean` | Set this to force prefixed/postfixed format for short names |
 
 
-* [createPackageIdentifier](#createPackageIdentifier) ⇒ [<code>PackageIdentifier</code>](#PackageIdentifier)
-    * [.isValidFullName(maybeFullName)](#createPackageIdentifier.isValidFullName) ⇒ <code>boolean</code>
-    * [.lookup(name, handler)](#createPackageIdentifier.lookup) ⇒ [<code>PackageIdentifier</code>](#PackageIdentifier) \| <code>null</code>
+* [createPackageIdentifier]
+    * [.isValidFullName(maybeFullName)]
+    * [.lookup(name, handler)]
 
-<a name="createPackageIdentifier.isValidFullName"></a>
 
-### createPackageIdentifier.isValidFullName(maybeFullName) ⇒ <code>boolean</code>
+### createPackageIdentifier.isValidFullName(maybeFullName) ⇒ `boolean`
+
 Static util method to check if a full name is valid
 
 Examples:
@@ -558,27 +496,72 @@ Examples:
 - @gasket/plugin-https@1.2.3 -> false
 - https -> false
 
-**Kind**: static method of [<code>createPackageIdentifier</code>](#createPackageIdentifier)  
-**Returns**: <code>boolean</code> - fullName  
+**Kind**: static method of [`createPackageIdentifier`]  
+**Returns**: `boolean` - fullName  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| maybeFullName | <code>string</code> | Name to check |
+| maybeFullName | `string` | Name to check |
 
-<a name="createPackageIdentifier.lookup"></a>
 
-### createPackageIdentifier.lookup(name, handler) ⇒ [<code>PackageIdentifier</code>](#PackageIdentifier) \| <code>null</code>
+### createPackageIdentifier.lookup(name, handler) ⇒ `PackageIdentifier` ⎮ `null`
+
 Static util method to loop through format options for short names.
 The handler will be provide the next formatted identifier to try,
 which should return falsy to continue,
 or return truthy to end and return the current identifier.
 If the lookup runs out of formats to try, it will return null.
 
-**Kind**: static method of [<code>createPackageIdentifier</code>](#createPackageIdentifier)  
-**Returns**: [<code>PackageIdentifier</code>](#PackageIdentifier) \| <code>null</code> - identifier if found or null  
+**Kind**: static method of [`createPackageIdentifier`]  
+**Returns**: [`PackageIdentifier`] ⎮ `null` - identifier if found or null  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| name | <code>string</code> | Name to check |
-| handler | <code>function</code> | Attempt to find package current format |
+| name | `string` | Name to check |
+| handler | `function` | Attempt to find package current format |
 
+<!-- LINKS -->
+
+[Loader]:#loader--loader
+[PackageIdentifier]:#packageidentifier--packageidentifier
+[Resolver]:#resolver--resolver
+[pluginIdentifier()]:#pluginidentifier--createpackageidentifier
+[presetIdentifier()]:#presetidentifier--createpackageidentifier
+[PluginDesc]:#plugindesc--string
+[PresetDesc]:#presetdesc--string
+[PluginName]:#pluginname--string
+[PresetName]:#presetname--string
+[ModuleInfo]:#moduleinfo--object
+[PluginInfo]:#plugininfo--moduleinfo
+[PresetInfo]:#presetinfo--moduleinfo
+[createPackageIdentifier]:#createpackageidentifier--packageidentifier
+[`Loader`]:#loader--loader
+[`Resolver`]:#new-resolveroptions
+[1]:#loadergetmoduleinfomodule-modulename-meta--moduleinfo
+[2]:#loaderloadmodulemodulename-meta--moduleinfo
+[3]:#loaderloadpluginmodule-meta--plugininfo
+[4]:#loaderloadpresetmodule-meta-options--presetinfo
+[.loadConfigured(config)]:#loaderloadconfiguredconfig--object
+[.resolve(moduleName)]:#resolverresolvemodulename--string
+[.require(moduleName)]:#resolverrequiremodulename--object
+[.tryResolve(moduleName)]:#resolvertryresolvemodulename--string--null
+[.tryRequire(moduleName)]:#resolvertryrequiremodulename--object--null
+[`ModuleInfo`]:#moduleinfo--object
+[`PluginInfo`]:#plugininfo--moduleinfo
+[`PluginName`]:#pluginname--string
+[`PresetInfo`]:#presetinfo--moduleinfo
+[`PresetName`]:#presetname--string
+[`PackageIdentifier`]:#packageidentifier--packageidentifier
+[.rawName]:#packageidentifierrawname--string
+[.fullName]:#packageidentifierfullname--string
+[.longName]:#packageidentifierlongname--string
+[.shortName]:#packageidentifiershortname--string
+[.name]:#packageidentifiername--string
+[.version]:#packageidentifierversion--string
+[.full]:#packageidentifierfull--string
+[5]:#packageidentifierwithversiondefaultversion--packageidentifier
+[.nextFormat()]:#packageidentifiernextformat--packageidentifier--null
+[new Resolver(options)]:#new-resolveroptions
+[`createPackageIdentifier`]:#createpackageidentifier--packageidentifier
+[.isValidFullName(maybeFullName)]:#createpackageidentifierisvalidfullnamemaybefullname--boolean
+[.lookup(name, handler)]:#createpackageidentifierlookupname-handler--packageidentifier--null

--- a/packages/gasket-resolve/docs/api.md
+++ b/packages/gasket-resolve/docs/api.md
@@ -28,7 +28,7 @@ Name | Description
 [createPackageIdentifier] | Create a new PackageIdentifier instance
 
 
-## Loader : [`Loader`]
+## Loader
 
 Utility to load plugins, presets, and other modules with associated metadata
 
@@ -36,10 +36,10 @@ Utility to load plugins, presets, and other modules with associated metadata
 **Extends**: [`Resolver`]  
 
 * [Loader]
-    * [.getModuleInfo(module, moduleName, [meta])][1]
-    * [.loadModule(moduleName, [meta])][2]
-    * [.loadPlugin(module, [meta])][3]
-    * [.loadPreset(module, [meta], [options])][4]
+    * [.getModuleInfo(module, moduleName, \[meta\])][1]
+    * [.loadModule(moduleName, \[meta\])][2]
+    * [.loadPlugin(module, \[meta\])][3]
+    * [.loadPreset(module, \[meta\], \[options\])][4]
     * [.loadConfigured(config)]
     * [.resolve(moduleName)]
     * [.require(moduleName)]
@@ -47,7 +47,7 @@ Utility to load plugins, presets, and other modules with associated metadata
     * [.tryRequire(moduleName)]
 
 
-### loader.getModuleInfo(module, moduleName, [meta]) ⇒ `ModuleInfo`
+### loader.getModuleInfo(module, moduleName, \[meta\])
 
 Loads a module with additional metadata
 
@@ -61,7 +61,7 @@ Loads a module with additional metadata
 | \[meta\] | `Object` | Additional meta data |
 
 
-### loader.loadModule(moduleName, [meta]) ⇒ `ModuleInfo`
+### loader.loadModule(moduleName, \[meta\])
 
 Loads a module with additional metadata
 
@@ -74,7 +74,7 @@ Loads a module with additional metadata
 | \[meta\] | `Object` | Additional meta data |
 
 
-### loader.loadPlugin(module, [meta]) ⇒ `PluginInfo`
+### loader.loadPlugin(module, \[meta\])
 
 Loads a plugin with additional metadata.
 
@@ -87,7 +87,7 @@ Loads a plugin with additional metadata.
 | \[meta\] | `Object` | Additional meta data |
 
 
-### loader.loadPreset(module, [meta], [options]) ⇒ `PresetInfo`
+### loader.loadPreset(module, \[meta\], \[options\])
 
 Loads a preset with additional metadata
 
@@ -102,7 +102,7 @@ Loads a preset with additional metadata
 | \[options.shallow\] | `Boolean` | Do not recursively load dependencies |
 
 
-### loader.loadConfigured(config) ⇒ `Object`
+### loader.loadConfigured(config)
 
 Loads presets and plugins as configured.
 Plugins will be filtered and ordered as configuration with priority of:
@@ -119,7 +119,7 @@ Plugins will be filtered and ordered as configuration with priority of:
 | config.remove | `Array.<string>` | Names of plugins to remove (from presets) |
 
 
-### loader.resolve(moduleName) ⇒ `String`
+### loader.resolve(moduleName)
 
 Returns the resolved module filename
 
@@ -132,7 +132,7 @@ Returns the resolved module filename
 | moduleName | `String` | name of the module |
 
 
-### loader.require(moduleName) ⇒ `Object`
+### loader.require(moduleName)
 
 Returns the required module
 
@@ -145,7 +145,7 @@ Returns the required module
 | moduleName | `String` | name of the module |
 
 
-### loader.tryResolve(moduleName) ⇒ `String` ⎮ `null`
+### loader.tryResolve(moduleName)
 
 Returns the resolved module filename, or null if not found
 
@@ -158,7 +158,7 @@ Returns the resolved module filename, or null if not found
 | moduleName | `String` | name of the module |
 
 
-### loader.tryRequire(moduleName) ⇒ `Object` ⎮ `null`
+### loader.tryRequire(moduleName)
 
 Returns the required module, or null if not found
 
@@ -171,7 +171,7 @@ Returns the required module, or null if not found
 | moduleName | `String` | name of the module |
 
 
-## PackageIdentifier : [`PackageIdentifier`]
+## PackageIdentifier
 
 Utility class for working with package names and versions
 
@@ -185,18 +185,18 @@ Utility class for working with package names and versions
     * [.name]
     * [.version]
     * [.full]
-    * [.withVersion([defaultVersion])][5]
+    * [.withVersion(\[defaultVersion\])][5]
     * [.nextFormat()]
 
 
-### packageIdentifier.rawName ⇒ `string`
+### packageIdentifier.rawName
 
 Get the package name as provided to the identifier
 
 **Kind**: instance property of [`PackageIdentifier`]  
 **Returns**: `string` - rawName  
 
-### packageIdentifier.fullName ⇒ `string`
+### packageIdentifier.fullName
 
 Get the long package name
 
@@ -209,14 +209,14 @@ Examples:
 **Kind**: instance property of [`PackageIdentifier`]  
 **Returns**: `string` - fullName  
 
-### packageIdentifier.longName ⇒ `string`
+### packageIdentifier.longName
 
 Alias to this.fullName
 
 **Kind**: instance property of [`PackageIdentifier`]  
 **Returns**: `string` - fullName  
 
-### packageIdentifier.shortName ⇒ `string`
+### packageIdentifier.shortName
 
 Get the short package name
 
@@ -228,7 +228,7 @@ Examples:
 **Kind**: instance property of [`PackageIdentifier`]  
 **Returns**: `string` - fullName  
 
-### packageIdentifier.name ⇒ `string`
+### packageIdentifier.name
 
 Get only the package name
 
@@ -239,7 +239,7 @@ Examples:
 **Kind**: instance property of [`PackageIdentifier`]  
 **Returns**: `string` - fullName  
 
-### packageIdentifier.version ⇒ `string`
+### packageIdentifier.version
 
 Get only the package version
 
@@ -250,7 +250,7 @@ Examples:
 **Kind**: instance property of [`PackageIdentifier`]  
 **Returns**: `string` - fullName  
 
-### packageIdentifier.full ⇒ `string`
+### packageIdentifier.full
 
 Get the full package name with version
 
@@ -261,7 +261,7 @@ Examples:
 **Kind**: instance property of [`PackageIdentifier`]  
 **Returns**: `string` - fullName  
 
-### packageIdentifier.withVersion([defaultVersion]) ⇒ `PackageIdentifier`
+### packageIdentifier.withVersion(\[defaultVersion\])
 
 Returns new PackageIdentifier with version added to desc if missing
 
@@ -277,7 +277,7 @@ Examples:
 | \[defaultVersion\] | `string` | `'latest'` | the version name to add if missing |
 
 
-### packageIdentifier.nextFormat() ⇒ `PackageIdentifier` ⎮ `null`
+### packageIdentifier.nextFormat()
 
 If the rawName is a short name, get a new identifier, cycling through
 formats which can be used to attempt to resolve packages by different
@@ -291,7 +291,7 @@ Examples:
 **Kind**: instance method of [`PackageIdentifier`]  
 **Returns**: [`PackageIdentifier`] ⎮ `null` - identifier  
 
-## Resolver : [`Resolver`]
+## Resolver
 
 Utility to help resolve and require modules
 
@@ -315,7 +315,7 @@ Utility to help resolve and require modules
 | \[options.require\] | `require` | Require instance to use |
 
 
-### resolver.resolve(moduleName) ⇒ `String`
+### resolver.resolve(moduleName)
 
 Returns the resolved module filename
 
@@ -327,7 +327,7 @@ Returns the resolved module filename
 | moduleName | `String` | name of the module |
 
 
-### resolver.require(moduleName) ⇒ `Object`
+### resolver.require(moduleName)
 
 Returns the required module
 
@@ -339,7 +339,7 @@ Returns the required module
 | moduleName | `String` | name of the module |
 
 
-### resolver.tryResolve(moduleName) ⇒ `String` ⎮ `null`
+### resolver.tryResolve(moduleName)
 
 Returns the resolved module filename, or null if not found
 
@@ -351,7 +351,7 @@ Returns the resolved module filename, or null if not found
 | moduleName | `String` | name of the module |
 
 
-### resolver.tryRequire(moduleName) ⇒ `Object` ⎮ `null`
+### resolver.tryRequire(moduleName)
 
 Returns the required module, or null if not found
 
@@ -363,19 +363,19 @@ Returns the required module, or null if not found
 | moduleName | `String` | name of the module |
 
 
-## pluginIdentifier() : [`createPackageIdentifier`]
+## pluginIdentifier()
 
 Create package identifiers for Gasket plugins
 
 **Kind**: global function  
 
-## presetIdentifier() : [`createPackageIdentifier`]
+## presetIdentifier()
 
 Create package identifiers for Gasket presets
 
 **Kind**: global function  
 
-## PluginDesc : `String`
+## PluginDesc
 
 The package name with or without version of a plugin.
 
@@ -393,7 +393,7 @@ For example, the following patterns will not work:
 
 **Kind**: global typedef  
 
-## PresetDesc : `String`
+## PresetDesc
 
 The package name with or without version of a preset.
 
@@ -407,7 +407,7 @@ For example:
 
 **Kind**: global typedef  
 
-## PluginName : `String`
+## PluginName
 
 The package name only of a plugin.
 
@@ -419,7 +419,7 @@ For example:
 
 **Kind**: global typedef  
 
-## PresetName : `String`
+## PresetName
 
 The package name only of a preset.
 
@@ -431,7 +431,7 @@ For example:
 
 **Kind**: global typedef  
 
-## ModuleInfo : `Object`
+## ModuleInfo
 
 Module with meta data
 
@@ -449,13 +449,13 @@ Module with meta data
 | \[range\] | `String` | Range by which this module was required |
 
 
-## PluginInfo : [`ModuleInfo`]
+## PluginInfo
 
 Plugin module with meta data
 
 **Kind**: global typedef  
 
-## PresetInfo : [`ModuleInfo`]
+## PresetInfo
 
 Preset module with meta data
 
@@ -468,7 +468,7 @@ Preset module with meta data
 | plugins | `Array.<PluginInfo>` | Plugins this preset uses |
 
 
-## createPackageIdentifier ⇒ [`PackageIdentifier`]
+## createPackageIdentifier
 
 Create a new PackageIdentifier instance
 
@@ -487,7 +487,7 @@ Create a new PackageIdentifier instance
     * [.lookup(name, handler)]
 
 
-### createPackageIdentifier.isValidFullName(maybeFullName) ⇒ `boolean`
+### createPackageIdentifier.isValidFullName(maybeFullName)
 
 Static util method to check if a full name is valid
 
@@ -504,7 +504,7 @@ Examples:
 | maybeFullName | `string` | Name to check |
 
 
-### createPackageIdentifier.lookup(name, handler) ⇒ `PackageIdentifier` ⎮ `null`
+### createPackageIdentifier.lookup(name, handler)
 
 Static util method to loop through format options for short names.
 The handler will be provide the next formatted identifier to try,
@@ -522,46 +522,46 @@ If the lookup runs out of formats to try, it will return null.
 
 <!-- LINKS -->
 
-[Loader]:#loader--loader
-[PackageIdentifier]:#packageidentifier--packageidentifier
-[Resolver]:#resolver--resolver
-[pluginIdentifier()]:#pluginidentifier--createpackageidentifier
-[presetIdentifier()]:#presetidentifier--createpackageidentifier
-[PluginDesc]:#plugindesc--string
-[PresetDesc]:#presetdesc--string
-[PluginName]:#pluginname--string
-[PresetName]:#presetname--string
-[ModuleInfo]:#moduleinfo--object
-[PluginInfo]:#plugininfo--moduleinfo
-[PresetInfo]:#presetinfo--moduleinfo
-[createPackageIdentifier]:#createpackageidentifier--packageidentifier
-[`Loader`]:#loader--loader
+[Loader]:#loader
+[PackageIdentifier]:#packageidentifier
+[Resolver]:#resolver
+[pluginIdentifier()]:#pluginidentifier
+[presetIdentifier()]:#presetidentifier
+[PluginDesc]:#plugindesc
+[PresetDesc]:#presetdesc
+[PluginName]:#pluginname
+[PresetName]:#presetname
+[ModuleInfo]:#moduleinfo
+[PluginInfo]:#plugininfo
+[PresetInfo]:#presetinfo
+[createPackageIdentifier]:#createpackageidentifier
 [`Resolver`]:#new-resolveroptions
-[1]:#loadergetmoduleinfomodule-modulename-meta--moduleinfo
-[2]:#loaderloadmodulemodulename-meta--moduleinfo
-[3]:#loaderloadpluginmodule-meta--plugininfo
-[4]:#loaderloadpresetmodule-meta-options--presetinfo
-[.loadConfigured(config)]:#loaderloadconfiguredconfig--object
-[.resolve(moduleName)]:#resolverresolvemodulename--string
-[.require(moduleName)]:#resolverrequiremodulename--object
-[.tryResolve(moduleName)]:#resolvertryresolvemodulename--string--null
-[.tryRequire(moduleName)]:#resolvertryrequiremodulename--object--null
-[`ModuleInfo`]:#moduleinfo--object
-[`PluginInfo`]:#plugininfo--moduleinfo
-[`PluginName`]:#pluginname--string
-[`PresetInfo`]:#presetinfo--moduleinfo
-[`PresetName`]:#presetname--string
-[`PackageIdentifier`]:#packageidentifier--packageidentifier
-[.rawName]:#packageidentifierrawname--string
-[.fullName]:#packageidentifierfullname--string
-[.longName]:#packageidentifierlongname--string
-[.shortName]:#packageidentifiershortname--string
-[.name]:#packageidentifiername--string
-[.version]:#packageidentifierversion--string
-[.full]:#packageidentifierfull--string
-[5]:#packageidentifierwithversiondefaultversion--packageidentifier
-[.nextFormat()]:#packageidentifiernextformat--packageidentifier--null
+[1]:#loadergetmoduleinfomodule-modulename-meta
+[2]:#loaderloadmodulemodulename-meta
+[3]:#loaderloadpluginmodule-meta
+[4]:#loaderloadpresetmodule-meta-options
+[.loadConfigured(config)]:#loaderloadconfiguredconfig
+[.resolve(moduleName)]:#resolverresolvemodulename
+[.require(moduleName)]:#resolverrequiremodulename
+[.tryResolve(moduleName)]:#resolvertryresolvemodulename
+[.tryRequire(moduleName)]:#resolvertryrequiremodulename
+[`Loader`]:#loader
+[`ModuleInfo`]:#moduleinfo
+[`PluginInfo`]:#plugininfo
+[`PluginName`]:#pluginname
+[`PresetInfo`]:#presetinfo
+[`PresetName`]:#presetname
+[.rawName]:#packageidentifierrawname
+[.fullName]:#packageidentifierfullname
+[.longName]:#packageidentifierlongname
+[.shortName]:#packageidentifiershortname
+[.name]:#packageidentifiername
+[.version]:#packageidentifierversion
+[.full]:#packageidentifierfull
+[5]:#packageidentifierwithversiondefaultversion
+[.nextFormat()]:#packageidentifiernextformat
+[`PackageIdentifier`]:#packageidentifier
 [new Resolver(options)]:#new-resolveroptions
-[`createPackageIdentifier`]:#createpackageidentifier--packageidentifier
-[.isValidFullName(maybeFullName)]:#createpackageidentifierisvalidfullnamemaybefullname--boolean
-[.lookup(name, handler)]:#createpackageidentifierlookupname-handler--packageidentifier--null
+[.isValidFullName(maybeFullName)]:#createpackageidentifierisvalidfullnamemaybefullname
+[.lookup(name, handler)]:#createpackageidentifierlookupname-handler
+[`createPackageIdentifier`]:#createpackageidentifier

--- a/packages/gasket-resolve/docs/api.md
+++ b/packages/gasket-resolve/docs/api.md
@@ -83,7 +83,7 @@ Loads a plugin with additional metadata.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| module | [`PluginName`] \| `Object` | Name of module to load (or module content) |
+| module | [`PluginName`] \| `object` | Name of module to load (or module content) |
 | \[meta\] | `object` | Additional meta data |
 
 
@@ -311,7 +311,7 @@ Utility to help resolve and require modules
 | Param | Type | Description |
 | --- | --- | --- |
 | options | `object` | Options |
-| \[options.resolveFrom\] | `string` \| `Array.<String>` | Path(s) to resolve modules from |
+| \[options.resolveFrom\] | `string` \| `Array.<string>` | Path(s) to resolve modules from |
 | \[options.require\] | `require` | Require instance to use |
 
 

--- a/packages/gasket-resolve/docs/api.md
+++ b/packages/gasket-resolve/docs/api.md
@@ -36,10 +36,10 @@ Utility to load plugins, presets, and other modules with associated metadata
 **Extends**: [`Resolver`]  
 
 * [Loader]
-    * [.getModuleInfo(module, moduleName, \[meta\])][1]
-    * [.loadModule(moduleName, \[meta\])][2]
-    * [.loadPlugin(module, \[meta\])][3]
-    * [.loadPreset(module, \[meta\], \[options\])][4]
+    * [.getModuleInfo(module, moduleName, \[meta\])]
+    * [.loadModule(moduleName, \[meta\])]
+    * [.loadPlugin(module, \[meta\])]
+    * [.loadPreset(module, \[meta\], \[options\])]
     * [.loadConfigured(config)]
     * [.resolve(moduleName)]
     * [.require(moduleName)]
@@ -185,7 +185,7 @@ Utility class for working with package names and versions
     * [.name]
     * [.version]
     * [.full]
-    * [.withVersion(\[defaultVersion\])][5]
+    * [.withVersion(\[defaultVersion\])]
     * [.nextFormat()]
 
 
@@ -536,10 +536,10 @@ If the lookup runs out of formats to try, it will return null.
 [PresetInfo]:#presetinfo
 [createPackageIdentifier]:#createpackageidentifier
 [`Resolver`]:#new-resolveroptions
-[1]:#loadergetmoduleinfomodule-modulename-meta
-[2]:#loaderloadmodulemodulename-meta
-[3]:#loaderloadpluginmodule-meta
-[4]:#loaderloadpresetmodule-meta-options
+[.getModuleInfo(module, moduleName, \[meta\])]:#loadergetmoduleinfomodule-modulename-meta
+[.loadModule(moduleName, \[meta\])]:#loaderloadmodulemodulename-meta
+[.loadPlugin(module, \[meta\])]:#loaderloadpluginmodule-meta
+[.loadPreset(module, \[meta\], \[options\])]:#loaderloadpresetmodule-meta-options
 [.loadConfigured(config)]:#loaderloadconfiguredconfig
 [.resolve(moduleName)]:#resolverresolvemodulename
 [.require(moduleName)]:#resolverrequiremodulename
@@ -558,7 +558,7 @@ If the lookup runs out of formats to try, it will return null.
 [.name]:#packageidentifiername
 [.version]:#packageidentifierversion
 [.full]:#packageidentifierfull
-[5]:#packageidentifierwithversiondefaultversion
+[.withVersion(\[defaultVersion\])]:#packageidentifierwithversiondefaultversion
 [.nextFormat()]:#packageidentifiernextformat
 [`PackageIdentifier`]:#packageidentifier
 [new Resolver(options)]:#new-resolveroptions

--- a/packages/gasket-resolve/lib/identifiers.js
+++ b/packages/gasket-resolve/lib/identifiers.js
@@ -15,7 +15,7 @@ const { projectIdentifier } = require('./package-identifier');
  * For example, the following patterns will not work:
  *   - @gasket/https
  *
- * @typedef {String} PluginDesc
+ * @typedef {string} PluginDesc
  */
 
 /**
@@ -29,7 +29,7 @@ const { projectIdentifier } = require('./package-identifier');
  *   - gasket-preset-nextjs         - user fullName
  *   - nextjs                       - user shortName
  *
- * @typedef {String} PresetDesc
+ * @typedef {string} PresetDesc
  */
 
 /**
@@ -41,7 +41,7 @@ const { projectIdentifier } = require('./package-identifier');
  *   - gasket-plugin-https         - user fullName
  *   - https                       - user shortName
  *
- * @typedef {String} PluginName
+ * @typedef {string} PluginName
  */
 
 /**
@@ -53,7 +53,7 @@ const { projectIdentifier } = require('./package-identifier');
  *   - gasket-preset-nextjs         - user fullName
  *   - nextjs                       - user shortName
  *
- * @typedef {String} PresetName
+ * @typedef {string} PresetName
  */
 
 /**

--- a/packages/gasket-resolve/lib/loader.js
+++ b/packages/gasket-resolve/lib/loader.js
@@ -5,16 +5,16 @@ const { pluginIdentifier, presetIdentifier } = require('./identifiers');
 /**
  * Module with meta data
  *
- * @typedef {Object} ModuleInfo
+ * @typedef {object} ModuleInfo
  *
  *
- * @property {String} name - Name of preset
- * @property {String} module - Actual module content
- * @property {String} [package] - Package.json contents
- * @property {String} [version] - Resolved version
- * @property {String} [path] - Path to the root of package
- * @property {String} [from] - Name of module which requires this module
- * @property {String} [range] - Range by which this module was required
+ * @property {string} name - Name of preset
+ * @property {string} module - Actual module content
+ * @property {string} [package] - Package.json contents
+ * @property {string} [version] - Resolved version
+ * @property {string} [path] - Path to the root of package
+ * @property {string} [from] - Name of module which requires this module
+ * @property {string} [range] - Range by which this module was required
  */
 
 /**
@@ -55,9 +55,9 @@ class Loader extends Resolver {
   /**
    * Loads a module with additional metadata
    *
-   * @param {String} module - Module content
-   * @param {String} moduleName - Name of module to load
-   * @param {Object} [meta] - Additional meta data
+   * @param {string} module - Module content
+   * @param {string} moduleName - Name of module to load
+   * @param {object} [meta] - Additional meta data
    * @returns {ModuleInfo} module
    */
   getModuleInfo(module, moduleName, meta = {}) {
@@ -82,8 +82,8 @@ class Loader extends Resolver {
   /**
    * Loads a module with additional metadata
    *
-   * @param {String} moduleName - Name of module to load
-   * @param {Object} [meta] - Additional meta data
+   * @param {string} moduleName - Name of module to load
+   * @param {object} [meta] - Additional meta data
    * @returns {ModuleInfo} module
    */
   loadModule(moduleName, meta = {}) {
@@ -94,8 +94,8 @@ class Loader extends Resolver {
   /**
    * Loads a plugin with additional metadata.
    *
-   * @param {PluginName|Object} module - Name of module to load (or module content)
-   * @param {Object} [meta] - Additional meta data
+   * @param {PluginName|object} module - Name of module to load (or module content)
+   * @param {object} [meta] - Additional meta data
    * @returns {PluginInfo} module
    */
   loadPlugin(module, meta = {}) {
@@ -117,9 +117,9 @@ class Loader extends Resolver {
    * Loads a preset with additional metadata
    *
    * @param {PresetName} module - Name of module to load
-   * @param {Object} [meta] - Additional meta data
-   * @param {Boolean} [options] - Loading options
-   * @param {Boolean} [options.shallow] - Do not recursively load dependencies
+   * @param {object} [meta] - Additional meta data
+   * @param {boolean} [options] - Loading options
+   * @param {boolean} [options.shallow] - Do not recursively load dependencies
    * @returns {PresetInfo} module
    */
   loadPreset(module, meta, { shallow = false } = {}) {
@@ -163,7 +163,7 @@ class Loader extends Resolver {
    * Plugins will be filtered and ordered as configuration with priority of:
    *  - added plugins > preset plugins > nested preset plugins
    *
-   * @param {Object}                config         - Presets and plugins to load
+   * @param {object}                config         - Presets and plugins to load
    * @param {PresetName[]}          config.presets - Presets to load and add plugins from
    * @param {PluginName[]|module[]} config.add     - Names of plugins to load
    * @param {string[]}              config.remove  - Names of plugins to remove (from presets)

--- a/packages/gasket-resolve/lib/package-identifier.js
+++ b/packages/gasket-resolve/lib/package-identifier.js
@@ -106,8 +106,8 @@ function projectIdentifier(projectName, type = 'plugin') {
    *
    * @typedef {function} createPackageIdentifier
    *
-   * @param {String} rawName - Original input name of a package
-   * @param {Object} [options] - Options
+   * @param {string} rawName - Original input name of a package
+   * @param {object} [options] - Options
    * @param {boolean} [options.prefixed] - Set this to force prefixed/postfixed format for short names
    * @returns {PackageIdentifier} instance
    */
@@ -131,7 +131,7 @@ function projectIdentifier(projectName, type = 'plugin') {
       /**
        * The parts of an identifier's name format
        *
-       * @typedef {Object} NameFormat
+       * @typedef {object} NameFormat
        *
        * @property {boolean} prefixed
        * @property {boolean} short
@@ -347,7 +347,7 @@ function projectIdentifier(projectName, type = 'plugin') {
     /**
      * Output the original raw name for string concatenation.
      *
-     * @returns {String} string
+     * @returns {string} string
      */
     PackageIdentifier.prototype.toString = function toString() {
       return rawName;

--- a/packages/gasket-resolve/lib/resolver.js
+++ b/packages/gasket-resolve/lib/resolver.js
@@ -7,8 +7,8 @@ const debug = require('diagnostics')('gasket:resolver');
  */
 class Resolver {
   /**
-   * @param {Object} options - Options
-   * @param {String|String[]} [options.resolveFrom] - Path(s) to resolve modules from
+   * @param {object} options - Options
+   * @param {string|string[]} [options.resolveFrom] - Path(s) to resolve modules from
    * @param {require} [options.require] - Require instance to use
    */
   constructor(options) {
@@ -26,8 +26,8 @@ class Resolver {
   /**
    * Returns the resolved module filename
    *
-   * @param {String} moduleName name of the module
-   * @returns {String} filename of the module
+   * @param {string} moduleName name of the module
+   * @returns {string} filename of the module
    */
   resolve(moduleName) {
     const options = this._resolveFrom ? { paths: this._resolveFrom } : {};
@@ -37,8 +37,8 @@ class Resolver {
   /**
    * Returns the required module
    *
-   * @param {String} moduleName name of the module
-   * @returns {Object} module contents
+   * @param {string} moduleName name of the module
+   * @returns {object} module contents
    */
   require(moduleName) {
     const modulePath = this.resolve(moduleName);
@@ -48,8 +48,8 @@ class Resolver {
   /**
    * Returns the resolved module filename, or null if not found
    *
-   * @param {String} moduleName name of the module
-   * @returns {String|null} filename of the module
+   * @param {string} moduleName name of the module
+   * @returns {string|null} filename of the module
    */
   tryResolve(moduleName) {
     try {
@@ -67,8 +67,8 @@ class Resolver {
   /**
    * Returns the required module, or null if not found
    *
-   * @param {String} moduleName name of the module
-   * @returns {Object|null} module contents
+   * @param {string} moduleName name of the module
+   * @returns {object|null} module contents
    */
   tryRequire(moduleName) {
     try {

--- a/packages/gasket-resolve/package.json
+++ b/packages/gasket-resolve/package.json
@@ -10,7 +10,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "posttest": "npm run lint",
-    "docs": "jsdoc2md lib/*.js > docs/api.md"
+    "docs": "jsdoc2md --plugin @godaddy/dmd --files lib/*.js > docs/api.md"
   },
   "repository": {
     "type": "git",

--- a/packages/gasket-resolve/package.json
+++ b/packages/gasket-resolve/package.json
@@ -40,6 +40,7 @@
     "semver": "^6.3.0"
   },
   "devDependencies": {
+    "@godaddy/dmd": "^1.0.0",
     "eslint": "^6.1.0",
     "eslint-config-godaddy": "^4.0.0",
     "eslint-plugin-jest": "^22.15.1",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

The markdown from jsdocs was pretty messy for reading as text, and terrible for rendering with docsify. This PR regenerates API docs using the new [@godaddy/dmd] plugin for `jsdocs2md`.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

- Fix primitive casing in jsdocs and regen API docs with [@godaddy/dmd] plugin

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Read the updated docs.
- Tested locally with docsify using `npm run docs-view`.

<img width="1212" alt="Screen Shot 2020-01-16 at 2 56 43 PM" src="https://user-images.githubusercontent.com/82775/72568073-8069ca80-3874-11ea-9f6c-93108c5120c9.png">


<!-- LINKS -->
[@godaddy/dmd]:https://github.com/godaddy/dmd