### PR TITLE
[minor] add middie plugin

### DIFF
--- a/packages/gasket-plugin-fastify/CHANGELOG.md
+++ b/packages/gasket-plugin-fastify/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `@gasket/plugin-fastify`
 
+Enable middleware support
+- Add `middie@5` as dependency
+- Register `middie` to enable Fastify middleware
+
 ### 5.0.0
 
 - Open Source Release

--- a/packages/gasket-plugin-fastify/index.js
+++ b/packages/gasket-plugin-fastify/index.js
@@ -34,9 +34,9 @@ module.exports = {
       const cookieParser = require('cookie-parser');
       const compression = require('compression');
 
-      const { config } = gasket;
+      const { logger, config } = gasket;
       const excludedRoutesRegex = config.fastify && config.fastify.excludedRoutesRegex;
-      const app = fastify();
+      const app = fastify({ logger });
 
       // Enable middleware for fastify@3
       await app.register(middie);
@@ -71,7 +71,10 @@ module.exports = {
 
       return {
         ...serverOpts,
-        handler: app
+        handler: async function handler(...args) {
+          await app.ready();
+          app.server.emit('request', ...args);
+        }
       };
     },
     metadata(gasket, meta) {

--- a/packages/gasket-plugin-fastify/index.js
+++ b/packages/gasket-plugin-fastify/index.js
@@ -30,12 +30,16 @@ module.exports = {
     // eslint-disable-next-line max-statements
     createServers: async function createServers(gasket, serverOpts) {
       const fastify = require('fastify');
+      const middie = require('middie');
       const cookieParser = require('cookie-parser');
       const compression = require('compression');
 
       const { config } = gasket;
       const excludedRoutesRegex = config.fastify && config.fastify.excludedRoutesRegex;
       const app = fastify();
+
+      // Enable middleware for fastify@3
+      await app.register(middie);
 
       if (excludedRoutesRegex) {
         app.use(excludedRoutesRegex, cookieParser());

--- a/packages/gasket-plugin-fastify/package.json
+++ b/packages/gasket-plugin-fastify/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "compression": "^1.7.2",
     "cookie-parser": "^1.4.3",
-    "diagnostics": "^2.0.2"
+    "diagnostics": "^2.0.2",
+    "middie": "5.1.0"
   },
   "devDependencies": {
     "assume": "^2.2.0",
@@ -46,13 +47,13 @@
     "eslint-config-godaddy": "^4.0.0",
     "eslint-plugin-json": "^1.4.0",
     "eslint-plugin-mocha": "^6.0.0",
-    "fastify": "^2.10.0",
+    "fastify": "^3.3.0",
     "mocha": "^6.2.0",
     "nyc": "^14.1.1",
     "proxyquire": "^2.1.3",
     "sinon": "^7.4.1"
   },
   "peerDependencies": {
-    "fastify": "^2.10.0"
+    "fastify": "^3.0.0"
   }
 }

--- a/packages/gasket-plugin-fastify/test/plugin.test.js
+++ b/packages/gasket-plugin-fastify/test/plugin.test.js
@@ -110,7 +110,6 @@ describe('createServers', () => {
     assume(app.register).to.have.been.calledWith(middie);
   });
 
-
   it('adds the cookie-parser middleware before plugin middleware', async () => {
     await plugin.hooks.createServers(gasket, {});
 

--- a/packages/gasket-plugin-fastify/test/plugin.test.js
+++ b/packages/gasket-plugin-fastify/test/plugin.test.js
@@ -1,9 +1,13 @@
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const assume = require('assume');
+const middie = require('middie');
 const version = require('../package.json').peerDependencies.fastify;
 
-const app = { use: sinon.spy() };
+const app = {
+  register: sinon.spy(),
+  use: sinon.spy()
+};
 const fastify = sinon.stub().returns(app);
 
 const cookieParserMiddleware = sinon.spy();
@@ -99,6 +103,13 @@ describe('createServers', () => {
       (mw) => mw === errorMiddlewares[0]);
     assume(errorMiddleware).to.not.be.null();
   });
+
+  it('registers the middie middleware plugin', async () => {
+    await plugin.hooks.createServers(gasket, {});
+
+    assume(app.register).to.have.been.calledWith(middie);
+  });
+
 
   it('adds the cookie-parser middleware before plugin middleware', async () => {
     await plugin.hooks.createServers(gasket, {});


### PR DESCRIPTION
Release as new major `6` and no longer support `fastify@<3` for new apps. 

![image](https://user-images.githubusercontent.com/670951/92606332-1b575f00-f2b3-11ea-8387-dc531774922a.png)

## Summary

`Fastify@3` requires middleware to be enabled first through a plugin. Register [middie](https://github.com/fastify/middie) to enable middleware. 

## Changelog

✅ 

## Test Plan

New unit test added
