### PR TITLE
Adjustment to local http fallback w/o config

### DIFF
--- a/packages/gasket-plugin-https/test/index.test.js
+++ b/packages/gasket-plugin-https/test/index.test.js
@@ -31,7 +31,6 @@ describe('Plugin', () => {
 
   it('has expected hooks', () => {
     const expected = [
-      'create',
       'start',
       'metadata'
     ];
@@ -41,37 +40,6 @@ describe('Plugin', () => {
     const hooks = Object.keys(plugin.hooks);
     assume(hooks).eqls(expected);
     assume(hooks).is.length(expected.length);
-  });
-});
-
-describe('create hook', () => {
-  let mockContext, pkgAddStub;
-
-  async function create() {
-    return plugin.hooks.create({}, mockContext);
-  }
-
-  beforeEach(() => {
-    pkgAddStub = sinon.stub();
-
-    mockContext = {
-      gasketConfig: {
-        add: pkgAddStub
-      }
-    };
-  });
-
-  it('is an async function', function () {
-    assume(create).to.be.an('asyncfunction');
-  });
-
-  it('adds the expected http port for local development', async function () {
-    await create();
-    assume(pkgAddStub).calledWithMatch('environments', {
-      local: {
-        http: 8080
-      }
-    });
   });
 });
 
@@ -134,6 +102,31 @@ describe('start hook', () => {
 
     const createServerOpts = createServersModule.lastCall.args[0];
     assume(createServerOpts).property('http', 80);
+    assume(createServerOpts).not.property('https');
+  });
+
+  it('defaults HTTP server to port 8080 if env is local', async () => {
+    gasketAPI.config = {
+      env: 'local'
+    };
+
+    await start();
+
+    const createServerOpts = createServersModule.lastCall.args[0];
+    assume(createServerOpts).property('http', 8080);
+    assume(createServerOpts).not.property('https');
+  });
+
+  it('does not defaults HTTP port if configured', async () => {
+    gasketAPI.config = {
+      env: 'local',
+      http: 1234
+    };
+
+    await start();
+
+    const createServerOpts = createServersModule.lastCall.args[0];
+    assume(createServerOpts).property('http', 1234);
     assume(createServerOpts).not.property('https');
   });
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Having boilerplate user config generated for http in the local env, introduced in https://github.com/godaddy/gasket/pull/130, causes issues for user plugins which set a default http if not configured by the user. This moves the default check to after the lifecycle. This returns the fallback priority back to `gasket.config > lifecycle > https plugin default`.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

- Set http fallbacks after createServer lifecycle

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Unit tests
- `npm link` into existing app
