### PR TITLE
Lookup version for plugins if not set

### DIFF
--- a/packages/gasket-cli/src/scaffold/actions/prompt-hooks.js
+++ b/packages/gasket-cli/src/scaffold/actions/prompt-hooks.js
@@ -1,7 +1,6 @@
 const inquirer = require('inquirer');
 const action = require('../action-wrapper');
-const { addPluginsToContext, addPluginsToPkg } = require('../utils');
-const { pluginIdentifier } = require('@gasket/resolve');
+const { addPluginsToContext, addPluginsToPkg, getPluginsWithVersions } = require('../utils');
 const createEngine = require('../create-engine');
 
 /**
@@ -23,12 +22,12 @@ const createAddPlugins = context => {
     const { pkg, pkgLinks = [], pkgManager } = context;
 
     addPluginsToContext(pluginsToAdd, context);
-    addPluginsToPkg(pluginsToAdd, pkg);
+    const pluginIds = await getPluginsWithVersions(pluginsToAdd, pkgManager);
+    addPluginsToPkg(pluginIds, pkg);
 
     //
     // Install new plugins if not already linked
     //
-    const pluginIds = pluginsToAdd.map(p => pluginIdentifier(p).withVersion());
     const toInstall = pluginIds.filter(p => !pkgLinks.includes(p.fullName));
     if (toInstall.length) {
       await pkgManager.install(toInstall.map(p => p.full));

--- a/packages/gasket-cli/src/scaffold/actions/setup-pkg.js
+++ b/packages/gasket-cli/src/scaffold/actions/setup-pkg.js
@@ -1,6 +1,6 @@
 const action = require('../action-wrapper');
 const ConfigBuilder = require('../config-builder');
-const { addPluginsToPkg } = require('../utils');
+const { addPluginsToPkg, getPluginsWithVersions } = require('../utils');
 const { PackageManager } = require('@gasket/utils');
 const { presetIdentifier } = require('@gasket/resolve');
 
@@ -31,9 +31,10 @@ async function setupPkg(context) {
   }, {
     '@gasket/cli': cliVersionRequired
   }));
-  addPluginsToPkg(rawPlugins, pkg);
 
   const pkgManager = new PackageManager(context);
+  const pluginIds = await getPluginsWithVersions(rawPlugins, pkgManager);
+  addPluginsToPkg(pluginIds, pkg);
 
   Object.assign(context, { pkg, pkgManager });
 }

--- a/packages/gasket-cli/src/scaffold/utils.js
+++ b/packages/gasket-cli/src/scaffold/utils.js
@@ -42,7 +42,7 @@ function addPluginsToContext(plugins, context) {
 /**
  * Adds plugins and dependencies of the app package
  *
- * @param {PluginDesc[]} plugins - Plugins names
+ * @param {PluginDesc[]|pluginIdentifier[]} plugins - Plugins names
  * @param {PackageJson} pkg - Package builder
  * @param {String} [field] - Dependency type (Default: dependencies)
  */
@@ -54,6 +54,24 @@ function addPluginsToPkg(plugins, pkg, field = 'dependencies') {
     }
     return acc;
   }, {}));
+}
+
+/**
+ * Look up registry version of provided plugin descriptions w/o versions set.
+ *
+ * @param {PluginDesc[]|pluginIdentifier[]} plugins - Plugins names
+ * @param {PackageManager} pkgManager - Package manager instance
+ * @returns {Promise<pluginIdentifier[]>} plugins
+ */
+async function getPluginsWithVersions(plugins, pkgManager) {
+  return await Promise.all(
+    plugins.map(async name => {
+      const id = pluginIdentifier(name);
+      if (id.version !== null) return id;
+      const version = (await pkgManager.info([id.fullName, 'version'])).data;
+      return id.withVersion(`^${version}`);
+    })
+  );
 }
 
 /**
@@ -94,6 +112,7 @@ function ensureAbsolute(filepath) {
 module.exports = {
   addPluginsToContext,
   addPluginsToPkg,
+  getPluginsWithVersions,
   flattenPresets,
   ensureAbsolute
 };

--- a/packages/gasket-cli/test/unit/scaffold/actions/load-preset.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/load-preset.test.js
@@ -209,7 +209,8 @@ describe('loadPreset', () => {
       ...mockPkgs['@gasket/preset-bogus@^1.0.0'],
       from: 'cli',
       rawName: '@gasket/preset-bogus@^1.0.0',
-      presets: [{ package: { name: '@gasket/preset-some', version: '1.0.1' }, from: '@gasket/preset-bogus', rawName: '@gasket/preset-some@1.0.1' }]
+      presets: [{ package: { name: '@gasket/preset-some', version: '1.0.1' },
+        from: '@gasket/preset-bogus', rawName: '@gasket/preset-some@1.0.1' }]
     }]);
   });
 });

--- a/packages/gasket-cli/test/unit/scaffold/actions/prompt-hooks.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/prompt-hooks.test.js
@@ -27,7 +27,8 @@ describe('promptHooks', () => {
       }),
       pkgManager: {
         install: installStub,
-        link: linkStub
+        link: linkStub,
+        info: sinon.stub().callsFake(() => ({ data: '7.8.9-faked' }))
       }
     };
 
@@ -86,7 +87,7 @@ describe('promptHooks', () => {
 
     it('adds new plugins to pkg', async () => {
       await mockAddPlugins('@gasket/plugin-jest');
-      assume(pkgAddSpy).is.calledWith('dependencies', { '@gasket/plugin-jest': 'latest' });
+      assume(pkgAddSpy).is.calledWith('dependencies', { '@gasket/plugin-jest': '^7.8.9-faked' });
     });
 
     it('adds new plugins to pkg with version', async () => {

--- a/packages/gasket-cli/test/unit/scaffold/actions/setup-pkg.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/setup-pkg.test.js
@@ -15,6 +15,10 @@ describe('setupPkg', () => {
 
     class PackageManager {
       constructor() {}
+
+      info() {
+        return { data: '7.8.9-faked' };
+      }
     }
 
     mockImports = {
@@ -90,7 +94,7 @@ describe('setupPkg', () => {
     mockContext.rawPlugins = ['@gasket/jest@1.2.3', 'gasket-plugin-custom'];
     await setupPkg.wrapped(mockContext);
     assume(mockContext.pkg.fields.dependencies).property('@gasket/plugin-jest', '1.2.3');
-    assume(mockContext.pkg.fields.dependencies).property('gasket-plugin-custom', 'latest');
+    assume(mockContext.pkg.fields.dependencies).property('gasket-plugin-custom', '^7.8.9-faked');
   });
 
   it('adds pkg to context', async () => {

--- a/packages/gasket-cli/test/unit/scaffold/create-context.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/create-context.test.js
@@ -232,13 +232,19 @@ describe('makeCreateContext', () => {
 
   it('sets plugins short names from flags', () => {
     results =
-      makeCreateContext(argv, { plugins: ['@gasket/jest@^1.2.3', 'gasket-plugin-some-user', '@gasket/plugin-intl'], presets: ['@gasket/nextjs'] });
+      makeCreateContext(argv, {
+        plugins: ['@gasket/jest@^1.2.3', 'gasket-plugin-some-user', '@gasket/plugin-intl'],
+        presets: ['@gasket/nextjs']
+      });
     assume(results.plugins).eqls(['@gasket/jest', 'some-user', '@gasket/intl']);
   });
 
   it('sets rawPlugins from flags', () => {
     results =
-      makeCreateContext(argv, { plugins: ['@gasket/jest@^1.2.3', 'gasket-plugin-some-user', '@gasket/plugin-intl'], presets: ['@gasket/nextjs'] });
+      makeCreateContext(argv, {
+        plugins: ['@gasket/jest@^1.2.3', 'gasket-plugin-some-user', '@gasket/plugin-intl'],
+        presets: ['@gasket/nextjs']
+      });
     assume(results.rawPlugins).eqls(['@gasket/jest@^1.2.3', 'gasket-plugin-some-user', '@gasket/plugin-intl']);
   });
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

During the create command, when plugins added via `--plugins` flag without the version specified, they were being installed with the version set to `'latest'`. Same with the test plugins from the prompt. Having the version as `'latest'` causes issues when using `npm ci` combined with `npm prune --production` as [documented here](https://npm.community/t/npm-prune-production-after-npm-ci-only-erroneously-uninstalls-regular-dependency/5055).

Since the CLI is installing these modules anyway during create, this PR uses the package manager to look up the actual "latest" and set the version in the pakage.json accordingly.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/cli**
- Look up and install the latest version of a plugin if not set

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Updated units tests
- Tested locally:
  ```shell
  > path/to/local/gasket/packages/gasket-cli/bin/run create my-app --plugins @gasket/workbox
  > cat my-app/package.json | jq .dependencies
  # {
  #   "@gasket/cli": "^5.6.0",
  #   "@gasket/plugin-jest": "^5.6.0",
  #   "@gasket/plugin-workbox": "^5.6.0"
  # }
  ```