### PR TITLE
Add more accurate desc of redux client-side of config

### DIFF
--- a/packages/gasket-plugin-config/README.md
+++ b/packages/gasket-plugin-config/README.md
@@ -149,8 +149,8 @@ module.exports = {
 
 If you need access to config values in client-side code, this can be done
 through your redux store. The config plugin looks for a `redux` property of your
-configuration in `app.config.js` and places it under a `config` reducer in your initial redux
-state. Example below appears in `config` reducer in client-side code
+configuration in `app.config.js` and places it under a `config` property in your initial redux
+state. Example below can selected from `state.config.url` in client-side code
 
 ```js
 module.exports = {

--- a/packages/gasket-plugin-config/README.md
+++ b/packages/gasket-plugin-config/README.md
@@ -149,8 +149,25 @@ module.exports = {
 
 If you need access to config values in client-side code, this can be done
 through your redux store. The config plugin looks for a `redux` property of your
-configuration and places it under a `config` property in your initial redux
-state.
+configuration in `app.config.js` and places it under a `config` reducer in your initial redux
+state. Example below appears in `config` reducer in client-side code
+
+```js
+module.exports = {
+  environments: {
+    dev: {
+      redux: {
+        url: 'https://your-dev-service-endpoint.com'
+      }
+    },
+    test: {
+      redux: {
+        url: 'https://your-test-service-endpoint.com'
+      }
+    }
+  }
+};
+```
 
 ## Lifecycles
 


### PR DESCRIPTION
## Summary

There is some difference between example of client-side redux reducer injection of config env and same for gasket non-run time and server-side example. I fixed it
