### PR TITLE
[doc] Remove next-routes from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ Available structure
 | [app.config.js]    | App configuration with environment overrides           |
 | [gasket.config.js] | Gasket config for an app                               |
 | [jest.config.js]   | Jest configuration                                     |
-| [routes.js]        | Routing when using `next-routes`                       |
 | [store.js]         | Setup to make Redux store                              |
 
 ## Presets


### PR DESCRIPTION
## Summary

since next-routes is not supported anymore, we should remove it to not confuse engineers

