### PR TITLE
Fix missing await

### DIFF
--- a/packages/gasket-plugin-intl/CHANGELOG.md
+++ b/packages/gasket-plugin-intl/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-intl`
 
+- Fixed missing `await` when saving locales-manifest.json file ([#144])
+
 ### 5.0.0
 
 - Open Source Release
@@ -59,3 +61,7 @@
 ### 1.0.0
 
 - Initial release.
+
+<!-- LINK -->
+
+[#144]: https://github.com/godaddy/gasket/pull/144

--- a/packages/gasket-plugin-intl/lib/builder.js
+++ b/packages/gasket-plugin-intl/lib/builder.js
@@ -227,7 +227,7 @@ class Builder {
       await this.processFiles(srcDir, tgtDir, fileNames);
     }
 
-    fsUtils.saveJsonFile(this._mapFile, this.builderMap);
+    await fsUtils.saveJsonFile(this._mapFile, this.builderMap);
 
     this._logger.log(`build:locales: Completed locale files update.`);
   }

--- a/packages/gasket-plugin-intl/lib/builder.spec.js
+++ b/packages/gasket-plugin-intl/lib/builder.spec.js
@@ -203,7 +203,7 @@ describe('Builder', function () {
         fs.mkdirp = jest.fn().mockReturnValue(Promise.resolve());
         fs.readdir = jest.fn().mockResolvedValue(['test/folder/name.json']);
         fs.readJson = jest.fn().mockResolvedValue({ name: 'bogus-package' });
-        fsUtils.saveJsonFile = jest.fn().mockReturnValue(Promise.resolve());
+        fsUtils.saveJsonFile = jest.fn().mockResolvedValue();
         builder.processFiles = jest.fn();
       });
 
@@ -215,6 +215,12 @@ describe('Builder', function () {
       it('saves locales manifest file', async function () {
         await builder.processDirs(buildDirs);
         expect(fsUtils.saveJsonFile).toHaveBeenCalledWith(expect.stringContaining('locales-manifest.json'), expect.any(Object));
+      });
+
+      it('throws if failure to write locales manifest file', function () {
+        const mockError = new Error('Bad things man');
+        fsUtils.saveJsonFile = jest.fn().mockRejectedValue(mockError);
+        return expect(builder.processDirs(buildDirs)).rejects.toBe(mockError);
       });
     });
 

--- a/packages/gasket-plugin-intl/lib/builder.spec.js
+++ b/packages/gasket-plugin-intl/lib/builder.spec.js
@@ -203,12 +203,18 @@ describe('Builder', function () {
         fs.mkdirp = jest.fn().mockReturnValue(Promise.resolve());
         fs.readdir = jest.fn().mockResolvedValue(['test/folder/name.json']);
         fs.readJson = jest.fn().mockResolvedValue({ name: 'bogus-package' });
+        fsUtils.saveJsonFile = jest.fn().mockReturnValue(Promise.resolve());
         builder.processFiles = jest.fn();
       });
 
       it('calls processFiles for each directory', async function () {
         await builder.processDirs(buildDirs);
         expect(builder.processFiles.mock.calls).toHaveLength(2);
+      });
+
+      it('saves locales manifest file', async function () {
+        await builder.processDirs(buildDirs);
+        expect(fsUtils.saveJsonFile).toHaveBeenCalledWith(expect.stringContaining('locales-manifest.json'), expect.any(Object));
       });
     });
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

There was a strange race condition when using `gasket local` in an app with both intl and service-worker plugins. Tracked it down to this missing await.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

- Fixed missing await when saving `locales-manifest.json` file

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Added unit test. Integration test in repro app with `npm link`.