### PR TITLE
Remove next-routes from meta/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Supporting modules
 [config/]:/packages/gasket-plugin-config/README.md
 [lifecycles/]:/packages/gasket-plugin-lifecycle/README.md
 [locales/]:/packages/gasket-plugin-intl/README.md#Options
-[pages/]:https://nextjs.org/docs#routing
+[pages/]:https://nextjs.org/docs/routing/introduction
 [plugins/]:/packages/gasket-cli/docs/plugins.md#one-off-plugins
 [app.config.js]:/packages/gasket-plugin-config/README.md
 [gasket.config.js]:/packages/gasket-cli/docs/configuration.md

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ Available structure
 | [app.config.js]    | App configuration with environment overrides           |
 | [gasket.config.js] | Gasket config for an app                               |
 | [jest.config.js]   | Jest configuration                                     |
-| [routes.js]        | Routing when using `next-routes`                       |
 | [store.js]         | Setup to make Redux store                              |
 
 ## Presets
@@ -242,7 +241,6 @@ Supporting modules
 [app.config.js]:/packages/gasket-plugin-config/README.md
 [gasket.config.js]:/packages/gasket-cli/docs/configuration.md
 [jest.config.js]:https://jestjs.io/docs/configuration
-[routes.js]:https://github.com/fridays/next-routes#how-to-use
 [store.js]:/packages/gasket-plugin-redux/README.md
 [@gasket/preset-api]:/packages/gasket-preset-api/README.md
 [@gasket/preset-nextjs]:/packages/gasket-preset-nextjs/README.md

--- a/packages/gasket-plugin-nextjs/index.js
+++ b/packages/gasket-plugin-nextjs/index.js
@@ -211,10 +211,6 @@ module.exports = {
           name: 'pages/',
           description: 'NextJS routing',
           link: 'https://nextjs.org/docs#routing'
-        }, {
-          name: routes,
-          description: 'Routing when using `next-routes`',
-          link: 'https://github.com/fridays/next-routes#how-to-use'
         }]
       };
     }

--- a/packages/gasket-plugin-nextjs/index.js
+++ b/packages/gasket-plugin-nextjs/index.js
@@ -173,8 +173,6 @@ module.exports = {
       };
     },
     metadata(gasket, meta) {
-      const { routes = 'routes.js' } = gasket.config || {};
-
       return {
         ...meta,
         guides: [{

--- a/packages/gasket-plugin-nextjs/index.js
+++ b/packages/gasket-plugin-nextjs/index.js
@@ -210,7 +210,7 @@ module.exports = {
         structures: [{
           name: 'pages/',
           description: 'NextJS routing',
-          link: 'https://nextjs.org/docs#routing'
+          link: 'https://nextjs.org/docs/routing/introduction'
         }]
       };
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Follow up to #178 and reimplement #214 - `next-routes` is no longer recommended for Next.js apps. Instead, use the built-in [dynamic route segements](https://nextjs.org/docs/routing/introduction#dynamic-route-segments).

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/plugin-nextjs**
- Remove meta structure for `next-routes` and update Next.js pages link

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Updated docs