### PR TITLE
Do Not Autoload Test Files in Lifecycle Plugin

### DIFF
--- a/packages/gasket-plugin-lifecycle/index.js
+++ b/packages/gasket-plugin-lifecycle/index.js
@@ -26,7 +26,7 @@ async function resolve(root, name) {
     }
   }
 
-  const reg = /.*^((?!(test|spec).js).)*\.js$/;
+  const reg = /.*^((?!(\.test|\.spec).js).)*\.js$/;
   return files.filter(function filter(file) {
     return !!reg.exec(file);
   }).map(function each(file) {

--- a/packages/gasket-plugin-lifecycle/index.js
+++ b/packages/gasket-plugin-lifecycle/index.js
@@ -26,27 +26,27 @@ async function resolve(root, name) {
     }
   }
 
-  const reg = /.*^((?!(\.test|\.spec).js).)*\.js$/;
-  return files.filter(function filter(file) {
-    return !!reg.exec(file);
-  }).map(function each(file) {
-    const extname = path.extname(file);
-    const event = camelCase(path.basename(file, extname));
+  const isJs = /\.js$/i;
+  const isTest = /\.(spec|test)\./i;
+  return files.filter(file => isJs.test(file) && !isTest.test(file))
+    .map(function each(file) {
+      const extname = path.extname(file);
+      const event = camelCase(path.basename(file, extname));
 
-    let hook = require(path.join(dir, file));
-    debug('found %s as lifecycle for %s', file, event);
+      let hook = require(path.join(dir, file));
+      debug('found %s as lifecycle for %s', file, event);
 
-    if (typeof hook === 'function') {
-      hook = {
-        handler: hook
+      if (typeof hook === 'function') {
+        hook = {
+          handler: hook
+        };
+      }
+
+      return {
+        pluginName: file,
+        event,
+        ...hook
       };
-    }
-
-    return {
-      pluginName: file,
-      event,
-      ...hook
-    };
   });
 }
 

--- a/packages/gasket-plugin-lifecycle/index.js
+++ b/packages/gasket-plugin-lifecycle/index.js
@@ -27,7 +27,8 @@ async function resolve(root, name) {
   }
 
   return files.filter(function filter(file) {
-    return path.extname(file) === '.js';
+    const reg = /.*^((?!(test|spec).js).)*\.js$/;
+    return !!reg.exec(file);
   }).map(function each(file) {
     const extname = path.extname(file);
     const event = camelCase(path.basename(file, extname));

--- a/packages/gasket-plugin-lifecycle/index.js
+++ b/packages/gasket-plugin-lifecycle/index.js
@@ -26,8 +26,8 @@ async function resolve(root, name) {
     }
   }
 
+  const reg = /.*^((?!(test|spec).js).)*\.js$/;
   return files.filter(function filter(file) {
-    const reg = /.*^((?!(test|spec).js).)*\.js$/;
     return !!reg.exec(file);
   }).map(function each(file) {
     const extname = path.extname(file);

--- a/packages/gasket-plugin-lifecycle/test/fixtures/with-tests/lifecycles/some-event.spec.js
+++ b/packages/gasket-plugin-lifecycle/test/fixtures/with-tests/lifecycles/some-event.spec.js
@@ -1,0 +1,5 @@
+const proxy = require('../../../proxy');
+
+module.exports = (...args) => {
+  proxy.emit('someEvent', ...args);
+};

--- a/packages/gasket-plugin-lifecycle/test/fixtures/with-tests/lifecycles/some-event.test.js
+++ b/packages/gasket-plugin-lifecycle/test/fixtures/with-tests/lifecycles/some-event.test.js
@@ -1,0 +1,5 @@
+const proxy = require('../../../proxy');
+
+module.exports = (...args) => {
+  proxy.emit('someEvent', ...args);
+};

--- a/packages/gasket-plugin-lifecycle/test/plugin.test.js
+++ b/packages/gasket-plugin-lifecycle/test/plugin.test.js
@@ -101,4 +101,23 @@ describe('Plugin', function () {
     await engine.exec('someEvent', 'testing');
     assume(called).is.true();
   });
+
+  it('skips *.test.js and *.spec.js files', async () => {
+    const engine = new PluginEngine({
+      root: path.join(__dirname, './fixtures/with-tests'),
+      plugins: {
+        add: [plugin]
+      }
+    });
+    await engine.exec('init');
+
+    let called = false;
+    proxy.once('someEvent', function () {
+      called = true;
+    });
+
+    await engine.exec('someEvent', 'testing');
+    assume(called).is.false();
+
+  });
 });


### PR DESCRIPTION
## Summary

Keeping test files in the lifecycle folder was causing them to be autoloaded. This PR filters out `*.spec.js` and `*.test.js` files allowing them to be kept alongside their corresponding modules.

## Changelog

- Updated Lifecycle plugin filter function
- Added addition tests

## Test Plan

Added basic unit tests for `some-event.test.js` and `some-event.spec.js`


Results of testing some basic file names.
```
express.js -> true
app.express.js ->  true
express.test.js ->  false
app.express.test.js ->  false
express.spec.js ->  false
app.express.spec.js ->  false
test.md ->  false
test.js ->  true
spec.js ->  true
test.asd.js ->  true
test.spec.js ->  false
index.html ->  false
special.js ->  true
special.spec.js ->  false
respec.js ->  true
asdftest.js ->  true
```
