### PR TITLE
Replace cross-fetch with local polyfill and ponyfill for node

### DIFF
--- a/packages/gasket-fetch/.babelrc.json
+++ b/packages/gasket-fetch/.babelrc.json
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "@babel/preset-env"
+  ],
+  "plugins": [
+    "@babel/plugin-transform-runtime"
+  ]
+}

--- a/packages/gasket-fetch/.mocharc.yaml
+++ b/packages/gasket-fetch/.mocharc.yaml
@@ -1,0 +1,3 @@
+require:
+  - 'regenerator-runtime'
+  - '@babel/register'

--- a/packages/gasket-fetch/CHANGELOG.md
+++ b/packages/gasket-fetch/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### ...
+
+- Replace cross-fetch with native implementation.
+
 ### 5.6.0
 
 - Updating version of cross-fetch to 3.0.4 ([#164])

--- a/packages/gasket-fetch/browser.js
+++ b/packages/gasket-fetch/browser.js
@@ -1,0 +1,9 @@
+
+exports = window.fetch; // To import fetch from @gasket/fetch
+exports.default = window.fetch; // For TypeScript consumers without esModuleInterop.
+exports.fetch = window.fetch; // To import {fetch} from @gasket/fetch
+exports.Headers = window.Headers;
+exports.Request = window.Request;
+exports.Response = window.Response;
+
+module.exports = exports;

--- a/packages/gasket-fetch/browser.js
+++ b/packages/gasket-fetch/browser.js
@@ -1,7 +1,6 @@
 
 exports = window.fetch; // To import fetch from @gasket/fetch
 exports.default = window.fetch; // For TypeScript consumers without esModuleInterop.
-exports.fetch = window.fetch; // To import {fetch} from @gasket/fetch
 exports.Headers = window.Headers;
 exports.Request = window.Request;
 exports.Response = window.Response;

--- a/packages/gasket-fetch/browser.js
+++ b/packages/gasket-fetch/browser.js
@@ -5,5 +5,6 @@ exports.fetch = window.fetch; // To import {fetch} from @gasket/fetch
 exports.Headers = window.Headers;
 exports.Request = window.Request;
 exports.Response = window.Response;
+exports.AbortController = window.AbortController;
 
 module.exports = exports;

--- a/packages/gasket-fetch/index.js
+++ b/packages/gasket-fetch/index.js
@@ -1,1 +1,0 @@
-module.exports = require('cross-fetch');

--- a/packages/gasket-fetch/node.js
+++ b/packages/gasket-fetch/node.js
@@ -1,0 +1,2 @@
+const fetch = require('node-fetch');
+module.exports = fetch;

--- a/packages/gasket-fetch/node.js
+++ b/packages/gasket-fetch/node.js
@@ -1,2 +1,3 @@
 const fetch = require('node-fetch');
+fetch.AbortController = require('abort-controller');
 module.exports = fetch;

--- a/packages/gasket-fetch/package.json
+++ b/packages/gasket-fetch/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/godaddy/gasket/tree/master/packages/gasket-fetch#readme",
   "dependencies": {
+    "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {}

--- a/packages/gasket-fetch/package.json
+++ b/packages/gasket-fetch/package.json
@@ -9,6 +9,7 @@
     "lint:fix": "npm run lint -- --fix",
     "test": "npm run test:runner",
     "test:runner": "mocha test/*.spec.js --require test/setup.js",
+    "test:server": "mocha test/server.spec.js",
     "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",
     "posttest": "npm run lint"
   },

--- a/packages/gasket-fetch/package.json
+++ b/packages/gasket-fetch/package.json
@@ -4,6 +4,10 @@
   "description": "Gasket Fetch API",
   "main": "./node.js",
   "browser": "./browser.js",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "npm run lint -- --fix"
+  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/godaddy/gasket.git"
@@ -28,5 +32,15 @@
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "eslint": "^6.1.0",
+    "eslint-config-godaddy": "^4.0.0",
+    "eslint-plugin-json": "^1.4.0",
+    "eslint-plugin-mocha": "^6.0.0"
+  },
+  "eslintConfig": {
+    "extends": [
+      "godaddy"
+    ]
+  }
 }

--- a/packages/gasket-fetch/package.json
+++ b/packages/gasket-fetch/package.json
@@ -4,7 +4,6 @@
   "description": "Gasket Fetch API",
   "main": "./node.js",
   "browser": "./browser.js",
-  "react-native": "./react-native.js",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/godaddy/gasket.git"

--- a/packages/gasket-fetch/package.json
+++ b/packages/gasket-fetch/package.json
@@ -6,7 +6,10 @@
   "browser": "./browser.js",
   "scripts": {
     "lint": "eslint .",
-    "lint:fix": "npm run lint -- --fix"
+    "lint:fix": "npm run lint -- --fix",
+    "test": "npm run test:runner",
+    "test:runner": "mocha test/*.test.js --require test/setup.js",
+    "posttest": "npm run lint"
   },
   "repository": {
     "type": "git",
@@ -33,10 +36,16 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
+    "assume": "^2.2.0",
+    "assume-sinon": "^1.0.1",
+    "chai": "^4.2.0",
     "eslint": "^6.1.0",
     "eslint-config-godaddy": "^4.0.0",
     "eslint-plugin-json": "^1.4.0",
-    "eslint-plugin-mocha": "^6.0.0"
+    "eslint-plugin-mocha": "^6.0.0",
+    "mocha": "^6.2.0",
+    "proxyquire": "^2.1.3",
+    "sinon": "^7.4.1"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/gasket-fetch/package.json
+++ b/packages/gasket-fetch/package.json
@@ -2,7 +2,6 @@
   "name": "@gasket/fetch",
   "version": "6.0.0-canary.0",
   "description": "Gasket Fetch API",
-  "main": "./index.js",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/godaddy/gasket.git"
@@ -23,7 +22,5 @@
     "url": "https://github.com/godaddy/gasket/issues"
   },
   "homepage": "https://github.com/godaddy/gasket/tree/master/packages/gasket-fetch#readme",
-  "dependencies": {
-    "cross-fetch": "^3.0.4"
-  }
+  "dependencies": {}
 }

--- a/packages/gasket-fetch/package.json
+++ b/packages/gasket-fetch/package.json
@@ -25,8 +25,8 @@
     "url": "https://github.com/godaddy/gasket/issues"
   },
   "homepage": "https://github.com/godaddy/gasket/tree/master/packages/gasket-fetch#readme",
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "node-fetch": "^2.6.1"
-  }
+  },
+  "devDependencies": {}
 }

--- a/packages/gasket-fetch/package.json
+++ b/packages/gasket-fetch/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "test": "npm run test:runner",
-    "test:runner": "mocha test/*.spec.js --require test/setup.js",
+    "test:runner": "npm run test:server && npm run test:browser",
     "test:server": "mocha --require core-js test/server.spec.js",
     "test:browser": "mocha --require setup-env test/browser.spec.js",
     "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",

--- a/packages/gasket-fetch/package.json
+++ b/packages/gasket-fetch/package.json
@@ -9,7 +9,8 @@
     "lint:fix": "npm run lint -- --fix",
     "test": "npm run test:runner",
     "test:runner": "mocha test/*.spec.js --require test/setup.js",
-    "test:server": "mocha test/server.spec.js",
+    "test:server": "mocha --require core-js test/server.spec.js",
+    "test:browser": "mocha --require setup-env test/browser.spec.js",
     "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",
     "posttest": "npm run lint"
   },
@@ -38,17 +39,27 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.11.6",
+    "@babel/preset-env": "^7.11.5",
+    "@babel/register": "^7.11.5",
+    "@babel/plugin-transform-runtime": "^7.5.5",
     "assume": "^2.2.0",
     "assume-sinon": "^1.0.1",
     "chai": "^4.2.0",
-    "eslint": "^6.1.0",
+    "core-js": "^3.6.5",
+    "eslint": "^6.2.1",
     "eslint-config-godaddy": "^4.0.0",
     "eslint-plugin-json": "^1.4.0",
-    "eslint-plugin-mocha": "^6.0.0",
+    "eslint-plugin-mocha": "^6.1.0",
+    "jsdom": "16.4.0",
+    "jsdom-global": "3.0.2",
     "mocha": "^6.2.0",
+    "nyc": "^14.1.1",
     "proxyquire": "^2.1.3",
+    "regenerator-runtime": "^0.13.7",
     "sinon": "^7.4.1",
-    "nyc": "^14.1.1"
+    "setup-env": "^1.2.2",
+    "whatwg-fetch": "^3.0.0"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/gasket-fetch/package.json
+++ b/packages/gasket-fetch/package.json
@@ -2,6 +2,9 @@
   "name": "@gasket/fetch",
   "version": "6.0.0-canary.0",
   "description": "Gasket Fetch API",
+  "main": "./node.js",
+  "browser": "./browser.js",
+  "react-native": "./react-native.js",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/godaddy/gasket.git"
@@ -22,5 +25,8 @@
     "url": "https://github.com/godaddy/gasket/issues"
   },
   "homepage": "https://github.com/godaddy/gasket/tree/master/packages/gasket-fetch#readme",
-  "dependencies": {}
+  "dependencies": {},
+  "devDependencies": {
+    "node-fetch": "^2.6.1"
+  }
 }

--- a/packages/gasket-fetch/package.json
+++ b/packages/gasket-fetch/package.json
@@ -8,7 +8,8 @@
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "test": "npm run test:runner",
-    "test:runner": "mocha test/*.test.js --require test/setup.js",
+    "test:runner": "mocha test/*.spec.js --require test/setup.js",
+    "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",
     "posttest": "npm run lint"
   },
   "repository": {
@@ -45,11 +46,15 @@
     "eslint-plugin-mocha": "^6.0.0",
     "mocha": "^6.2.0",
     "proxyquire": "^2.1.3",
-    "sinon": "^7.4.1"
+    "sinon": "^7.4.1",
+    "nyc": "^14.1.1"
   },
   "eslintConfig": {
     "extends": [
       "godaddy"
     ]
-  }
+  },
+  "eslintIgnore": [
+    "coverage"
+  ]
 }

--- a/packages/gasket-fetch/react-native.js
+++ b/packages/gasket-fetch/react-native.js
@@ -1,9 +1,0 @@
-
-exports = global.fetch; // To import fetch from @gasket/fetch
-exports.default = global.fetch; // For TypeScript consumers without esModuleInterop.
-exports.fetch = global.fetch; // To import {fetch} from @gasket/fetch
-exports.Headers = global.Headers;
-exports.Request = global.Request;
-exports.Response = global.Response;
-
-module.exports = exports;

--- a/packages/gasket-fetch/react-native.js
+++ b/packages/gasket-fetch/react-native.js
@@ -1,0 +1,9 @@
+
+exports = global.fetch; // To import fetch from @gasket/fetch
+exports.default = global.fetch; // For TypeScript consumers without esModuleInterop.
+exports.fetch = global.fetch; // To import {fetch} from @gasket/fetch
+exports.Headers = global.Headers;
+exports.Request = global.Request;
+exports.Response = global.Response;
+
+module.exports = exports;

--- a/packages/gasket-fetch/test/browser.spec.js
+++ b/packages/gasket-fetch/test/browser.spec.js
@@ -1,7 +1,8 @@
 import 'whatwg-fetch';
 import { describe, it } from 'mocha';
 
-import fetch, { AbortController, Request, Headers, Response } from '../browser';
+import fetch from '../browser';
+const { AbortController, Request, Headers, Response } = fetch;
 import { assertExports, assertGet, assertAbort, assertPost } from './utils';
 
 describe('fetch is available in browsers', function () {

--- a/packages/gasket-fetch/test/browser.spec.js
+++ b/packages/gasket-fetch/test/browser.spec.js
@@ -1,0 +1,12 @@
+import 'whatwg-fetch';
+import { describe, it } from 'mocha';
+
+import fetch, { AbortController, Request, Headers, Response } from '../browser';
+import { assertExports, assertGet, assertAbort, assertPost } from './utils';
+
+describe('fetch is available in browsers', function () {
+  it('exposes default classes', assertExports(Request, Headers, Response));
+  it('can fetch resources', assertGet(fetch));
+  it('fetch can POST to API', assertPost(fetch));
+  it('can abort fetch', assertAbort(fetch, AbortController));
+});

--- a/packages/gasket-fetch/test/server.spec.js
+++ b/packages/gasket-fetch/test/server.spec.js
@@ -1,0 +1,13 @@
+const { describe, it } = require('mocha');
+
+const fetch = require('../node');
+import { assertExports, assertGet, assertAbort, assertPost } from './utils';
+
+const { AbortController, Request, Headers, Response } = fetch;
+
+describe('fetch is available in Node.JS', function () {
+  it('exposes default classes', assertExports(Request, Headers, Response));
+  it('can fetch resources', assertGet(fetch));
+  it('fetch can POST to API', assertPost(fetch));
+  it('can abort fetch', assertAbort(fetch, AbortController));
+});

--- a/packages/gasket-fetch/test/test-server.js
+++ b/packages/gasket-fetch/test/test-server.js
@@ -1,0 +1,22 @@
+import http from 'http';
+
+export const createServer = () => {
+  return http.createServer((req, res) => {
+    const chunks = [];
+
+    req.on('data', chunk => chunks.push(chunk));
+    req.on('end',  () => {
+      res.writeHead(200, {
+        'content-type': 'application/json',
+        'cache-control': 'max-age=0, no-cache, no-store',
+        'access-control-allow-origin': '*'
+      });
+
+      res.end(JSON.stringify({ echo: JSON.parse(chunks.join()) }));
+    });
+  });
+};
+
+export const closeServer = (server) => {
+  server.close();
+};

--- a/packages/gasket-fetch/test/utils.js
+++ b/packages/gasket-fetch/test/utils.js
@@ -102,7 +102,7 @@ function assertPost(fetch) {
 function assertAbort(fetch, AbortController) {
   return async () => {
     const controller = new AbortController();
-    const timeout = setTimeout(controller.abort.bind(controller), 20);
+    const timeout = setTimeout(controller.abort.bind(controller), 10);
     let res;
 
     try {

--- a/packages/gasket-fetch/test/utils.js
+++ b/packages/gasket-fetch/test/utils.js
@@ -1,0 +1,125 @@
+import assume from 'assume';
+import { createServer, closeServer } from './test-server';
+
+const port = 9090;
+const domain = 'testing-fetch.com';
+const API = {
+  POST: `http://localhost:${ port }`,
+  GET: 'https://jsonplaceholder.typicode.com/todos/1'
+};
+
+/**
+ * Assert fetch API compliant classes.
+ *
+ * @param {Function} Request constructor for Request class.
+ * @param {Function} Headers constructor for Headers class.
+ * @param {Function} Response constructor for Response class.
+ * @returns {Function} runnable test descriptor.
+ * @public
+ */
+function assertExports(Request, Headers, Response) {
+  return () => {
+    [Request, Headers, Response].forEach(className => assume(className).to.be.a('function'));
+    const req = new Request(API.GET, { method: 'GET' });
+    const res = new Response();
+    const headers = new Headers([['Content-Type', 'text/xml']]);
+
+    assume(req).be.instanceof(Request);
+    assume(res).be.instanceof(Response);
+    assume(res.ok).to.equal(true);
+    assume(res.status).to.equal(200);
+    assume(headers).be.instanceof(Headers);
+    assume(headers.get('Content-Type')).to.equal('text/xml');
+  };
+}
+
+/**
+ * Assert fetch API executing GET request.
+ *
+ * @async
+ * @param {Function} fetch implementation of fetch.
+ * @returns {Function} runnable test descriptor.
+ * @public
+ */
+function assertGet(fetch) {
+  return async () => {
+    const res = await fetch(API.GET);
+    const body = await res.json();
+    const headers = res.headers;
+
+    assume(res.ok).to.be.true();
+    assume(res.status).to.equal(200);
+    assume(headers.get('content-type')).to.equal('application/json; charset=utf-8');
+    assume(body.id).equals(1);
+  };
+}
+
+/**
+ * Assert fetch API executing POST request.
+ *
+ * @async
+ * @param {Function} fetch implementation of fetch.
+ * @returns {Function} runnable test descriptor.
+ * @public
+ */
+function assertPost(fetch) {
+  return async () => {
+    const server = createServer();
+    server.listen(port, async () => {
+      try {
+        const res = await fetch(API.POST, {
+          method: 'POST',
+          body: JSON.stringify([domain])
+        });
+
+        const body = await res.json();
+        const headers = res.headers;
+        assume(res.ok).to.be.true();
+        assume(res.status).to.equal(200);
+        assume(headers.get('content-type')).to.equal('application/json');
+        assume(headers.get('cache-control')).to.equal('max-age=0, no-cache, no-store');
+        assume(body).to.deep.equal({ echo: [domain] });
+
+        closeServer(server);
+      } catch (error) {
+        console.error(error); // eslint-disable-line no-console
+      } finally {
+        closeServer(server);
+      }
+    });
+  };
+}
+
+/**
+ * Assert AbortController aborting fetch requests.
+ *
+ * @async
+ * @param {Function} fetch implementation of fetch.
+ * @param {Function} AbortController constructor for aborting fetch request.
+ * @returns {Function} runnable test descriptor.
+ * @public
+ */
+function assertAbort(fetch, AbortController) {
+  return async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(controller.abort.bind(controller), 20);
+    let res;
+
+    try {
+      res = await fetch(API.GET, { signal: controller.signal });
+    } catch (error) {
+      assume(error).to.be.instanceof(Error);
+      assume(error.name).to.equal('AbortError');
+    } finally {
+      assume(res).to.be.falsy();
+      clearTimeout(timeout);
+    }
+  };
+}
+
+module.exports = {
+  assertGet,
+  assertPost,
+  assertExports,
+  assertAbort
+};


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Next is now poly-filling fetch with SSR support using node-fetch. Following through with similar approach by switching up @gasket/fetch to use native (or poly-filled) fetch in the browser and a pony-fill for SSR. 

## Changelog

Change-log updates in files changed

## Test Plan

As we now switched from passing through cross-fetch to poly-filling window.fetch for browsers and pony-filling node-fetch for node, we've added tests to validate the following:

- Validating exports: Fetch, Request, Response, Headers
- Sending out Get and Post Requests
- Validating abort/cancel works accordingly