### PR TITLE
Unique names for anonymous plugins

### DIFF
--- a/packages/gasket-resolve/CHANGELOG.md
+++ b/packages/gasket-resolve/CHANGELOG.md
@@ -1,6 +1,6 @@
 # `@gasket/resolve`
 
-- Generate unique names for anonymous plugins and presets
+- Validate that plugin objects are named
 
 ### 5.1.0
 

--- a/packages/gasket-resolve/CHANGELOG.md
+++ b/packages/gasket-resolve/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/resolve`
 
+- Generate unique names for anonymous plugins and presets
+
 ### 5.1.0
 
 - Expose projectIdentifier with support for scope-only package short names ([#142])

--- a/packages/gasket-resolve/lib/loader.js
+++ b/packages/gasket-resolve/lib/loader.js
@@ -101,6 +101,10 @@ class Loader extends Resolver {
   loadPlugin(module, meta = {}) {
     // If the provide plugin is an already required module, just gather info.
     if (typeof module !== 'string') {
+      if (typeof module.name !== 'string') {
+        throw new Error('Plugin object must have a string `name` property.');
+      }
+
       const moduleName = pluginIdentifier(module.name).fullName;
       return this.getModuleInfo(module, moduleName, { ...meta, preloaded: true });
     }

--- a/packages/gasket-resolve/lib/package-identifier.js
+++ b/packages/gasket-resolve/lib/package-identifier.js
@@ -123,14 +123,7 @@ function projectIdentifier(projectName, type = 'plugin') {
       throw new Error('Package name must be supplied. See the @gasket/resolve documentation for naming conventions: https://github.com/godaddy/gasket/tree/master/packages/gasket-resolve#naming-convention');
     }
 
-    let parsedName, parsedVersion;
-
-    if (rawName) {
-      [, parsedName, parsedVersion] = reName.exec(rawName);
-    } else {
-      parsedName = `anonymous${anonymousId++}`;
-      parsedVersion = '';
-    }
+    const [, parsedName, parsedVersion] = reName.exec(rawName);
 
     /**
      * * Setup package level variables

--- a/packages/gasket-resolve/lib/package-identifier.js
+++ b/packages/gasket-resolve/lib/package-identifier.js
@@ -107,8 +107,6 @@ function projectIdentifier(projectName, type = 'plugin') {
   //
   const projectVars = setupProjectVars();
 
-  let anonymousId = 1;
-
   /**
    * Create a new PackageIdentifier instance
    *
@@ -120,6 +118,10 @@ function projectIdentifier(projectName, type = 'plugin') {
    * @returns {PackageIdentifier} instance
    */
   function createPackageIdentifier(rawName, options) {
+    if (!rawName) {
+      // eslint-disable-next-line max-len
+      throw new Error('Package name must be supplied. See the @gasket/resolve documentation for naming conventions: https://github.com/godaddy/gasket/tree/master/packages/gasket-resolve#naming-convention');
+    }
 
     let parsedName, parsedVersion;
 

--- a/packages/gasket-resolve/lib/package-identifier.js
+++ b/packages/gasket-resolve/lib/package-identifier.js
@@ -107,6 +107,8 @@ function projectIdentifier(projectName, type = 'plugin') {
   //
   const projectVars = setupProjectVars();
 
+  let anonymousId = 1;
+
   /**
    * Create a new PackageIdentifier instance
    *
@@ -119,7 +121,14 @@ function projectIdentifier(projectName, type = 'plugin') {
    */
   function createPackageIdentifier(rawName, options) {
 
-    const [, parsedName, parsedVersion] = reName.exec(rawName);
+    let parsedName, parsedVersion;
+
+    if (rawName) {
+      [, parsedName, parsedVersion] = reName.exec(rawName);
+    } else {
+      parsedName = `anonymous${anonymousId++}`;
+      parsedVersion = '';
+    }
 
     /**
      * * Setup package level variables

--- a/packages/gasket-resolve/test/identifiers.test.js
+++ b/packages/gasket-resolve/test/identifiers.test.js
@@ -20,6 +20,12 @@ describe('pluginIdentifier', () => {
     result = pluginIdentifier('example').fullName;
     expect(result).toContain('gasket');
   });
+
+  it('generates unique names for anonymous plugins', () => {
+    const name1 = pluginIdentifier().fullName;
+    const name2 = pluginIdentifier().fullName;
+    expect(name1).not.toEqual(name2);
+  });
 });
 
 describe('presetIdentifier', () => {

--- a/packages/gasket-resolve/test/identifiers.test.js
+++ b/packages/gasket-resolve/test/identifiers.test.js
@@ -21,10 +21,8 @@ describe('pluginIdentifier', () => {
     expect(result).toContain('gasket');
   });
 
-  it('generates unique names for anonymous plugins', () => {
-    const name1 = pluginIdentifier().fullName;
-    const name2 = pluginIdentifier().fullName;
-    expect(name1).not.toEqual(name2);
+  it('requires the supplied name to be a string', () => {
+    expect(pluginIdentifier).toThrow(Error);
   });
 });
 

--- a/packages/gasket-resolve/test/loader.test.js
+++ b/packages/gasket-resolve/test/loader.test.js
@@ -233,10 +233,9 @@ describe('Loader', () => {
       }));
     });
 
-    it('generates unique names for nameless plugin objects', () => {
-      const plugin1 = loader.loadPlugin({ hooks: { foo: () => { } } });
-      const plugin2 = loader.loadPlugin({ hooks: { bar: () => { } } });
-      expect(plugin1.name).not.toEqual(plugin2.name);
+    it('throws if a plugin object does not have a name', () => {
+      const plugin = { hooks: { foo: () => { } } };
+      expect(() => loader.loadPlugin(plugin)).toThrow(Error);
     });
   });
 
@@ -389,8 +388,8 @@ describe('Loader', () => {
     });
 
     it('loads configured plugins', () => {
-      const objectPlugin1 = { hooks: { foo: () => { } } };
-      const objectPlugin2 = { hooks: { bar: () => { } } };
+      const objectPlugin1 = { name: 'a', hooks: { foo: () => { } } };
+      const objectPlugin2 = { name: 'b', hooks: { bar: () => { } } };
       const config = {
         add: ['@gasket/plugin-one', objectPlugin1, objectPlugin2]
       };

--- a/packages/gasket-resolve/test/loader.test.js
+++ b/packages/gasket-resolve/test/loader.test.js
@@ -232,6 +232,12 @@ describe('Loader', () => {
         preloaded: true
       }));
     });
+
+    it('generates unique names for nameless plugin objects', () => {
+      const plugin1 = loader.loadPlugin({ hooks: { foo: () => { } } });
+      const plugin2 = loader.loadPlugin({ hooks: { bar: () => { } } });
+      expect(plugin1.name).not.toEqual(plugin2.name);
+    });
   });
 
   describe('.loadPreset', () => {
@@ -383,14 +389,22 @@ describe('Loader', () => {
     });
 
     it('loads configured plugins', () => {
+      const objectPlugin1 = { hooks: { foo: () => { } } };
+      const objectPlugin2 = { hooks: { bar: () => { } } };
       const config = {
-        add: ['@gasket/plugin-one']
+        add: ['@gasket/plugin-one', objectPlugin1, objectPlugin2]
       };
       const results = loader.loadConfigured(config);
       expect(results.plugins).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             module: pluginOne
+          }),
+          expect.objectContaining({
+            module: objectPlugin1
+          }),
+          expect.objectContaining({
+            module: objectPlugin2
           })
         ])
       );

--- a/packages/gasket-resolve/test/package-identifier.test.js
+++ b/packages/gasket-resolve/test/package-identifier.test.js
@@ -256,6 +256,13 @@ describe('projectIdentifier', () => {
     expect(result).toContain(type);
   });
 
+  it('generates unique names for anonymous entities', () => {
+    const identifier = projectIdentifier('gasket', 'plugin');
+    const name1 = identifier().fullName;
+    const name2 = identifier().fullName;
+    expect(name1).not.toEqual(name2);
+  });
+
   describe('isValidFullName', () => {
     const packageIdentifier = projectIdentifier('gasket');
 

--- a/packages/gasket-resolve/test/package-identifier.test.js
+++ b/packages/gasket-resolve/test/package-identifier.test.js
@@ -256,11 +256,9 @@ describe('projectIdentifier', () => {
     expect(result).toContain(type);
   });
 
-  it('generates unique names for anonymous entities', () => {
+  it('throws if a name is not provided', () => {
     const identifier = projectIdentifier('gasket', 'plugin');
-    const name1 = identifier().fullName;
-    const name2 = identifier().fullName;
-    expect(name1).not.toEqual(name2);
+    expect(identifier).toThrow(Error);
   });
 
   describe('isValidFullName', () => {


### PR DESCRIPTION
## Summary

I'm building a framework with `@gasket/engine`. When setting up the engine, I used the `plugins.add` array in the config, passing in plugin _objects_. Strangely, only the _first_ plugin did anything when invoking a hooked lifecycle. It turned out that this is because of how `@gasket/resolve` processes plugin objects. It requires unique names. If a `name` property is missing, it creates the name `gasket-plugin-undefined`. Therefore, if two plugins are missing a name property, they're given this same name. Then `@gasket/resolve` discards the "duplicate" silently.

It seems like a less surprising behavior that would have saved me tons of head scratching would have been to either:

1. Throw an error if a plugin is unnamed (I actually thought I was naming them, but I erroneously used an `id` property)
2. Allow unnamed plugins by assigning them distinct names.

I went with the nicer option 2, since IMO naming plugins if you don't care to refer to them in other contexts seems pointless, but option 1 is reasonable if we don't want to go my route.

## Changelog

- Generate unique names for anonymous plugins and presets

## Test Plan

Created unit tests that exercised the problem and demonstrate the fix.
