### PR TITLE
Allow context to set packageManager without overriding installCmd or localCmd

### DIFF
--- a/packages/gasket-cli/src/scaffold/actions/global-prompts.js
+++ b/packages/gasket-cli/src/scaffold/actions/global-prompts.js
@@ -32,7 +32,7 @@ async function chooseAppDescription(context) {
  */
 async function choosePackageManager(context) {
   const packageManager = context.packageManager ||
-    await inquirer.prompt([
+    (await inquirer.prompt([
       {
         name: 'packageManager',
         message: 'Which packager would you like to use?',
@@ -41,7 +41,7 @@ async function choosePackageManager(context) {
           { name: 'npm' },
           { name: 'yarn' }
         ]
-      }]).packageManager;
+      }])).packageManager;
 
   const installCmd = context.installCmd || `${packageManager} install`;
 

--- a/packages/gasket-cli/src/scaffold/actions/global-prompts.js
+++ b/packages/gasket-cli/src/scaffold/actions/global-prompts.js
@@ -31,8 +31,8 @@ async function chooseAppDescription(context) {
  * @returns {Promise} promise
  */
 async function choosePackageManager(context) {
-  if (!context.packageManager) {
-    const { packageManager } = await inquirer.prompt([
+  const packageManager = context.packageManager ||
+    await inquirer.prompt([
       {
         name: 'packageManager',
         message: 'Which packager would you like to use?',
@@ -41,19 +41,22 @@ async function choosePackageManager(context) {
           { name: 'npm' },
           { name: 'yarn' }
         ]
-      }]);
+      }]).packageManager;
 
-    const runners = {
-      npm: 'npx',
-      yarn: 'yarn'
-    };
+  const installCmd = context.installCmd || `${packageManager} install`;
 
-    Object.assign(context, {
-      packageManager,
-      installCmd: `${packageManager} install`,
-      localCmd: `${runners[packageManager]} gasket local`
-    });
-  }
+  const runners = {
+    npm: 'npx',
+    yarn: 'yarn'
+  };
+
+  const localCmd = context.localCmd || `${runners[packageManager]} gasket local`;
+
+  Object.assign(context, {
+    packageManager,
+    installCmd,
+    localCmd
+  });
 }
 
 /**

--- a/packages/gasket-cli/test/unit/scaffold/actions/global-prompts.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/global-prompts.test.js
@@ -84,6 +84,13 @@ describe('globalPrompts', () => {
 
         assume(mockContext).property('installCmd', `${manager} install`);
       });
+
+      it(`[${manager}] sets package manager commands in context even when packageManager is already set in context`, async () => {
+        mockContext.packageManager = manager;
+        await choosePackageManager(mockContext);
+
+        assume(mockContext).property('installCmd', `${manager} install`);
+      });
     });
   });
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

When setting a default `packageManager` in the `createContext` of a new plugin, the `installCmd` and `localCmd` values never get set, which lead to the Readme.md looking something like this:

Now start up the app.

```bash
cd process-manager-ui




```

## Changelog

Allow `createContext` to set `packageManager` without overriding `installCmd` or `localCmd`

## Test Plan

Added unit tests that fail without the code changes.  Totally open to finding a better way of testing locally with an actual `gasket create`
