### PR TITLE
first draft of starter pack

### DIFF
--- a/packages/create-gasket-app/.gitignore
+++ b/packages/create-gasket-app/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/create-gasket-app/README.md
+++ b/packages/create-gasket-app/README.md
@@ -1,0 +1,31 @@
+# create-gasket-app
+
+Starter Pack for creating Gasket apps. 
+
+### Get Started Immediately
+
+You **don’t** need to install gasket-cli tools
+
+To create a new app, you may choose one of the following methods:
+
+### npx
+
+```sh
+npx create-gasket-app my-app
+```
+
+### npm
+
+```sh
+npm init gasket-app my-app
+```
+
+### Yarn
+
+```sh
+yarn create gasket-app my-app
+```
+
+## License
+
+[MIT](./LICENSE.md)

--- a/packages/create-gasket-app/README.md
+++ b/packages/create-gasket-app/README.md
@@ -4,7 +4,7 @@ Starter Pack for creating Gasket apps.
 
 ### Get Started Immediately
 
-You **don’t** need to install gasket-cli tools
+You **don’t** need to globally install the Gasket CLI
 
 To create a new app, you may choose one of the following methods:
 

--- a/packages/create-gasket-app/index.js
+++ b/packages/create-gasket-app/index.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+const { fork } = require('child_process');
+
+const [,, ...args] = process.argv;
+
+function main() {
+  return fork(path.join(__dirname, 'node_modules', '.bin', 'gasket'), [...['create'], args], {stdio: 'inherit', stdin: 'inherit', stderr: 'inherit'});
+}
+main();

--- a/packages/create-gasket-app/index.js
+++ b/packages/create-gasket-app/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const { fork } = require('child_process');
+const path = require('path');
 
 const [,, ...args] = process.argv;
 

--- a/packages/create-gasket-app/package.json
+++ b/packages/create-gasket-app/package.json
@@ -10,7 +10,7 @@
   "bin": {
     "create-gasket-app": "./index.js"
   },
-  "author": "",
+  "author": "GoDaddy Operating Company, LLC",
   "license": "ISC",
   "dependencies": {
     "@gasket/cli": "^5.3.4"

--- a/packages/create-gasket-app/package.json
+++ b/packages/create-gasket-app/package.json
@@ -4,7 +4,7 @@
   "description": "starter pack for creating a gasket app",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"no test specified\" && exit 0",
     "init": "./index.js"
   },
   "bin": {

--- a/packages/create-gasket-app/package.json
+++ b/packages/create-gasket-app/package.json
@@ -11,7 +11,7 @@
     "create-gasket-app": "./index.js"
   },
   "author": "GoDaddy Operating Company, LLC",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@gasket/cli": "^5.3.4"
   }

--- a/packages/create-gasket-app/package.json
+++ b/packages/create-gasket-app/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "create-gasket-app",
+  "version": "1.0.0",
+  "description": "starter pack for creating a gasket app",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "init": "./index.js"
+  },
+  "bin": {
+    "create-gasket-app": "./index.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@gasket/cli": "^5.3.4"
+  }
+}

--- a/packages/gasket-plugin-nextjs/package.json
+++ b/packages/gasket-plugin-nextjs/package.json
@@ -8,8 +8,8 @@
     "lint:fix": "npm run lint -- --fix",
     "test": "npm run test:runner",
     "test:runner": "mocha --require ./setup.js \"test/**/*.test.js\"",
-    "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",
     "test:watch": "npm run test:runner -- --watch",
+    "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",
     "posttest": "npm run lint",
     "report": "nyc report --reporter=lcov"
   },


### PR DESCRIPTION
Goal is to reduce the barrier to entry for users of the framework by not requiring @gasket/cli to be globally installed. Using yarn create, npm init, or npx, a user can skip the global install and simply use one of these commands to spin up a gasket app.