### PR TITLE
Better lint config name handling

### DIFF
--- a/packages/gasket-plugin-lint/CHANGELOG.md
+++ b/packages/gasket-plugin-lint/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-lint`
 
+- Add support for scope-only package short names with eslint configs. ([#142])
+
 ### 5.0.0
 
 - Open Source Release
@@ -56,3 +58,5 @@
 [Airbnb]: README.md#airbnb
 
 [#98]: https://github.com/godaddy/gasket/pull/98
+[#142]: https://github.com/godaddy/gasket/pull/142
+

--- a/packages/gasket-plugin-lint/lib/code-styles.js
+++ b/packages/gasket-plugin-lint/lib/code-styles.js
@@ -1,4 +1,6 @@
 /* eslint-disable complexity,max-statements */
+const { eslintConfigIdentifier, stylelintConfigIdentifier } = require('./utils');
+
 
 /**
  *
@@ -128,16 +130,13 @@ const other = {
     const { gatherDevDeps } = utils;
 
     if (eslintConfig) {
-      // TODO (kinetifex): utilize v4 package identifier with prefix format support to handle short names with scopes
-      const configName = !eslintConfig.includes('eslint-config') ? `eslint-config-${eslintConfig}` : eslintConfig;
-
+      const configName = eslintConfigIdentifier(eslintConfig).fullName;
       pkg.add('devDependencies', (await gatherDevDeps(configName)));
       pkg.add('eslintConfig', { extends: [eslintConfig] });
     }
 
     if (stylelintConfig) {
-      const stylelintName = !stylelintConfig.includes('stylelint-config') ?
-        `stylelint-config-${stylelintConfig}` : stylelintConfig;
+      const stylelintName = stylelintConfigIdentifier(stylelintConfig).fullName;
       pkg.add('devDependencies', (await gatherDevDeps(stylelintName)));
       pkg.add('stylelint', { extends: [stylelintConfig] });
     }

--- a/packages/gasket-plugin-lint/lib/code-styles.js
+++ b/packages/gasket-plugin-lint/lib/code-styles.js
@@ -130,15 +130,15 @@ const other = {
     const { gatherDevDeps } = utils;
 
     if (eslintConfig) {
-      const configName = eslintConfigIdentifier(eslintConfig).fullName;
-      pkg.add('devDependencies', (await gatherDevDeps(configName)));
-      pkg.add('eslintConfig', { extends: [eslintConfig] });
+      const identifier = eslintConfigIdentifier(eslintConfig);
+      pkg.add('devDependencies', (await gatherDevDeps(identifier.full)));
+      pkg.add('eslintConfig', { extends: [identifier.shortName] });
     }
 
     if (stylelintConfig) {
-      const stylelintName = stylelintConfigIdentifier(stylelintConfig).fullName;
-      pkg.add('devDependencies', (await gatherDevDeps(stylelintName)));
-      pkg.add('stylelint', { extends: [stylelintConfig] });
+      const identifier = stylelintConfigIdentifier(stylelintConfig);
+      pkg.add('devDependencies', (await gatherDevDeps(identifier.full)));
+      pkg.add('stylelintConfig', { extends: [identifier.name] });
     }
   }
 };

--- a/packages/gasket-plugin-lint/lib/utils.js
+++ b/packages/gasket-plugin-lint/lib/utils.js
@@ -1,4 +1,7 @@
 const semver = require('semver');
+const { projectIdentifier } = require('@gasket/resolve');
+const eslintConfigIdentifier = projectIdentifier('eslint', 'config');
+const stylelintConfigIdentifier = projectIdentifier('stylelint', 'config');
 
 const reName = /^(@?[\w/-]+)@?(.*)/;
 
@@ -99,5 +102,7 @@ function makeSafeRunScript(context, runScript) {
 module.exports = {
   makeGatherDevDeps,
   makeRunScriptStr,
-  makeSafeRunScript
+  makeSafeRunScript,
+  eslintConfigIdentifier,
+  stylelintConfigIdentifier
 };

--- a/packages/gasket-plugin-lint/package.json
+++ b/packages/gasket-plugin-lint/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/godaddy/gasket/tree/master/packages/gasket-plugin-lint#readme",
   "dependencies": {
+    "@gasket/resolve": "^5.0.2",
     "semver": "^6.3.0"
   },
   "devDependencies": {

--- a/packages/gasket-plugin-lint/test/code-styles.test.js
+++ b/packages/gasket-plugin-lint/test/code-styles.test.js
@@ -216,76 +216,102 @@ describe('code styles', () => {
       assume(codeStyle.allowStylelint).true();
     });
 
-    it('uses eslint config', async () => {
-      context.eslintConfig = 'eslint-config-fake';
-      await codeStyle.create(context, utils);
+    describe('eslintConfig', () => {
+      it('gathers dependencies', async () => {
+        context.eslintConfig = 'eslint-config-fake';
+        await codeStyle.create(context, utils);
 
-      assume(pkgAdd).calledWithMatch('devDependencies', {
-        'eslint-config-fake': sinon.match.string
+        assume(utils.gatherDevDeps).calledWith('eslint-config-fake');
       });
-      assume(pkgAdd).calledWithMatch('eslintConfig', {
-        extends: ['eslint-config-fake']
+
+      it('gathers dependencies for short name with version', async () => {
+        context.eslintConfig = 'fake@^1.2.3';
+        await codeStyle.create(context, utils);
+
+        assume(utils.gatherDevDeps).calledWith('eslint-config-fake@^1.2.3');
       });
-    });
 
-    it('uses eslint config with short name', async () => {
-      context.eslintConfig = 'fake';
-      await codeStyle.create(context, utils);
+      it('gathers dependencies for scope-only short names', async () => {
+        context.eslintConfig = '@fake@^1.2.3';
+        await codeStyle.create(context, utils);
 
-      assume(pkgAdd).calledWithMatch('devDependencies', {
-        'eslint-config-fake': sinon.match.string
+        assume(utils.gatherDevDeps).calledWith('@fake/eslint-config@^1.2.3');
       });
-      assume(pkgAdd).calledWithMatch('eslintConfig', {
-        extends: ['fake']
+
+      it('add gathered devDependencies', async () => {
+        context.eslintConfig = 'eslint-config-fake';
+        await codeStyle.create(context, utils);
+
+        assume(pkgAdd).calledWithMatch('devDependencies', {
+          'eslint-config-fake': sinon.match.string
+        });
       });
-    });
 
-    it.skip('uses eslint config with scoped short name', async () => {
-      context.eslintConfig = '@scope/fake';
-      await codeStyle.create(context, utils);
+      it('adds eslint config as short name', async () => {
+        context.eslintConfig = 'eslint-config-fake@^1.2.3';
+        await codeStyle.create(context, utils);
 
-      assume(pkgAdd).calledWithMatch('devDependencies', {
-        '@scope/eslint-config-fake': sinon.match.string
+        assume(pkgAdd).calledWithMatch('eslintConfig', {
+          extends: ['fake']
+        });
       });
-      assume(pkgAdd).calledWithMatch('eslintConfig', {
-        extends: ['@scope/fake']
+
+      it('adds eslint config with scope-only short name', async () => {
+        context.eslintConfig = '@fake/eslint-config@^1.2.3';
+        await codeStyle.create(context, utils);
+
+        assume(pkgAdd).calledWithMatch('eslintConfig', {
+          extends: ['@fake']
+        });
       });
-    });
 
-    it('ignores if no eslint config', async () => {
-      await codeStyle.create(context, utils);
+      it('ignores if no eslint config', async () => {
+        await codeStyle.create(context, utils);
 
-      assume(pkgAdd).not.calledWithMatch('eslintConfig');
-    });
-
-    it('uses stylelint config', async () => {
-      context.stylelintConfig = 'stylelint-config-fake';
-      await codeStyle.create(context, utils);
-
-      assume(pkgAdd).calledWithMatch('devDependencies', {
-        'stylelint-config-fake': sinon.match.string
-      });
-      assume(pkgAdd).calledWithMatch('stylelint', {
-        extends: ['stylelint-config-fake']
-      });
-    });
-
-    it('uses stylelint config with short name', async () => {
-      context.stylelintConfig = 'fake';
-      await codeStyle.create(context, utils);
-
-      assume(pkgAdd).calledWithMatch('devDependencies', {
-        'stylelint-config-fake': sinon.match.string
-      });
-      assume(pkgAdd).calledWithMatch('stylelint', {
-        extends: ['fake']
+        assume(pkgAdd).not.calledWithMatch('eslintConfig');
       });
     });
 
-    it('ignores if no stylelint config', async () => {
-      await codeStyle.create(context, utils);
 
-      assume(pkgAdd).not.calledWithMatch('stylelint');
+    describe('stylelintConfig', () => {
+
+      it('gathers dependencies', async () => {
+        context.stylelintConfig = 'stylelint-config-fake';
+        await codeStyle.create(context, utils);
+
+        assume(utils.gatherDevDeps).calledWith('stylelint-config-fake');
+      });
+
+      it('gathers dependencies with version', async () => {
+        context.stylelintConfig = 'stylelint-config-fake@^1.2.3';
+        await codeStyle.create(context, utils);
+
+        assume(utils.gatherDevDeps).calledWith('stylelint-config-fake@^1.2.3');
+      });
+
+      it('add gathered devDependencies', async () => {
+        context.stylelintConfig = 'stylelint-config-fake';
+        await codeStyle.create(context, utils);
+
+        assume(pkgAdd).calledWithMatch('devDependencies', {
+          'stylelint-config-fake': sinon.match.string
+        });
+      });
+
+      it('adds stylelintConfig as name (does not shorten)', async () => {
+        context.stylelintConfig = 'stylelint-config-fake@^1.2.3';
+        await codeStyle.create(context, utils);
+
+        assume(pkgAdd).calledWithMatch('stylelintConfig', {
+          extends: ['stylelint-config-fake']
+        });
+      });
+
+      it('ignores if no stylelint config', async () => {
+        await codeStyle.create(context, utils);
+
+        assume(pkgAdd).not.calledWithMatch('stylelintConfig');
+      });
     });
   });
 

--- a/packages/gasket-plugin-lint/test/prompt.test.js
+++ b/packages/gasket-plugin-lint/test/prompt.test.js
@@ -71,6 +71,7 @@ describe('prompt hook', function () {
     const question = prompt.getCall(0).args[0][1];
     assume(question.name).equals('eslintConfig');
     assume(question.transformer('@scope/config')).equals('@scope/config');
+    assume(question.transformer('@scope')).equals('@scope');
   });
 
   it('addStylelint question shown only codeStyle has support', async () => {
@@ -110,5 +111,6 @@ describe('prompt hook', function () {
     const question = prompt.getCall(0).args[0][3];
     assume(question.name).equals('stylelintConfig');
     assume(question.transformer('@scope/config')).equals('@scope/config');
+    assume(question.transformer('@scope')).equals('@scope');
   });
 });

--- a/packages/gasket-plugin-lint/test/utils.test.js
+++ b/packages/gasket-plugin-lint/test/utils.test.js
@@ -4,7 +4,8 @@ const sinon = require('sinon');
 const {
   makeGatherDevDeps,
   makeRunScriptStr,
-  makeSafeRunScript
+  makeSafeRunScript,
+  eslintConfigIdentifier
 } = require('../lib/utils');
 
 describe('utils', () => {
@@ -135,6 +136,14 @@ describe('utils', () => {
       await safeRunScript('existing');
       assume(runScript).called();
       assume(context.warnings).length(0);
+    });
+  });
+
+  describe('eslintConfigIdentifier', () => {
+    it('does stuff', () => {
+      const config = eslintConfigIdentifier('@scope');
+
+      assume(config.longName).equals('@scope/eslint-config');
     });
   });
 });

--- a/packages/gasket-resolve/CHANGELOG.md
+++ b/packages/gasket-resolve/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `@gasket/resolve`
 
+- Expose projectIdentifier with support for scope-only package short names ([#142])
 - Clean markdown from jsdocs ([#141])
 
 ### 5.0.0
@@ -47,5 +48,6 @@
 [#93]: https://github.com/godaddy/gasket/pull/93
 [#105]: https://github.com/godaddy/gasket/pull/105
 [#141]: https://github.com/godaddy/gasket/pull/141
+[#142]: https://github.com/godaddy/gasket/pull/142
 
 [Loader]:/packages/gasket-resolve/docs/api.md#loader

--- a/packages/gasket-resolve/README.md
+++ b/packages/gasket-resolve/README.md
@@ -26,6 +26,7 @@ projects such a `@babel` and `@oclif`.
 |:--------|:--------------------------------|:------------------|:-------------------------------|
 | project | `@gasket/plugin-<name>`         | `@gasket/<name>`  | Official Gasket project plugin |
 | user    | `@<scope>/gasket-plugin-<name>` | `@<scope>/<name>` | Any user plugins with a scope  |
+| user    | `@<scope>/gasket-plugin`        | `@<scope>`        | Scope-only user plugins        |
 | none    | `gasket-plugin-<name>`          | `<name>`          | Any user plugins with no scope |
 
 ### Presets
@@ -34,6 +35,7 @@ projects such a `@babel` and `@oclif`.
 |:--------|:--------------------------------|:------------------|:-------------------------------|
 | project | `@gasket/preset-<name>`         | `@gasket/<name>`  | Official Gasket project preset |
 | user    | `@<scope>/gasket-preset-<name>` | `@<scope>/<name>` | Any user presets with a scope  |
+| user    | `@<scope>/gasket-preset`        | `@<scope>`        | Scope-only user presets        |
 | none    | `gasket-preset-<name>`          | `<name>`          | Any user presets with no scope |
 
 ### Fallbacks

--- a/packages/gasket-resolve/docs/api.md
+++ b/packages/gasket-resolve/docs/api.md
@@ -13,7 +13,7 @@ Name | Description
 ------ | -----------
 [pluginIdentifier()] | Create package identifiers for Gasket plugins
 [presetIdentifier()] | Create package identifiers for Gasket presets
-[projectIdentifier(projectName, \[type\])] | Create function used to make instances of PackageIdentifier for a project.
+[projectIdentifier(projectName, \[type\])] | Create function used to make instances of PackageIdentifier for a project
 
 ## Typedefs
 
@@ -378,7 +378,7 @@ Create package identifiers for Gasket presets
 
 ## projectIdentifier(projectName, \[type\])
 
-Create function used to make instances of PackageIdentifier for a project.
+Create function used to make instances of PackageIdentifier for a project
 
 The `projectName` and `type` are components of the naming convention such as
 - @<projectName>/<type>-<name>

--- a/packages/gasket-resolve/docs/api.md
+++ b/packages/gasket-resolve/docs/api.md
@@ -13,6 +13,7 @@ Name | Description
 ------ | -----------
 [pluginIdentifier()] | Create package identifiers for Gasket plugins
 [presetIdentifier()] | Create package identifiers for Gasket presets
+[projectIdentifier(projectName, \[type\])] | Create function used to make instances of PackageIdentifier for a project.
 
 ## Typedefs
 
@@ -375,6 +376,34 @@ Create package identifiers for Gasket presets
 
 **Kind**: global function  
 
+## projectIdentifier(projectName, \[type\])
+
+Create function used to make instances of PackageIdentifier for a project.
+
+The `projectName` and `type` are components of the naming convention such as
+- @<projectName>/<type>-<name>
+- @<user-scope>/<projectName>-<type>-<name>
+- <projectName>-<type>-<name>
+
+If a package belongs to the project, it should use `projectName` in its scope.
+For user plugins, the `projectName` will be paired with the `type`.
+
+**Kind**: global function  
+**Returns**: `function` - function to make  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| projectName | `string` |  | Name of the project scope and base name |
+| \[type\] | `string` | `'plugin'` | Defaults to 'plugin'. |
+
+
+### projectIdentifier~setupProjectVars()
+
+Setup project level variables
+
+**Kind**: inner method of [`projectIdentifier`]  
+**Returns**: `object` - vars  
+
 ## PluginDesc
 
 The package name with or without version of a plugin.
@@ -525,8 +554,6 @@ If the lookup runs out of formats to try, it will return null.
 [Loader]:#loader
 [PackageIdentifier]:#packageidentifier
 [Resolver]:#resolver
-[pluginIdentifier()]:#pluginidentifier
-[presetIdentifier()]:#presetidentifier
 [PluginDesc]:#plugindesc
 [PresetDesc]:#presetdesc
 [PluginName]:#pluginname
@@ -536,15 +563,6 @@ If the lookup runs out of formats to try, it will return null.
 [PresetInfo]:#presetinfo
 [createPackageIdentifier]:#createpackageidentifier
 [`Resolver`]:#new-resolveroptions
-[.getModuleInfo(module, moduleName, \[meta\])]:#loadergetmoduleinfomodule-modulename-meta
-[.loadModule(moduleName, \[meta\])]:#loaderloadmodulemodulename-meta
-[.loadPlugin(module, \[meta\])]:#loaderloadpluginmodule-meta
-[.loadPreset(module, \[meta\], \[options\])]:#loaderloadpresetmodule-meta-options
-[.loadConfigured(config)]:#loaderloadconfiguredconfig
-[.resolve(moduleName)]:#resolverresolvemodulename
-[.require(moduleName)]:#resolverrequiremodulename
-[.tryResolve(moduleName)]:#resolvertryresolvemodulename
-[.tryRequire(moduleName)]:#resolvertryrequiremodulename
 [`Loader`]:#loader
 [`ModuleInfo`]:#moduleinfo
 [`PluginInfo`]:#plugininfo
@@ -558,10 +576,23 @@ If the lookup runs out of formats to try, it will return null.
 [.name]:#packageidentifiername
 [.version]:#packageidentifierversion
 [.full]:#packageidentifierfull
+[`PackageIdentifier`]:#packageidentifier
+[`projectIdentifier`]:#projectidentifierprojectname-type
+[`createPackageIdentifier`]:#createpackageidentifier
+[pluginIdentifier()]:#pluginidentifier
+[presetIdentifier()]:#presetidentifier
+[projectIdentifier(projectName, \[type\])]:#projectidentifierprojectname-type
+[.getModuleInfo(module, moduleName, \[meta\])]:#loadergetmoduleinfomodule-modulename-meta
+[.loadModule(moduleName, \[meta\])]:#loaderloadmodulemodulename-meta
+[.loadPlugin(module, \[meta\])]:#loaderloadpluginmodule-meta
+[.loadPreset(module, \[meta\], \[options\])]:#loaderloadpresetmodule-meta-options
+[.loadConfigured(config)]:#loaderloadconfiguredconfig
+[.resolve(moduleName)]:#resolverresolvemodulename
+[.require(moduleName)]:#resolverrequiremodulename
+[.tryResolve(moduleName)]:#resolvertryresolvemodulename
+[.tryRequire(moduleName)]:#resolvertryrequiremodulename
 [.withVersion(\[defaultVersion\])]:#packageidentifierwithversiondefaultversion
 [.nextFormat()]:#packageidentifiernextformat
-[`PackageIdentifier`]:#packageidentifier
 [new Resolver(options)]:#new-resolveroptions
 [.isValidFullName(maybeFullName)]:#createpackageidentifierisvalidfullnamemaybefullname
 [.lookup(name, handler)]:#createpackageidentifierlookupname-handler
-[`createPackageIdentifier`]:#createpackageidentifier

--- a/packages/gasket-resolve/lib/index.js
+++ b/packages/gasket-resolve/lib/index.js
@@ -1,8 +1,10 @@
 const { pluginIdentifier, presetIdentifier } = require('./identifiers');
+const { projectIdentifier } = require('./package-identifier');
 
 module.exports = {
   Resolver: require('./resolver'),
   Loader: require('./loader'),
   pluginIdentifier,
-  presetIdentifier
+  presetIdentifier,
+  projectIdentifier
 };

--- a/packages/gasket-resolve/lib/package-identifier.js
+++ b/packages/gasket-resolve/lib/package-identifier.js
@@ -14,7 +14,7 @@ function matchMaker(projectName, type = 'plugin') {
   return {
     prefixed: {
       project: new RegExp(`(@${projectName})/${type}-([\\w-.]+)`),
-      user: new RegExp(`(@[\\w-.]+)?\\/?${projectName}-${type}-([\\w-.]+)`)
+      user: new RegExp(`(@[\\w-.]+)?\\/?${projectName}-${type}-?([\\w-.]+)?`)
     },
     postfixed: {
       project: new RegExp(`(@${projectName})/([\\w-.]+)-${type}`),
@@ -226,7 +226,8 @@ function projectIdentifier(projectName, type = 'plugin') {
         }
 
         const [, scope, name] = re.exec(parsedName);
-        return scope ? `${scope}/${name}` : name;
+        if (name) return scope ? `${scope}/${name}` : name;
+        return scope;
       }
 
       /**

--- a/packages/gasket-resolve/lib/package-identifier.js
+++ b/packages/gasket-resolve/lib/package-identifier.js
@@ -1,3 +1,6 @@
+const reScope = /(@[\w-.]+)(\/.+)?/;
+const reName = /^(@?[\w/-]+)@?(.*)/;
+
 /**
  * Generate RegExp to help determine aspects of an identifier for a project
  *
@@ -16,9 +19,7 @@ function matchMaker(projectName, type = 'plugin') {
     postfixed: {
       project: new RegExp(`(@${projectName})/([\\w-.]+)-${type}`),
       user: new RegExp(`(@[\\w-.]+)?\\/?([\\w-.]+)-${projectName}-${type}`)
-    },
-    scope: /(@[\w-.]+)\/.+/,
-    name: /^(@?[\w/-]+)@?(.*)/
+    }
   };
 }
 
@@ -33,14 +34,19 @@ function matchMaker(projectName, type = 'plugin') {
 function expandMaker(projectName, type = 'plugin') {
   if (!projectName) throw new Error('projectName required.');
   const projectScope = `@${projectName}`;
-  const parse = short => short.split('/').reverse();
+  const parse = short => {
+    if (reScope.test(short) && !short.includes('/')) {
+      return ['', short];
+    }
+    return short.split('/').reverse();
+  };
   return {
     prefixed: short => {
       const [name, scope] = parse(short);
       if (scope === projectScope) {
         return `${projectScope}/${type}-${name}`;
       }
-      const result = `${projectName}-${type}-${name}`;
+      const result = `${projectName}-${type}` + (name ? `-${name}` : '');
       return scope ? `${scope}/${result}` : result;
     },
     postfixed: short => {
@@ -56,7 +62,8 @@ function expandMaker(projectName, type = 'plugin') {
 }
 
 /**
- * Create function used to make instances of PackageIdentifier for a project.
+ * Create function used to make instances of PackageIdentifier for a project
+ *
  * The `projectName` and `type` are components of the naming convention such as
  * - @<projectName>/<type>-<name>
  * - @<user-scope>/<projectName>-<type>-<name>
@@ -68,7 +75,6 @@ function expandMaker(projectName, type = 'plugin') {
  * @param {string} projectName - Name of the project scope and base name
  * @param {string} [type] - Defaults to 'plugin'.
  * @returns {function} function to make
- * @private
  */
 function projectIdentifier(projectName, type = 'plugin') {
 
@@ -80,7 +86,7 @@ function projectIdentifier(projectName, type = 'plugin') {
     const re = matchMaker(projectName, type);
     const expand = expandMaker(projectName, type);
     const projectScope = `@${projectName}`;
-    const isScopedFn = name => re.scope.test(name);
+    const isScopedFn = name => reScope.test(name);
     const isShortFn = name => !(name.includes(projectName) && name.includes(type));
     const isPrefixedFn = name => re.prefixed.project.test(name) || re.prefixed.user.test(name);
     const isProjectScopedFn = name => name.startsWith(projectScope);
@@ -113,7 +119,7 @@ function projectIdentifier(projectName, type = 'plugin') {
    */
   function createPackageIdentifier(rawName, options) {
 
-    const [, parsedName, parsedVersion] = projectVars.re.name.exec(rawName);
+    const [, parsedName, parsedVersion] = reName.exec(rawName);
 
     /**
      * * Setup package level variables

--- a/packages/gasket-resolve/test/package-identifier.instance.test.js
+++ b/packages/gasket-resolve/test/package-identifier.instance.test.js
@@ -57,8 +57,13 @@ describe('PackageIdentifier instance', () => {
         expect(result).toBe('@user/gasket-plugin-p');
       });
 
-      it('expands scope with no name to full', () => {
+      it('expands scope with no name part to full', () => {
         result = pluginIdentifier('@user/gasket-plugin').fullName;
+        expect(result).toBe('@user/gasket-plugin');
+      });
+
+      it('expands scope with no name part and with version to full', () => {
+        result = pluginIdentifier('@user/gasket-plugin@^1.2.3').fullName;
         expect(result).toBe('@user/gasket-plugin');
       });
 
@@ -169,6 +174,21 @@ describe('PackageIdentifier instance', () => {
       it('gets one-letter short name', () => {
         result = pluginIdentifier('@user/gasket-plugin-p').shortName;
         expect(result).toBe('@user/p');
+      });
+
+      it('gets scope only if full with no name part', () => {
+        result = pluginIdentifier('@user/gasket-plugin').shortName;
+        expect(result).toBe('@user');
+      });
+
+      it('gets scope only with no name part and with version', () => {
+        result = pluginIdentifier('@user/gasket-plugin@^1.2.3').shortName;
+        expect(result).toBe('@user');
+      });
+
+      it('keeps scope only names to shortName', () => {
+        result = pluginIdentifier('@user').shortName;
+        expect(result).toBe('@user');
       });
 
       it('gets multi-word short name', () => {
@@ -401,6 +421,21 @@ describe('PackageIdentifier instance', () => {
       it('expands one-letter plugin names to full', () => {
         result = pluginIdentifier('@user/p').full;
         expect(result).toBe('@user/gasket-plugin-p');
+      });
+
+      it('expands scope with no name part to full', () => {
+        result = pluginIdentifier('@user/gasket-plugin').full;
+        expect(result).toBe('@user/gasket-plugin');
+      });
+
+      it('expands scope with no name part and with version to full', () => {
+        result = pluginIdentifier('@user/gasket-plugin@^1.2.3').full;
+        expect(result).toBe('@user/gasket-plugin@^1.2.3');
+      });
+
+      it('expands scope only names to full', () => {
+        result = pluginIdentifier('@user').full;
+        expect(result).toBe('@user/gasket-plugin');
       });
 
       it('expands multi-word plugin names to full', () => {

--- a/packages/gasket-resolve/test/package-identifier.instance.test.js
+++ b/packages/gasket-resolve/test/package-identifier.instance.test.js
@@ -57,6 +57,16 @@ describe('PackageIdentifier instance', () => {
         expect(result).toBe('@user/gasket-plugin-p');
       });
 
+      it('expands scope with no name to full', () => {
+        result = pluginIdentifier('@user/gasket-plugin').fullName;
+        expect(result).toBe('@user/gasket-plugin');
+      });
+
+      it('expands scope only names to full', () => {
+        result = pluginIdentifier('@user').fullName;
+        expect(result).toBe('@user/gasket-plugin');
+      });
+
       it('expands multi-word plugin names to full', () => {
         result = pluginIdentifier('@user/another-example').fullName;
         expect(result).toBe('@user/gasket-plugin-another-example');

--- a/packages/gasket-resolve/test/package-identifier.test.js
+++ b/packages/gasket-resolve/test/package-identifier.test.js
@@ -192,6 +192,10 @@ describe('expandMaker', () => {
       expect(expand('@user/example')).toEqual('@user/gasket-plugin-example');
     });
 
+    it('expands user scope-only short name', () => {
+      expect(expand('@user')).toEqual('@user/gasket-plugin');
+    });
+
     it('expands user short name', () => {
       expect(expand('example')).toEqual('gasket-plugin-example');
     });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

This uses `packageIdentifiers` for handling name parsing of eslint and stylelint configs in the lint plugin. Also, this expands support of scope-only identifiers, i.e. `@scope -> @scope/eslint-config` as [supported by eslint](https://eslint.org/docs/developer-guide/shareable-configs#npm-scoped-modules), which can now also be used with Gasket presets and plugins, i.e. `@scope -> @scope/gasket-preset`.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/resolve**

- Expose `projectIdentifier` with support for scope-only package short names

**@gasket/plugin-lint**

- Add support for scope-only package short names with eslint configs.

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Additional unit tests