### PR TITLE
updating cross-fetch to 3.0.4

### DIFF
--- a/packages/gasket-fetch/CHANGELOG.md
+++ b/packages/gasket-fetch/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 5.0.3
+
+- Updating version of cross-fetch to 3.0.4 
+
 ### 5.0.0
 
 - Open Source Release

--- a/packages/gasket-fetch/package.json
+++ b/packages/gasket-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasket/fetch",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Gasket Fetch API",
   "main": "./index.js",
   "repository": {
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/godaddy/gasket/tree/master/packages/gasket-fetch#readme",
   "dependencies": {
-    "cross-fetch": "^2.1.1"
+    "cross-fetch": "^3.0.4"
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Updating the version of cross-fetch to 3.0.4. The current version of cross fetch is 2.1.1 and this doesn't support fetch's integration with signal.abort for creating a configurable request timeout. Here is some documentation that explains this method of aborting and the "special" fetch integration: https://javascript.info/fetch-abort

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

CHANGELOG updated with:

- Updating the version of cross-fetch to 3.0.4

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

Version update, if this section applies I can come up with something.

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
