### PR TITLE
Static service worker support

### DIFF
--- a/packages/gasket-plugin-intl/lib/workbox.js
+++ b/packages/gasket-plugin-intl/lib/workbox.js
@@ -27,18 +27,24 @@ function makeEncodeLocaleUrls(localesPath) {
 }
 
 /**
- * Workbox config partial to add next.js static assets to precache
+ * Workbox config partial to add locale files to precache for request-based
+ * service workers.
  *
  * @param {Gasket} gasket - Gasket
  * @param {Object} config - Initial workbox config
- * @param {Request} req - Request
- * @param {Response} res - Response
+ * @param {Object} context - Service worker context
+ * @param {Response} context.res - Response
  * @returns {Promise<Object>} config
  */
-module.exports = async function workbox(gasket, config, req, res) {
+module.exports = async function workbox(gasket, config, context) {
   const { root } = gasket.config;
   const { basePath = '' } = getIntlConfig(gasket);
   const { localesPath, localesDir } = getIntlConfig(gasket);
+  const { res } = context;
+
+  // since we cannot determine a users' locale at build time, exit early
+  if (!res) return {};
+
   const { locale } = res.gasketData.intl;
 
   // Get the relative dir glob path

--- a/packages/gasket-plugin-intl/test/workbox.test.js
+++ b/packages/gasket-plugin-intl/test/workbox.test.js
@@ -3,7 +3,7 @@ const workbox = require('../lib/workbox');
 const { makeEncodeLocaleUrls } = workbox;
 
 describe('workbox', function () {
-  let result, mockGasket, mockConfig, mockReq, mockRes;
+  let result, mockGasket, mockConfig, mockContext;
 
   beforeEach(function () {
     mockGasket = {
@@ -17,24 +17,34 @@ describe('workbox', function () {
       }
     };
     mockConfig = {};
-    mockReq = {};
-    mockRes = {
-      gasketData: {
-        intl: {
-          locale: 'en-US'
+    mockContext = {
+      req: {},
+      res: {
+        gasketData: {
+          intl: {
+            locale: 'en-US'
+          }
         }
       }
     };
   });
 
   it('returns workbox config partial', async function () {
-    result = await workbox(mockGasket, mockConfig, mockReq, mockRes);
+    result = await workbox(mockGasket, mockConfig, mockContext);
 
     assume(result).instanceOf(Object);
+    assume(result).not.eqls({});
+  });
+
+  it('returns empty partial for static service workers', async function () {
+    result = await workbox(mockGasket, mockConfig, {});
+
+    assume(result).instanceOf(Object);
+    assume(result).eqls({});
   });
 
   it('config partial contains expected properties', async function () {
-    result = await workbox(mockGasket, mockConfig, mockReq, mockRes);
+    result = await workbox(mockGasket, mockConfig, mockContext);
 
     assume(result).property('globDirectory', '.');
     assume(result).property('globPatterns');
@@ -43,7 +53,7 @@ describe('workbox', function () {
   });
 
   it('config modifies urls from to _next', async function () {
-    result = await workbox(mockGasket, mockConfig, mockReq, mockRes);
+    result = await workbox(mockGasket, mockConfig, mockContext);
 
     assume(result.modifyURLPrefix).property(
       'public/locales', 'locales'
@@ -52,7 +62,7 @@ describe('workbox', function () {
 
   it('config modifies urls to use assetPrefix URL with trailing slash', async function () {
     mockGasket.config.intl.basePath = 'https://some-cdn.com/';
-    result = await workbox(mockGasket, mockConfig, mockReq, mockRes);
+    result = await workbox(mockGasket, mockConfig, mockContext);
 
     assume(result.modifyURLPrefix).property(
       'public/locales', 'https://some-cdn.com/locales'
@@ -61,7 +71,7 @@ describe('workbox', function () {
 
   it('config modifies urls to use assetPrefix URL without trailing slash', async function () {
     mockGasket.config.intl.basePath = 'https://some-cdn.com';
-    result = await workbox(mockGasket, mockConfig, mockReq, mockRes);
+    result = await workbox(mockGasket, mockConfig, mockContext);
 
     assume(result.modifyURLPrefix).property(
       'public/locales', 'https://some-cdn.com/locales'
@@ -70,7 +80,7 @@ describe('workbox', function () {
 
   it('config modifies urls to use assetPrefix relative path with trailing slash', async function () {
     mockGasket.config.intl.basePath = '/some/asset/prefix/';
-    result = await workbox(mockGasket, mockConfig, mockReq, mockRes);
+    result = await workbox(mockGasket, mockConfig, mockContext);
 
     assume(result.modifyURLPrefix).property(
       'public/locales', '/some/asset/prefix/locales'
@@ -79,7 +89,7 @@ describe('workbox', function () {
 
   it('config modifies urls to use assetPrefix relative path without trailing slash', async function () {
     mockGasket.config.intl.basePath = '/some/asset/prefix';
-    result = await workbox(mockGasket, mockConfig, mockReq, mockRes);
+    result = await workbox(mockGasket, mockConfig, mockContext);
 
     assume(result.modifyURLPrefix).property(
       'public/locales', '/some/asset/prefix/locales'
@@ -87,7 +97,7 @@ describe('workbox', function () {
   });
 
   it('manifestTransforms contains an encodeLocaleUrls function', async function () {
-    result = await workbox(mockGasket, mockConfig, mockReq, mockRes);
+    result = await workbox(mockGasket, mockConfig, mockContext);
 
     assume(result.manifestTransforms).instanceOf(Array);
     assume(result.manifestTransforms[0]).property('name', 'encodeLocaleUrls');

--- a/packages/gasket-plugin-service-worker/README.md
+++ b/packages/gasket-plugin-service-worker/README.md
@@ -51,14 +51,18 @@ To be set in under `serviceWorker` in the `gasket.config.js`.
   This is turned on in `production` by default. Adding `minify: { }` will turn
   on the default behavior in other environments, if specified.
 - `webpackRegister` - (string|string[]|function|boolean) By default, a service
-  worker registration script will will be injected to the webpack entry modules.
-  This can be disabled by setting this to `false`. If you wish to control which
-  entry modules get injected, read more in the [registering] section.
+  worker registration script will be injected to the webpack entry modules. This
+  can be disabled by setting this to `false`. If you wish to control which entry
+  modules get injected, read more in the [registering] section.
+- `staticOutput` - (string|boolean) If `true`, a static `sw.js` will be output
+  to the `./public` dir. Otherwise, this can be set to a string with a path to
+  an alternate output location. This disables request-based service workers.
+  Default is `false`.
 
 
 #### Example
 
-The defaults options for this plugin should be sufficient. However, they can be
+The defaults option for this plugin should be sufficient. However, they can be
 tuned as needed. A real-world use case may be for a micro-app served under a
 sub-path.
 
@@ -95,10 +99,7 @@ content.
 ```js
 module.exports = {
   hooks: {
-    composeServiceWorker: function (gasket, content, req, res) {
-
-      // `req` allows SW content based on hostname, cookie, etc.
-
+    composeServiceWorker: function (gasket, content, context) {
       return content.concat(`
 self.addEventListener('push', (event) => {
   const title = 'My App Notification';
@@ -125,7 +126,9 @@ const readFile = util.promisify(fs.readFile);
 
 module.exports = {
   hooks: {
-    composeServiceWorker: async function (gasket, content, req, res) {
+    composeServiceWorker: async function (gasket, content, context) {
+      const { req, res } = context;
+      // `req` allows SW content based on hostname, cookie, etc.
 
       const { market = 'en-US' } = req.cookies || {};
       const marketFile = `${market.toLowerCase()}.js`;
@@ -183,10 +186,10 @@ and can be included with your app in a couple of ways.
 
 ### Webpack
 
-When using the [@gasket/plugin-webpack] in your app, the service worker registration script
-will automatically be injected to entry modules by default at build time. If you
-are also using the [@gasket/plugin-nextjs], only the `_app` entry module will be
-injected with the script.
+When using the [@gasket/plugin-webpack] in your app, the service worker
+registration script will automatically be injected to entry modules by default
+at build time. If you are also using the [@gasket/plugin-nextjs], only the
+`_app` entry module will be injected with the script.
 
 If you otherwise need to tune which Webpack entry modules are injected, you can
 set the `webpackRegister` to the name or array of names of the entries you want
@@ -250,3 +253,4 @@ environment, which can be easily done using [service-worker-mock].
 [service workers]:https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API
 [@gasket/plugin-webpack]:/packages/gasket-plugin-webpack/README.md
 [@gasket/plugin-nextjs]:/packages/gasket-plugin-nextjs/README.md
+

--- a/packages/gasket-plugin-service-worker/__mocks__/mkdirp.js
+++ b/packages/gasket-plugin-service-worker/__mocks__/mkdirp.js
@@ -1,0 +1,1 @@
+module.exports = jest.fn();

--- a/packages/gasket-plugin-service-worker/lib/build.js
+++ b/packages/gasket-plugin-service-worker/lib/build.js
@@ -1,0 +1,38 @@
+const path = require('path');
+const util = require('util');
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+const { getComposedContent, getSWConfig } = require('./utils');
+
+const writeFile = util.promisify(fs.writeFile);
+
+/**
+ * Write a static service worker file
+ *
+ * @param {Gasket} gasket - Gasket
+ * @async
+ */
+async function handler(gasket) {
+  const { logger, config: { root } } = gasket;
+  const { staticOutput } = getSWConfig(gasket);
+  if (!staticOutput) return;
+
+  const composedContent = await getComposedContent(gasket, {});
+
+  await mkdirp(path.dirname(staticOutput));
+  await writeFile(staticOutput, composedContent, 'utf-8');
+  logger.log(`build:service-worker: Wrote service worker file (${path.relative(root, staticOutput)}).`);
+}
+
+/**
+ * Build lifecycle to write a static service worker file
+ *
+ * @param {Gasket} gasket - Gasket
+ * @param {Express} app - App
+ */
+module.exports = {
+  timing: {
+    last: true
+  },
+  handler
+};

--- a/packages/gasket-plugin-service-worker/lib/configure.js
+++ b/packages/gasket-plugin-service-worker/lib/configure.js
@@ -1,4 +1,6 @@
+const path = require('path');
 const merge = require('deepmerge');
+const { getSWConfig } = require('./utils');
 
 /**
  * Service worker defaults
@@ -23,10 +25,23 @@ const defaultConfig = {
  * Configure lifecycle to set up SW config with defaults
  *
  * @param {Gasket} gasket - Gasket
- * @param {Object} baseConfig - Base gasket config
+ * @param {Object} config - Base gasket config
  * @returns {Object} config
  */
-module.exports = function configure(gasket, baseConfig = {}) {
-  baseConfig.serviceWorker = merge(defaultConfig, baseConfig.serviceWorker || {});
-  return baseConfig;
+module.exports = function configure(gasket, config = {}) {
+  const { config: { root } } = gasket;
+  const serviceWorker = merge(defaultConfig, getSWConfig({ config }));
+  let { staticOutput } = serviceWorker;
+
+  // Fixup staticOutput - use default if true
+  if (staticOutput === true) {
+    staticOutput = 'public/sw.js';
+  }
+  if (staticOutput) {
+    staticOutput = path.join(root, staticOutput);
+  }
+
+  serviceWorker.staticOutput = staticOutput;
+
+  return { ...config, serviceWorker };
 };

--- a/packages/gasket-plugin-service-worker/lib/index.js
+++ b/packages/gasket-plugin-service-worker/lib/index.js
@@ -1,4 +1,5 @@
 const configure = require('./configure');
+const build = require('./build');
 const middleware = require('./middleware');
 const express = require('./express');
 const webpack = require('./webpack');
@@ -7,6 +8,7 @@ module.exports = {
   name: require('../package').name,
   hooks: {
     configure,
+    build,
     middleware,
     express,
     webpack,
@@ -18,6 +20,12 @@ module.exports = {
           method: 'execWaterfall',
           description: 'Update the service worker script',
           link: 'README.md#composeServiceWorker',
+          parent: 'express'
+        }, {
+          name: 'serviceWorkerCacheKey',
+          method: 'exec',
+          description: 'Get cache keys for request based service workers',
+          link: 'README.md#serviceWorkerCacheKey',
           parent: 'express'
         }]
       };

--- a/packages/gasket-plugin-service-worker/lib/webpack.js
+++ b/packages/gasket-plugin-service-worker/lib/webpack.js
@@ -1,3 +1,5 @@
+const { getSWConfig } = require('./utils');
+
 /**
  * Add the analyzer webpack plugin if analyze flag has been set
  *
@@ -8,14 +10,10 @@
  * @returns {Object} webpackConfig
  */
 module.exports = function webpack(gasket, webpackConfig, data) {
-  const {
-    command,
-    config: {
-      serviceWorker: config = {}
-    }
-  } = gasket;
+  const { command } = gasket;
+  const swConfig = getSWConfig(gasket);
 
-  const { webpackRegister } = config;
+  const { webpackRegister } = swConfig;
   const { isServer } = data;
   //
   // Do not register the service worker for local development or if webpackRegister is false
@@ -38,7 +36,7 @@ module.exports = function webpack(gasket, webpackConfig, data) {
     //
     return {
       plugins: [
-        new WebpackInjectPlugin(() => loadRegisterScript(config), entryName && { entryName })
+        new WebpackInjectPlugin(() => loadRegisterScript(swConfig), entryName && { entryName })
       ]
     };
   }

--- a/packages/gasket-plugin-service-worker/package.json
+++ b/packages/gasket-plugin-service-worker/package.json
@@ -4,7 +4,7 @@
   "description": "Gasket Service Worker Plugin",
   "main": "lib",
   "scripts": {
-    "lint": "eslint lib",
+    "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "test": "jest",
     "test:watch": "jest --watchAll",
@@ -35,6 +35,7 @@
   "dependencies": {
     "deepmerge": "^4.0.0",
     "lru-cache": "^5.1.1",
+    "mkdirp": "^0.5.1",
     "uglify-js": "^3.5.3",
     "webpack-inject-plugin": "^1.5.4"
   },
@@ -53,6 +54,8 @@
     ]
   },
   "eslintIgnore": [
-    "*.template.js"
+    "*.template.js",
+    "coverage",
+    "__mocks__"
   ]
 }

--- a/packages/gasket-plugin-service-worker/test/build.spec.js
+++ b/packages/gasket-plugin-service-worker/test/build.spec.js
@@ -1,0 +1,71 @@
+const mkdirp = require('mkdirp');
+const build = require('../lib/build');
+const fs = require('fs');
+jest.mock('fs');
+
+describe('build', () => {
+  let mockConfig, mockGasket;
+
+  beforeEach(() => {
+    fs.writeFile.mockImplementation((path, content, options, callback) => callback(null, true));
+
+    mockConfig = {
+      url: '/sw.js',
+      scope: '/',
+      content: '',
+      cacheKeys: [],
+      cache: {},
+      staticOutput: '/some-root/public/sw.js'
+    };
+
+    mockGasket = {
+      config: {
+        root: '/some-root',
+        serviceWorker: mockConfig
+      },
+      logger: {
+        log: jest.fn()
+      },
+      execWaterfall: jest.fn()
+    };
+  });
+
+  it('is configured with expected timing', function () {
+    expect(build).toHaveProperty('timing', {
+      last: true
+    });
+  });
+
+  it('does not build if staticOutput not configured', async () => {
+    delete mockConfig.staticOutput;
+    await build.handler(mockGasket);
+    expect(mockGasket.execWaterfall).not.toHaveBeenCalled();
+  });
+
+  it('executes execWaterfall for composeServiceWorker', async () => {
+    mockConfig.content = 'This is preconfigured content';
+    await build.handler(mockGasket);
+    expect(mockGasket.execWaterfall).toHaveBeenCalledWith(
+      'composeServiceWorker',
+      mockConfig.content,
+      expect.objectContaining({})
+    );
+  });
+
+  it('uses mkdirp to ensure directory exists', async () => {
+    mockConfig.content = 'This is preconfigured content';
+    await build.handler(mockGasket);
+    expect(mkdirp).toHaveBeenCalledWith('/some-root/public');
+  });
+
+  it('writes file out', async () => {
+    mockConfig.content = 'This is preconfigured content';
+    await build.handler(mockGasket);
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      '/some-root/public/sw.js',
+      expect.stringContaining('strict'),
+      'utf-8',
+      expect.any(Function)
+    );
+  });
+});

--- a/packages/gasket-plugin-service-worker/test/configure.spec.js
+++ b/packages/gasket-plugin-service-worker/test/configure.spec.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const configure = require('../lib/configure');
 
 describe('configure', () => {
@@ -6,7 +7,9 @@ describe('configure', () => {
 
   beforeEach(() => {
     mockGasket = {
-      config: {}
+      config: {
+        root: '/path/to/app'
+      }
     };
   });
 
@@ -40,5 +43,23 @@ describe('configure', () => {
       }
     });
     expect(results.serviceWorker).toHaveProperty('url', '/some-sw.js');
+  });
+
+  it('configures absolute staticOutput path', async () => {
+    results = await configure(mockGasket, {
+      serviceWorker: {
+        staticOutput: './some/path.js'
+      }
+    });
+    expect(results.serviceWorker).toHaveProperty('staticOutput', path.join(mockGasket.config.root, '/some/path.js'));
+  });
+
+  it('configures staticOutput path if true', async () => {
+    results = await configure(mockGasket, {
+      serviceWorker: {
+        staticOutput: true
+      }
+    });
+    expect(results.serviceWorker).toHaveProperty('staticOutput', path.join(mockGasket.config.root, '/public/sw.js'));
   });
 });

--- a/packages/gasket-plugin-service-worker/test/index.spec.js
+++ b/packages/gasket-plugin-service-worker/test/index.spec.js
@@ -13,6 +13,7 @@ describe('Plugin', () => {
   it('has expected hooks', () => {
     const expected = [
       'configure',
+      'build',
       'middleware',
       'express',
       'webpack',
@@ -24,5 +25,14 @@ describe('Plugin', () => {
     const hooks = Object.keys(plugin.hooks);
     expect(hooks).toEqual(expected);
     expect(hooks).toHaveLength(expected.length);
+  });
+
+  describe('meta', function () {
+    it('returns lifecycle metadata', function () {
+      const results = plugin.hooks.metadata({}, {});
+      expect(results).toEqual(expect.objectContaining({
+        lifecycles: expect.any(Array)
+      }));
+    });
   });
 });

--- a/packages/gasket-plugin-service-worker/test/middleware.spec.js
+++ b/packages/gasket-plugin-service-worker/test/middleware.spec.js
@@ -40,13 +40,13 @@ describe('middleware', () => {
     it('attaches swRegisterScript to req', async () => {
       layer = getLayer();
       await layer(mockReq, mockRes, mockNext);
-      expect(mockReq).toHaveProperty('swRegisterScript', expect.any(String))
+      expect(mockReq).toHaveProperty('swRegisterScript', expect.any(String));
     });
 
     it('swRegisterScript has content from sw-register.template', async () => {
       layer = getLayer();
       await layer(mockReq, mockRes, mockNext);
-      expect(mockReq.swRegisterScript).toContain('navigator.serviceWorker.register')
+      expect(mockReq.swRegisterScript).toContain('navigator.serviceWorker.register');
     });
 
     it('swRegisterScript has substituted variables', async () => {
@@ -63,7 +63,7 @@ describe('middleware', () => {
       mockReq.path = '/_next/some/asset.js';
       layer = getLayer();
       await layer(mockReq, mockRes, mockNext);
-      expect(mockReq).not.toHaveProperty('swRegisterScript', expect.any(String))
+      expect(mockReq).not.toHaveProperty('swRegisterScript', expect.any(String));
     });
   });
 });

--- a/packages/gasket-plugin-service-worker/test/utils.spec.js
+++ b/packages/gasket-plugin-service-worker/test/utils.spec.js
@@ -1,4 +1,6 @@
-const { getCacheKeys, loadRegisterScript } = require('../lib/utils');
+const mockMinify = require('uglify-js');
+const { getComposedContent } = require('../lib/utils');
+const { getCacheKeys, getSWConfig, loadRegisterScript } = require('../lib/utils');
 
 describe('utils', () => {
   describe('getCacheKeys', () => {
@@ -14,6 +16,7 @@ describe('utils', () => {
         config: {},
         exec: mockExec
       };
+      mockMinify.mockClear();
     });
 
     it('executes exec for serviceWorkerCacheKey lifecycle', async () => {
@@ -45,13 +48,87 @@ describe('utils', () => {
     });
 
     it('filters non-function cache keys', async () => {
+      /* eslint-disable no-undefined */
       mockGasket.config.serviceWorker = {
         cacheKeys: [cacheKeyA, null, undefined, '', {}]
       };
       mockPluginCacheKeys.push(cacheKeyB, null, undefined, '', {});
       results = await getCacheKeys(mockGasket);
       expect(results).toEqual([cacheKeyA, cacheKeyB]);
+      /* eslint-enable no-undefined */
     });
+  });
+
+  describe('getComposedContent', () => {
+    let mockConfig, mockGasket;
+    beforeEach(function () {
+
+      mockConfig = {
+        url: '/sw.js',
+        scope: '/',
+        content: '',
+        cacheKeys: [],
+        cache: {},
+        staticOutput: '/some-root/public/sw.js'
+      };
+
+      mockGasket = {
+        config: {
+          root: '/some-root',
+          serviceWorker: mockConfig
+        },
+        logger: {
+          log: jest.fn()
+        },
+        execWaterfall: jest.fn()
+      };
+    });
+
+    it('executes execWaterfall for composeServiceWorker', async () => {
+      mockConfig.content = 'This is preconfigured content';
+      const context = {};
+      await getComposedContent(mockGasket, context);
+      expect(mockGasket.execWaterfall).toHaveBeenCalledWith(
+        'composeServiceWorker',
+        mockConfig.content,
+        context
+      );
+    });
+
+    it('composed service worker contains expected head content', async () => {
+      const results = await getComposedContent(mockGasket);
+      expect(results).toEqual(expect.stringContaining('\'use strict\';'));
+    });
+
+    it('composed service worker contains composed hook content', async () => {
+      mockGasket.execWaterfall.mockResolvedValue('composed content');
+      const results = await getComposedContent(mockGasket);
+      expect(results).toEqual(expect.stringContaining('composed content'));
+    });
+
+    it('does not minifies code in an unknown environment', async () => {
+      await getComposedContent(mockGasket);
+      expect(mockMinify.minify).not.toHaveBeenCalled();
+    });
+
+    it('minifies code in the production environment', async () => {
+      mockGasket.config.env = 'production';
+      await getComposedContent(mockGasket);
+      expect(mockMinify.minify).toHaveBeenCalled();
+    });
+
+    it('minifies code if explicitly specified by gasket', async () => {
+      mockGasket.config.serviceWorker.minify = {};
+      await getComposedContent(mockGasket);
+      expect(mockMinify.minify).toHaveBeenCalled();
+    });
+
+    it('minifies code if passed a boolean', async () => {
+      mockGasket.config.serviceWorker.minify = true;
+      await getComposedContent(mockGasket);
+      expect(mockMinify.minify).toHaveBeenCalled();
+    });
+
   });
 
   describe('loadRegisterScript', () => {
@@ -76,6 +153,24 @@ describe('utils', () => {
       const results = await loadRegisterScript(mockConfig);
       expect(results).toContain(mockConfig.url);
       expect(results).toContain(mockConfig.scope);
+    });
+  });
+
+  describe('getSWConfig', function () {
+
+    it('returns empty object if no config', function () {
+      const results = getSWConfig({});
+      expect(results).toEqual({});
+    });
+
+    it('returns empty object if no sw config', function () {
+      const results = getSWConfig({ config: {} });
+      expect(results).toEqual({});
+    });
+
+    it('returns sw config', function () {
+      const results = getSWConfig({ config: { serviceWorker: { bogus: true } } });
+      expect(results).toEqual({ bogus: true });
     });
   });
 });

--- a/packages/gasket-plugin-workbox/README.md
+++ b/packages/gasket-plugin-workbox/README.md
@@ -76,9 +76,13 @@ partial which will be deeply merged.
 ```js
 module.exports = {
   hooks: {
-    workbox: function (gasket, config, req, res) {
-      // the initial `config`
-      // `req` allows rules based on headers, cookies, etc.
+    workbox: function (gasket, config, context) {
+      // `config` is the initial workbox config
+      // `context` is the service-worker context.
+      const { req, res } = context;
+      if(req) {
+        // adjust config for request-based service workers using headers, cookies, etc.
+      }
 
       // return a config partial which will be merged
       return {

--- a/packages/gasket-plugin-workbox/lib/compose-service-worker.js
+++ b/packages/gasket-plugin-workbox/lib/compose-service-worker.js
@@ -9,15 +9,14 @@ const reComments = /\/\*.*(\n.+)*\*\//g;
  *
  * @param {Gasket} gasket - Gasket
  * @param {String} content - Service worker content
- * @param {Request} req - Request
- * @param {Response} res - Response
+ * @param {Object} context - Service worker context
  * @returns {Promise<string>} content
  */
-module.exports = async function composeServiceWorker(gasket, content, req, res) {
+module.exports = async function composeServiceWorker(gasket, content, context) {
   const { exec, config, logger } = gasket;
   const { workbox } = config;
 
-  const configs = (await exec('workbox', workbox.config, req, res)).filter(Boolean);
+  const configs = (await exec('workbox', workbox.config, context)).filter(Boolean);
   const mergedConfig = merge.all([workbox.config, ...configs]);
 
   const build = await generateSWString(mergedConfig);

--- a/packages/gasket-plugin-workbox/package.json
+++ b/packages/gasket-plugin-workbox/package.json
@@ -4,7 +4,7 @@
   "description": "Gasket Workbox Plugin",
   "main": "lib",
   "scripts": {
-    "lint": "eslint lib",
+    "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "test": "jest",
     "test:watch": "jest --watchAll",
@@ -50,5 +50,9 @@
       "godaddy",
       "plugin:jest/recommended"
     ]
-  }
+  },
+  "eslintIgnore": [
+    "coverage",
+    "__mocks__"
+  ]
 }

--- a/packages/gasket-plugin-workbox/test/compose-service-worker.spec.js
+++ b/packages/gasket-plugin-workbox/test/compose-service-worker.spec.js
@@ -6,7 +6,7 @@ describe('composeServiceWorker', () => {
   const expectedComment = 'Welcome to your Workbox-powered service worker!';
   const expectedCode = 'workbox.precaching.precacheAndRoute';
 
-  let results, mockGasket, mockContent, mockReq, mockRes;
+  let results, mockGasket, mockContent, mockContext;
 
   beforeEach(() => {
     mockGasket = {
@@ -23,23 +23,21 @@ describe('composeServiceWorker', () => {
       }
     };
     mockContent = '/* mock sw content */';
-    mockReq = {};
-    mockRes = {};
+    mockContext = {};
     __setWarnings([]);
   });
 
   it('executes exec for workbox', async () => {
-    await composeServiceWorker(mockGasket, mockContent, mockReq, mockRes);
+    await composeServiceWorker(mockGasket, mockContent, mockContext);
     expect(mockGasket.exec).toHaveBeenCalledWith(
       'workbox',
       utils.defaultConfig.config,
-      mockReq,
-      mockRes
+      mockContext
     );
   });
 
   it('executes generateSWString with merged config', async () => {
-    await composeServiceWorker(mockGasket, mockContent, mockReq, mockRes);
+    await composeServiceWorker(mockGasket, mockContent, mockContext);
     expect(generateSWString).toHaveBeenCalledWith(
       expect.objectContaining({
         ...utils.defaultConfig.config,
@@ -49,7 +47,7 @@ describe('composeServiceWorker', () => {
   });
 
   it('appends generated workbox service worker content', async () => {
-    results = await composeServiceWorker(mockGasket, mockContent, mockReq, mockRes);
+    results = await composeServiceWorker(mockGasket, mockContent, mockContext);
     expect(results).toContain(mockContent);
     expect(results).toContain(expectedCode);
   });
@@ -58,20 +56,20 @@ describe('composeServiceWorker', () => {
     const withComments = await generateSWString();
     expect(withComments.swString).toContain(expectedComment);
 
-    results = await composeServiceWorker(mockGasket, mockContent, mockReq, mockRes);
+    results = await composeServiceWorker(mockGasket, mockContent, mockContext);
     expect(results).not.toContain(expectedComment);
     expect(results).toContain(expectedCode);
   });
 
   it('does not call logger if no warnings', async () => {
-    results = await composeServiceWorker(mockGasket, mockContent, mockReq, mockRes);
+    results = await composeServiceWorker(mockGasket, mockContent, mockContext);
     expect(mockGasket.logger.warning).not.toHaveBeenCalled();
   });
 
   it('logs warnings if they exists', async () => {
     const mockWarnings = ['something bad happened'];
     __setWarnings(mockWarnings);
-    results = await composeServiceWorker(mockGasket, mockContent, mockReq, mockRes);
+    results = await composeServiceWorker(mockGasket, mockContent, mockContext);
     expect(mockGasket.logger.warning).toHaveBeenCalledWith(mockWarnings);
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

This PR allows service worker files to be generated at build time. They are still available to be request-based depending on if `staticOutput` is configured or not. In both cases, `composeServiceWorker` is called but with different contexts, allowing plugins to change up their configuration results.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/plugin-service-worker**
- Ability to configure static output of service workers for build time
- Context for `composeServiceWorker` changes for build vs request-based service workers

**@gasket/plugin-intl**
- Use new `composeServiceWorker` context for determining locale precache config

**@gasket/plugin-workbox**
- Pass new `composeServiceWorker` context through to `workbox` lifecycle

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Updated unit tests
- Local testing in canary app