### PR TITLE
Fix app plugins on Windows

### DIFF
--- a/packages/gasket-cli/src/config/utils.js
+++ b/packages/gasket-cli/src/config/utils.js
@@ -77,13 +77,13 @@ function addDefaultPlugins(gasketConfig) {
  */
 async function addUserPlugins(gasketConfig) {
   try {
-    const pluginsDir = path.join(gasketConfig.root, './plugins');
+    const pluginsDir = path.join(gasketConfig.root, 'plugins');
     const files = await readDir(pluginsDir);
     const moduleNames = files
       .filter(fileName => jsExtension.test(fileName))
       .map(fileName => {
         const fileSansExtension = fileName.replace(jsExtension, '');
-        return path.join(pluginsDir, `./${fileSansExtension}`);
+        return path.join(pluginsDir, fileSansExtension);
       });
 
     const pluginsConfig = gasketConfig.plugins || {};

--- a/packages/gasket-engine/lib/engine.js
+++ b/packages/gasket-engine/lib/engine.js
@@ -1,7 +1,7 @@
 const { Loader, pluginIdentifier } = require('@gasket/resolve');
 
 let dynamicNamingId = 0;
-const isModulePath = /^[/.]/;
+const isModulePath = /^[/.]|^[a-zA-Z]:\\/;
 
 class PluginEngine {
   constructor(config, { resolveFrom } = {}) {

--- a/packages/gasket-engine/test/constructor.test.js
+++ b/packages/gasket-engine/test/constructor.test.js
@@ -101,10 +101,23 @@ describe('constructor', () => {
       expect(engine._plugins).toHaveProperty('some-local', mockPlugin.module);
     });
 
+    it('plugins loaded from paths use name from module (windows)', () => {
+      mockPlugin.name = 'C:\\\\path\\to\\some-local-plugin';
+      mockPlugin.module.name = 'some-local';
+      const engine = new PluginEngine(mockConfig);
+      expect(engine._plugins).toHaveProperty('some-local', mockPlugin.module);
+    });
+
     it('plugins loaded from paths fallback to path if name not in module', () => {
       mockPlugin.name = '/path/to/some-local-plugin';
       const engine = new PluginEngine(mockConfig);
       expect(engine._plugins).toHaveProperty('/path/to/some-local-plugin', mockPlugin.module);
+    });
+
+    it('plugins loaded from paths fallback to path if name not in module (windows)', () => {
+      mockPlugin.name = 'C:\\\\path\\to\\some-local-plugin';
+      const engine = new PluginEngine(mockConfig);
+      expect(engine._plugins).toHaveProperty('C:\\\\path\\to\\some-local-plugin', mockPlugin.module);
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

On Windows, app-level plugins were not being loaded correctly to due faulty module path check. This PR fixes this in the engine. Also, it cleans up some unnecessary `./` for paths found in the code flow.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/engine**
- Fix module path check regex to support Windows paths.

**@gasket/cli**
- Cleanup unnecessary `./` in path joins

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Added unit tests