### PR TITLE
Allow testing plugins to remove themselves after create lifecycle

### DIFF
--- a/packages/gasket-cli/CHANGELOG.md
+++ b/packages/gasket-cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/cli`
 
+- Add `remove` method to config-builder ([#179])
+
 ### 5.6.1
 
 - Lookup version for plugins if not set ([#170])
@@ -306,3 +308,4 @@ upon `gasket create`
 [#160]: https://github.com/godaddy/gasket/pull/160
 [#163]: https://github.com/godaddy/gasket/pull/163
 [#170]: https://github.com/godaddy/gasket/pull/170
+[#179]: https://github.com/godaddy/gasket/pull/179

--- a/packages/gasket-cli/src/scaffold/config-builder.js
+++ b/packages/gasket-cli/src/scaffold/config-builder.js
@@ -227,6 +227,38 @@ class ConfigBuilder {
   }
 
   /**
+   * Removes a dependecy from the package.json
+   *
+   * @param {String} key Dependency bucket
+   * @param {String|Array} value Dependency(ies) to search for
+   * @param {Object} source - Plugin name that calls this method
+   */
+  remove(key, value, source) {
+    if (typeof value === 'undefined') return;
+
+    const existing = this.fields[key];
+    const { name = 'Unknown plugin' } = (source || this.source || {});
+
+    debug('remove', { [key]: value, existing, from: name });
+
+    const message = (pkg) => `The package ${pkg} doesn't exist`;
+
+    if (Array.isArray(value)) {
+      value.forEach((pkg) => {
+        if (!this.fields[key][pkg]) {
+          this.warn(message(pkg));
+        } else {
+          delete this.fields[key][pkg];
+        }
+      });
+    } else if (!this.fields[key][value]) {
+      this.warn(message(value));
+    } else {
+      delete this.fields[key][value];
+    }
+  }
+
+  /**
    * Checks if a dependency has been already added
    * @param  {String} key Dependency bucket
    * @param  {String} value Dependency to search

--- a/packages/gasket-cli/test/unit/scaffold/config-builder.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/config-builder.test.js
@@ -236,6 +236,30 @@ describe('ConfigBuilder', () => {
     });
   });
 
+  describe('.remove(key)', () => {
+    it('removes the desired package', () => {
+      pkg.add('dependencies', { 'some-pkg': '^1.2.0' });
+      assume(pkg.fields.dependencies['some-pkg']).to.exist();
+      pkg.remove('dependencies', 'some-pkg');
+      assume(pkg.fields.dependencies['some-pkg']).to.not.exist();
+    });
+
+    it('can remove multple dependencies', () => {
+      pkg.add('dependencies', { 'some-pkg': '^1.2.0', 'some-pkg2': '^1.1.0' });
+      assume(pkg.fields.dependencies['some-pkg']).to.exist();
+      assume(pkg.fields.dependencies['some-pkg2']).to.exist();
+      pkg.remove('dependencies', ['some-pkg', 'some-pkg2']);
+      assume(pkg.fields.dependencies['some-pkg']).to.not.exist();
+      assume(pkg.fields.dependencies['some-pkg2']).to.not.exist();
+    });
+    it('should warn if a package doesnt exist', () => {
+      pkg.add('dependencies', { 'some-pkg': '^1.2.0', 'some-pkg2': '^1.1.0' });
+      pkg.remove('dependencies', ['some-pkg', 'some-pkg3']);
+      assume(pkg.fields.dependencies['some-pkg']).to.not.exist();
+      assume(warnSpy).calledWithMatch('The package some-pkg3 doesn\'t exist');
+    });
+  });
+
   describe('.has(key, value', () => {
     it('finds the value in a plain field', () => {
       pkg.add('name', 'my-app');

--- a/packages/gasket-plugin-jest/CHANGELOG.md
+++ b/packages/gasket-plugin-jest/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `@gasket/plugin-jest`
 
+- Add `postCreate` hook to remove plugin from created gasket
+  app dependencies ([#179])
+
 ### 5.0.0
 
 - Open Source Release
@@ -28,3 +31,4 @@
 
 [#98]: https://github.com/godaddy/gasket/pull/98
 [#114]: https://github.com/godaddy/gasket/pull/114
+[#179]: https://github.com/godaddy/gasket/pull/179

--- a/packages/gasket-plugin-jest/index.js
+++ b/packages/gasket-plugin-jest/index.js
@@ -1,7 +1,7 @@
-const { devDependencies } = require('./package.json');
+const { devDependencies, name } = require('./package.json');
 
 module.exports = {
-  name: require('./package').name,
+  name,
   hooks: {
     create: {
       timing: {
@@ -34,6 +34,9 @@ module.exports = {
           'test:coverage': 'jest --coverage'
         });
       }
+    },
+    postCreate: async function postCreate(gasket, { pkg }) {
+      pkg.remove('dependencies', name);
     },
     metadata(gasket, meta) {
       return {

--- a/packages/gasket-plugin-jest/test/index.test.js
+++ b/packages/gasket-plugin-jest/test/index.test.js
@@ -59,6 +59,7 @@ describe('Plugin', function () {
   it('has expected hooks', function ()  {
     const expected = [
       'create',
+      'postCreate',
       'metadata'
     ];
 
@@ -81,7 +82,7 @@ describe('Plugin', function () {
       expect(files[1]).toEqual(path.join(__dirname, '..', 'generator', '**', '*'));
     });
 
-    describe('adds react specific dependencies', function() {
+    describe('adds react specific dependencies', function () {
       [
         'jest',
         'enzyme',

--- a/packages/gasket-plugin-mocha/CHANGELOG.md
+++ b/packages/gasket-plugin-mocha/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `@gasket/plugin-mocha`
 
+- Add `postCreate` hook to remove plugin from created gasket
+  app dependencies ([#179])
+
 ### 5.0.0
 
 - Open Source Release
@@ -37,4 +40,4 @@
 
 
 [#114]: https://github.com/godaddy/gasket/pull/114
-
+[#179]: https://github.com/godaddy/gasket/pull/179

--- a/packages/gasket-plugin-mocha/index.js
+++ b/packages/gasket-plugin-mocha/index.js
@@ -1,7 +1,7 @@
-const { devDependencies } = require('./package.json');
+const { devDependencies, name } = require('./package.json');
 
 module.exports = {
-  name: require('./package').name,
+  name,
   hooks: {
     create: {
       timing: {
@@ -41,12 +41,15 @@ module.exports = {
         }
 
         pkg.add('scripts', {
-          'test': 'npm run test:runner',
+          'test': `${runCmd} test:runner`,
           'test:runner': 'mocha --require setup-env --recursive "test/**/*.*(test|spec).js"',
           'test:coverage': `nyc --reporter=text --reporter=json-summary ${runCmd} test:runner`,
           'test:watch': `${runCmd} test:runner -- --watch`
         });
       }
+    },
+    postCreate: async function postCreate(gasket, { pkg }) {
+      pkg.remove('dependencies', name);
     },
     metadata(gasket, meta) {
       return {

--- a/packages/gasket-plugin-mocha/test/index.test.js
+++ b/packages/gasket-plugin-mocha/test/index.test.js
@@ -61,6 +61,7 @@ describe('Plugin', () => {
   it('has expected hooks', () => {
     const expected = [
       'create',
+      'postCreate',
       'metadata'
     ];
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

This PR solves the problem of adding `@gasket/plugin-mocha` or `@gasket/plugin-jest` and having it persist as a dependency, though it is no longer needed. Those plugins just add other packages to `devDependencies` and have no real use after that.

## Changelog

- Changelog updates in files changed

## Test Plan

Add tests around new remove method
