### PR TITLE
Support for forcing a dependency range

### DIFF
--- a/packages/gasket-cli/src/scaffold/actions/create-hooks.js
+++ b/packages/gasket-cli/src/scaffold/actions/create-hooks.js
@@ -11,10 +11,10 @@ const Files = require('../files');
  * @returns {Promise} promise
  */
 async function createHooks(context) {
-  const { dest, presets = [], plugins = [] } = context;
+  const { dest, presets = [], plugins = [], warnings } = context;
 
   const files = new Files();
-  const gasketConfig = ConfigBuilder.create({}, { orderBy: ['plugins'] });
+  const gasketConfig = ConfigBuilder.create({}, { orderBy: ['plugins'], warnings });
   Object.assign(context, { files, gasketConfig });
 
   const gasket = await createEngine({ dest, presets, plugins });

--- a/packages/gasket-cli/src/scaffold/actions/load-pkg-for-debug.js
+++ b/packages/gasket-cli/src/scaffold/actions/load-pkg-for-debug.js
@@ -12,13 +12,13 @@ const ConfigBuilder = require('../config-builder');
  * @returns {Promise} promise
  */
 async function loadPkForDebug(context) {
-  const { dest } = context;
+  const { dest, warnings } = context;
 
   const filePath = path.join(dest, 'package.json');
 
   const contents = await readFile(filePath, 'utf8');
   const fields = JSON.parse(contents);
-  const pkg = ConfigBuilder.createPackageJson(fields);
+  const pkg = ConfigBuilder.createPackageJson(fields, { warnings });
 
   Object.assign(context, { pkg });
 }

--- a/packages/gasket-cli/src/scaffold/actions/setup-pkg.js
+++ b/packages/gasket-cli/src/scaffold/actions/setup-pkg.js
@@ -11,13 +11,13 @@ const { presetIdentifier } = require('@gasket/resolve');
  * @returns {Promise} promise
  */
 async function setupPkg(context) {
-  const { appName, appDescription, presetInfos = [], rawPlugins = [], cliVersionRequired } = context;
+  const { appName, appDescription, presetInfos = [], rawPlugins = [], cliVersionRequired, warnings } = context;
 
   const pkg = ConfigBuilder.createPackageJson({
     name: appName,
     version: '0.0.0',
     description: appDescription
-  });
+  }, { warnings });
 
   // The preset package itself must be included in the dependencies
   // of the `pkg` to be bootstrapped.

--- a/packages/gasket-cli/src/scaffold/create-context.js
+++ b/packages/gasket-cli/src/scaffold/create-context.js
@@ -29,8 +29,8 @@ function makeCreateRuntime(context, source) {
         context.pkg.extend(fields, source);
       },
 
-      add(key, value) {
-        context.pkg.add(key, value, source);
+      add(key, value, options) {
+        context.pkg.add(key, value, source, options);
       },
 
       has(key, value) {

--- a/packages/gasket-cli/test/unit/scaffold/config-builder.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/config-builder.test.js
@@ -1,8 +1,8 @@
 /* eslint-disable max-statements */
 
 const assume = require('assume');
-const stdMocks = require('std-mocks');
-const PackageJson = require('../../../src/scaffold/config-builder');
+const sinon = require('sinon');
+const ConfigBuilder = require('../../../src/scaffold/config-builder');
 
 const pluginOne = {
   name: 'gasket-plugin-one'
@@ -11,11 +11,17 @@ const pluginTwo = {
   name: 'gasket-plugin-two'
 };
 
-describe('PackageJson', () => {
-  let pkg;
+describe('ConfigBuilder', () => {
+  let pkg, warnSpy, consoleWarnStub;
 
   beforeEach(() => {
-    pkg = PackageJson.createPackageJson();
+    pkg = ConfigBuilder.createPackageJson();
+    warnSpy = sinon.spy(pkg, 'warn');
+    consoleWarnStub = sinon.spy(console, 'warn');
+  });
+
+  afterEach(() => {
+    consoleWarnStub.restore();
   });
 
   describe('.add(key, value)', () => {
@@ -153,89 +159,64 @@ describe('PackageJson', () => {
       assume(pkg.fields.dependencies).eqls({ 'some-pkg': '^1.2.0' });
     });
 
-    it('[semver] displays a warning when older range conflicts', () => {
+    it('[semver] warns when older range conflicts', () => {
       pkg.add('dependencies', { 'some-pkg': '^2.2.0' }, pluginOne);
       assume(pkg.fields.dependencies).eqls({ 'some-pkg': '^2.2.0' });
 
-      // Grab stdout
-      stdMocks.use();
       pkg.add('dependencies', { 'some-pkg': '^1.0.0' }, pluginTwo);
-      stdMocks.restore();
-      const actual = stdMocks.flush();
-      const [stderr] = actual.stderr;
 
-      assume(stderr).includes('Conflicting versions for some-pkg in "dependencies"');
-      assume(stderr).includes(`^2.2.0 provided by ${pluginOne.name}`);
-      assume(stderr).includes(`^1.0.0 provided by ${pluginTwo.name}`);
-      assume(stderr).includes('Using ^2.2.0, but');
+      assume(warnSpy).calledWithMatch('Conflicting versions for some-pkg in "dependencies"');
+      assume(warnSpy).calledWithMatch(`^2.2.0 provided by ${pluginOne.name}`);
+      assume(warnSpy).calledWithMatch(`^1.0.0 provided by ${pluginTwo.name}`);
+      assume(warnSpy).calledWithMatch('Using ^2.2.0, but');
     });
 
-    it('[semver] displays a warning when newer range conflicts', () => {
+    it('[semver] warns when newer range conflicts', () => {
       pkg.add('dependencies', { 'some-pkg': '^1.2.0' }, pluginOne);
       assume(pkg.fields.dependencies).eqls({ 'some-pkg': '^1.2.0' });
 
-      // Grab stdout
-      stdMocks.use();
       pkg.add('dependencies', { 'some-pkg': '^2.0.0' }, pluginTwo);
-      stdMocks.restore();
-      const actual = stdMocks.flush();
-      const [stderr] = actual.stderr;
 
-      assume(stderr).includes('Conflicting versions for some-pkg in "dependencies"');
-      assume(stderr).includes(`^1.2.0 provided by ${pluginOne.name}`);
-      assume(stderr).includes(`^2.0.0 provided by ${pluginTwo.name}`);
-      assume(stderr).includes('Using ^2.0.0, but');
+      assume(warnSpy).calledWithMatch('Conflicting versions for some-pkg in "dependencies"');
+      assume(warnSpy).calledWithMatch(`^1.2.0 provided by ${pluginOne.name}`);
+      assume(warnSpy).calledWithMatch(`^2.0.0 provided by ${pluginTwo.name}`);
+      assume(warnSpy).calledWithMatch('Using ^2.0.0, but');
     });
 
-    it('[semver] displays a warning when previously forced range conflicts', () => {
+    it('[semver] warns when previously forced range conflicts', () => {
       pkg.add('dependencies', { 'some-pkg': '^1.2.0' }, pluginOne, { force: true });
       assume(pkg.fields.dependencies).eqls({ 'some-pkg': '^1.2.0' });
 
-      // Grab stdout
-      stdMocks.use();
       pkg.add('dependencies', { 'some-pkg': '^2.0.0' }, pluginTwo);
-      stdMocks.restore();
-      const actual = stdMocks.flush();
-      const [stderr] = actual.stderr;
 
-      assume(stderr).includes('Conflicting versions for some-pkg in "dependencies"');
-      assume(stderr).includes(`^1.2.0 provided by ${pluginOne.name} (forced)`);
-      assume(stderr).includes(`^2.0.0 provided by ${pluginTwo.name}`);
-      assume(stderr).includes('Using ^1.2.0, but');
+      assume(warnSpy).calledWithMatch('Conflicting versions for some-pkg in "dependencies"');
+      assume(warnSpy).calledWithMatch(`^1.2.0 provided by ${pluginOne.name} (forced)`);
+      assume(warnSpy).calledWithMatch(`^2.0.0 provided by ${pluginTwo.name}`);
+      assume(warnSpy).calledWithMatch('Using ^1.2.0, but');
     });
 
-    it('[semver] displays a warning when forced range conflicts', () => {
+    it('[semver] warns when forced range conflicts', () => {
       pkg.add('dependencies', { 'some-pkg': '^2.0.0' }, pluginOne);
       assume(pkg.fields.dependencies).eqls({ 'some-pkg': '^2.0.0' });
 
-      // Grab stdout
-      stdMocks.use();
       pkg.add('dependencies', { 'some-pkg': '^1.2.0' }, pluginTwo, { force: true });
-      stdMocks.restore();
-      const actual = stdMocks.flush();
-      const [stderr] = actual.stderr;
 
-      assume(stderr).includes('Conflicting versions for some-pkg in "dependencies"');
-      assume(stderr).includes(`^2.0.0 provided by ${pluginOne.name}`);
-      assume(stderr).includes(`^1.2.0 provided by ${pluginTwo.name} (forced)`);
-      assume(stderr).includes('Using ^1.2.0, but');
+      assume(warnSpy).calledWithMatch('Conflicting versions for some-pkg in "dependencies"');
+      assume(warnSpy).calledWithMatch(`^2.0.0 provided by ${pluginOne.name}`);
+      assume(warnSpy).calledWithMatch(`^1.2.0 provided by ${pluginTwo.name} (forced)`);
+      assume(warnSpy).calledWithMatch('Using ^1.2.0, but');
     });
 
-    it('[semver] displays a warning when attempted re-force range conflicts', () => {
+    it('[semver] warns when attempted re-force range conflicts', () => {
       pkg.add('dependencies', { 'some-pkg': '^2.0.0' }, pluginOne, { force: true });
       assume(pkg.fields.dependencies).eqls({ 'some-pkg': '^2.0.0' });
 
-      // Grab stdout
-      stdMocks.use();
       pkg.add('dependencies', { 'some-pkg': '^1.2.0' }, pluginTwo, { force: true });
-      stdMocks.restore();
-      const actual = stdMocks.flush();
-      const [stderr] = actual.stderr;
 
-      assume(stderr).includes('Conflicting versions for some-pkg in "dependencies"');
-      assume(stderr).includes(`^2.0.0 provided by ${pluginOne.name} (forced)`);
-      assume(stderr).includes(`^1.2.0 provided by ${pluginTwo.name} (cannot be forced)`);
-      assume(stderr).includes('Using ^2.0.0, but');
+      assume(warnSpy).calledWithMatch('Conflicting versions for some-pkg in "dependencies"');
+      assume(warnSpy).calledWithMatch(`^2.0.0 provided by ${pluginOne.name} (forced)`);
+      assume(warnSpy).calledWithMatch(`^1.2.0 provided by ${pluginTwo.name} (cannot be forced)`);
+      assume(warnSpy).calledWithMatch('Using ^2.0.0, but');
     });
 
     it('[array] adds new fields', () => {
@@ -486,6 +467,35 @@ describe('PackageJson', () => {
         devDependencies: {},
         whatever: 'ok'
       });
+    });
+  });
+
+  describe('.warn(message)', () => {
+    let warnings;
+
+    beforeEach(() => {
+      warnings = [];
+    });
+
+    it('logs to console if no warnings array in options', () => {
+      pkg.add('dependencies', { 'some-pkg': '^2.2.0' }, pluginOne);
+      pkg.add('dependencies', { 'some-pkg': '^1.0.0' }, pluginTwo);
+
+      assume(warnSpy).called();
+      assume(consoleWarnStub).called();
+      assume(warnings).lengthOf(0);
+    });
+
+    it('adds to warnings array if exists instead of console', () => {
+      pkg = ConfigBuilder.createPackageJson({}, { warnings });
+      warnSpy = sinon.spy(pkg, 'warn');
+
+      pkg.add('dependencies', { 'some-pkg': '^2.2.0' }, pluginOne);
+      pkg.add('dependencies', { 'some-pkg': '^1.0.0' }, pluginTwo);
+
+      assume(warnSpy).called();
+      assume(consoleWarnStub).not.called();
+      assume(warnings).lengthOf(1);
     });
   });
 });

--- a/packages/gasket-cli/test/unit/scaffold/create-context.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/create-context.test.js
@@ -101,6 +101,17 @@ describe('CreateRuntime', () => {
     );
   });
 
+  it('passes through options for context.pkg.add', () => {
+    const mockOptions = { bogus: true };
+    runtime.pkg.add('name', 'legitimate-use-for-proxy', mockOptions);
+    assume(pkgAddStub).is.calledWithMatch(
+      'name',
+      'legitimate-use-for-proxy',
+      mockPlugin,
+      mockOptions
+    );
+  });
+
   it('invokes context.pkg.extend with source plugin', () => {
     const extension = { name: 'legitimate-use-for-proxy' };
     runtime.pkg.extend(extension);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Currently, if multiple plugins try to add dependencies on a package at differing versions, the newest is preferred. In some (hopefully rare) situations, it may be necessary for teams to force a particular dependency version, or older version, to be installed. This PR introduces options to `pkg.add` for the **create** lifecycle, allowing `force: true` to be set. If two or more plugins try to force a version, the first in wins.

Additionally, conflict warnings were output directly to the console. This PR also changes these warnings to be captured and outputted in the print report step and error log dump.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

- Support force option with `pkg.add`
- Output semver warnings with print report

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
- Additional unit tests.
- Local integration test using `gasket create` with `--npm-link`.
  Example output:
```
✨Success!
  
Finished with 1 warnings and 0 errors using
    _____         __       __
   / ___/__ ____ / /_____ / /_
  / (_ / _ `(_-</  '_/ -_) __/
  \___/\_,_/___/_/\_\\__/\__/


App Name
  some-app

Output
  /projects/debug/some-app

Plugins
  @gasket/mocha

Generated Files
  .babelrc
  .npmrc
  README.md
  components/head.js
  gasket.config.js
  locales/en-US.json
  locales/manifest.xml
  package.json
  pages/_app.js
  pages/_document.js
  pages/index.js
  store.js
  styles/_app.scss
  test/pages/index.test.js

Messages
  
Thank you for using Gasket!

Warnings
  
  Conflicting versions for react-intl in "dependencies":
    - ^2.9.0 provided by @some/gasket-plugin-example (forced)
    - ^3.9.1 provided by @gasket/plugin-intl 
    Using ^2.9.0, but this may cause unexpected behavior.
```