### PR TITLE
Support Webpack 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,15 +48,6 @@
 					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
 					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
 					"dev": true
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -82,15 +73,6 @@
 					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
 					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
 					"dev": true
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
 				},
 				"semver": {
 					"version": "5.7.1",
@@ -152,15 +134,6 @@
 				"which": "^1.3.1"
 			},
 			"dependencies": {
-				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -267,51 +240,6 @@
 				"chalk": "^2.3.1",
 				"execa": "^1.0.0",
 				"strong-log-transformer": "^2.0.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"execa": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/clean": {
@@ -383,51 +311,6 @@
 				"execa": "^1.0.0",
 				"is-ci": "^2.0.0",
 				"npmlog": "^4.1.2"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"execa": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/conventional-commits": {
@@ -447,49 +330,6 @@
 				"npmlog": "^4.1.2",
 				"pify": "^4.0.1",
 				"semver": "^6.2.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/create": {
@@ -516,40 +356,6 @@
 				"validate-npm-package-license": "^3.0.3",
 				"validate-npm-package-name": "^3.0.0",
 				"whatwg-url": "^7.0.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/create-symlink": {
@@ -561,34 +367,6 @@
 				"@zkochan/cmd-shim": "^3.1.0",
 				"fs-extra": "^8.1.0",
 				"npmlog": "^4.1.2"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/describe-ref": {
@@ -670,34 +448,6 @@
 				"fs-extra": "^8.1.0",
 				"ssri": "^6.0.1",
 				"tar": "^4.4.8"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/github-client": {
@@ -754,34 +504,6 @@
 				"dedent": "^0.7.0",
 				"fs-extra": "^8.1.0",
 				"p-map-series": "^1.0.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/info": {
@@ -806,34 +528,6 @@
 				"fs-extra": "^8.1.0",
 				"p-map": "^2.1.0",
 				"write-json-file": "^3.2.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/link": {
@@ -892,14 +586,6 @@
 			"requires": {
 				"config-chain": "^1.1.11",
 				"pify": "^4.0.1"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/npm-dist-tag": {
@@ -928,34 +614,6 @@
 				"npmlog": "^4.1.2",
 				"signal-exit": "^3.0.2",
 				"write-pkg": "^3.1.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/npm-publish": {
@@ -973,40 +631,6 @@
 				"npmlog": "^4.1.2",
 				"pify": "^4.0.1",
 				"read-package-json": "^2.0.13"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/npm-run-script": {
@@ -1098,34 +722,6 @@
 				"fs-extra": "^8.1.0",
 				"npmlog": "^4.1.2",
 				"upath": "^1.2.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/project": {
@@ -1146,6 +742,23 @@
 				"p-map": "^2.1.0",
 				"resolve-from": "^4.0.0",
 				"write-json-file": "^3.2.0"
+			},
+			"dependencies": {
+				"dot-prop": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+					"integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+					"dev": true,
+					"requires": {
+						"is-obj": "^1.0.0"
+					}
+				},
+				"is-obj": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+					"dev": true
+				}
 			}
 		},
 		"@lerna/prompt": {
@@ -1305,34 +918,6 @@
 				"p-map": "^2.1.0",
 				"p-pipe": "^1.2.0",
 				"semver": "^6.2.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/pulse-till-done": {
@@ -1363,34 +948,6 @@
 				"fs-extra": "^8.1.0",
 				"npmlog": "^4.1.2",
 				"read-cmd-shim": "^1.0.1"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/rimraf-dir": {
@@ -1466,34 +1023,6 @@
 				"@lerna/package": "3.16.0",
 				"fs-extra": "^8.1.0",
 				"p-map": "^2.1.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/symlink-dependencies": {
@@ -1509,34 +1038,6 @@
 				"p-finally": "^1.0.0",
 				"p-map": "^2.1.0",
 				"p-map-series": "^1.0.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"@lerna/timer": {
@@ -1596,6 +1097,19 @@
 			"requires": {
 				"npmlog": "^4.1.2",
 				"write-file-atomic": "^2.3.0"
+			},
+			"dependencies": {
+				"write-file-atomic": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+					"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
+					}
+				}
 			}
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -1615,21 +1129,21 @@
 			"dev": true
 		},
 		"@octokit/auth-token": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
-			"integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.4.tgz",
+			"integrity": "sha512-LNfGu3Ro9uFAYh10MUZVaT7X2CnNm2C8IDQmabx+3DygYIQjs9FwzFAHN/0t6mu5HEPhxcb1XOuxdpY82vCg2Q==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^5.0.0"
+				"@octokit/types": "^6.0.0"
 			}
 		},
 		"@octokit/endpoint": {
-			"version": "6.0.8",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.8.tgz",
-			"integrity": "sha512-MuRrgv+bM4Q+e9uEvxAB/Kf+Sj0O2JAOBA131uo1o6lgdq1iS8ejKwtqHgdfY91V3rN9R/hdGKFiQYMzVzVBEQ==",
+			"version": "6.0.10",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.10.tgz",
+			"integrity": "sha512-9+Xef8nT7OKZglfkOMm7IL6VwxXUQyR7DUSU0LH/F7VNqs8vyd7es5pTfz9E7DwUIx7R3pGscxu1EBhYljyu7Q==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^5.0.0",
+				"@octokit/types": "^6.0.0",
 				"is-plain-object": "^5.0.0",
 				"universal-user-agent": "^6.0.0"
 			},
@@ -1647,6 +1161,12 @@
 					"dev": true
 				}
 			}
+		},
+		"@octokit/openapi-types": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-2.0.0.tgz",
+			"integrity": "sha512-J4bfM7lf8oZvEAdpS71oTvC1ofKxfEZgU5vKVwzZKi4QPiL82udjpseJwxPid9Pu2FNmyRQOX4iEj6W1iOSnPw==",
+			"dev": true
 		},
 		"@octokit/plugin-enterprise-rest": {
 			"version": "6.0.1",
@@ -1675,9 +1195,9 @@
 			}
 		},
 		"@octokit/plugin-request-log": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
-			"integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz",
+			"integrity": "sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg==",
 			"dev": true
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
@@ -1702,14 +1222,14 @@
 			}
 		},
 		"@octokit/request": {
-			"version": "5.4.9",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.9.tgz",
-			"integrity": "sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==",
+			"version": "5.4.12",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.12.tgz",
+			"integrity": "sha512-MvWYdxengUWTGFpfpefBBpVmmEYfkwMoxonIB3sUGp5rhdgwjXL1ejo6JbgzG/QD9B/NYt/9cJX1pxXeSIUCkg==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^6.0.1",
 				"@octokit/request-error": "^2.0.0",
-				"@octokit/types": "^5.0.0",
+				"@octokit/types": "^6.0.3",
 				"deprecation": "^2.0.0",
 				"is-plain-object": "^5.0.0",
 				"node-fetch": "^2.6.1",
@@ -1718,12 +1238,12 @@
 			},
 			"dependencies": {
 				"@octokit/request-error": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
-					"integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.4.tgz",
+					"integrity": "sha512-LjkSiTbsxIErBiRh5wSZvpZqT4t0/c9+4dOe0PII+6jXR+oj/h66s7E4a/MghV7iT8W9ffoQ5Skoxzs96+gBPA==",
 					"dev": true,
 					"requires": {
-						"@octokit/types": "^5.0.1",
+						"@octokit/types": "^6.0.0",
 						"deprecation": "^2.0.0",
 						"once": "^1.4.0"
 					}
@@ -1789,11 +1309,12 @@
 			}
 		},
 		"@octokit/types": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
-			"integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.1.0.tgz",
+			"integrity": "sha512-bMWBmg77MQTiRkOVyf50qK3QECWOEy43rLy/6fTWZ4HEwAhNfqzMcjiBDZAowkILwTrFvzE1CpP6gD0MuPHS+A==",
 			"dev": true,
 			"requires": {
+				"@octokit/openapi-types": "^2.0.0",
 				"@types/node": ">= 8"
 			}
 		},
@@ -1829,15 +1350,15 @@
 			"dev": true
 		},
 		"@types/minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
+			"integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
-			"integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
+			"version": "14.14.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
+			"integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -1871,6 +1392,12 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
+		},
+		"acorn": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -1916,12 +1443,31 @@
 			"dev": true,
 			"requires": {
 				"string-width": "^3.0.0"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				}
 			}
+		},
+		"ansi-colors": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "4.3.1",
-			"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-			"integrity": "sha1-pcR8xDGB8fOP/XB2g3cA05VSKmE=",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+			"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.11.0"
@@ -1929,8 +1475,8 @@
 			"dependencies": {
 				"type-fest": {
 					"version": "0.11.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/type-fest/-/type-fest-0.11.0.tgz",
-					"integrity": "sha1-l6vwhyMQ/tiKXEZrJWgVdhReM/E=",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
 					"dev": true
 				}
 			}
@@ -2118,9 +1664,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
 			"dev": true
 		},
 		"balanced-match": {
@@ -2212,19 +1758,70 @@
 			"dev": true
 		},
 		"boxen": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
-			"integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
+			"integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
 			"dev": true,
 			"requires": {
 				"ansi-align": "^3.0.0",
 				"camelcase": "^5.3.1",
-				"chalk": "^2.4.2",
+				"chalk": "^3.0.0",
 				"cli-boxes": "^2.2.0",
-				"string-width": "^3.0.0",
-				"term-size": "^1.2.0",
-				"type-fest": "^0.3.0",
-				"widest-line": "^2.0.0"
+				"string-width": "^4.1.0",
+				"term-size": "^2.1.0",
+				"type-fest": "^0.8.1",
+				"widest-line": "^3.1.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"brace-expansion": {
@@ -2357,6 +1954,16 @@
 					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
 					"dev": true
 				}
+			}
+		},
+		"call-bind": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+			"integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.0"
 			}
 		},
 		"call-me-maybe": {
@@ -2494,6 +2101,21 @@
 			"integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
 			"dev": true
 		},
+		"cli-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "^3.1.0"
+			}
+		},
+		"cli-width": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+			"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+			"dev": true
+		},
 		"clipboard": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
@@ -2515,6 +2137,19 @@
 				"string-width": "^3.1.0",
 				"strip-ansi": "^5.2.0",
 				"wrap-ansi": "^5.1.0"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				}
 			}
 		},
 		"clone": {
@@ -2618,23 +2253,6 @@
 			"requires": {
 				"array-ify": "^1.0.0",
 				"dot-prop": "^5.1.0"
-			},
-			"dependencies": {
-				"dot-prop": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-					"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-					"dev": true,
-					"requires": {
-						"is-obj": "^2.0.0"
-					}
-				},
-				"is-obj": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-					"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-					"dev": true
-				}
 			}
 		},
 		"component-emitter": {
@@ -2649,6 +2267,18 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
+		"concat-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
+			}
+		},
 		"config-chain": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
@@ -2660,28 +2290,17 @@
 			}
 		},
 		"configstore": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
-			"integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+			"integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
 			"dev": true,
 			"requires": {
-				"dot-prop": "^4.1.0",
+				"dot-prop": "^5.2.0",
 				"graceful-fs": "^4.1.2",
-				"make-dir": "^1.0.0",
-				"unique-string": "^1.0.0",
-				"write-file-atomic": "^2.0.0",
-				"xdg-basedir": "^3.0.0"
-			},
-			"dependencies": {
-				"make-dir": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				}
+				"make-dir": "^3.0.0",
+				"unique-string": "^2.0.0",
+				"write-file-atomic": "^3.0.0",
+				"xdg-basedir": "^4.0.0"
 			}
 		},
 		"connect": {
@@ -2709,9 +2328,9 @@
 			"dev": true
 		},
 		"conventional-changelog-angular": {
-			"version": "5.0.11",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz",
-			"integrity": "sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==",
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.12.tgz",
+			"integrity": "sha512-5GLsbnkR/7A89RyHLvvoExbiGbd9xKdKqDTrArnPbOqBqG/2wIosu0fHwpeIRI8Tl94MhVNBXcLJZl92ZQ5USw==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^2.0.0",
@@ -2758,39 +2377,49 @@
 			"dev": true
 		},
 		"conventional-changelog-writer": {
-			"version": "4.0.17",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz",
-			"integrity": "sha512-IKQuK3bib/n032KWaSb8YlBFds+aLmzENtnKtxJy3+HqDq5kohu3g/UdNbIHeJWygfnEbZjnCKFxAW0y7ArZAw==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.18.tgz",
+			"integrity": "sha512-mAQDCKyB9HsE8Ko5cCM1Jn1AWxXPYV0v8dFPabZRkvsiWUul2YyAqbIaoMKF88Zf2ffnOPSvKhboLf3fnjo5/A==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^2.0.0",
-				"conventional-commits-filter": "^2.0.6",
+				"conventional-commits-filter": "^2.0.7",
 				"dateformat": "^3.0.0",
 				"handlebars": "^4.7.6",
 				"json-stringify-safe": "^5.0.1",
 				"lodash": "^4.17.15",
-				"meow": "^7.0.0",
+				"meow": "^8.0.0",
 				"semver": "^6.0.0",
 				"split": "^1.0.0",
-				"through2": "^3.0.0"
+				"through2": "^4.0.0"
 			},
 			"dependencies": {
-				"through2": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-					"integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
-						"inherits": "^2.0.4",
-						"readable-stream": "2 || 3"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"through2": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+					"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+					"dev": true,
+					"requires": {
+						"readable-stream": "3"
 					}
 				}
 			}
 		},
 		"conventional-commits-filter": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.6.tgz",
-			"integrity": "sha512-4g+sw8+KA50/Qwzfr0hL5k5NWxqtrOVw4DDk3/h6L85a9Gz0/Eqp3oP+CWCNfesBvZZZEFHF7OTEbRe+yYSyKw==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
+			"integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
 			"dev": true,
 			"requires": {
 				"lodash.ismatch": "^4.4.0",
@@ -2798,28 +2427,38 @@
 			}
 		},
 		"conventional-commits-parser": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.1.0.tgz",
-			"integrity": "sha512-RSo5S0WIwXZiRxUGTPuYFbqvrR4vpJ1BDdTlthFgvHt5kEdnd1+pdvwWphWn57/oIl4V72NMmOocFqqJ8mFFhA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.0.tgz",
+			"integrity": "sha512-XmJiXPxsF0JhAKyfA2Nn+rZwYKJ60nanlbSWwwkGwLQFbugsc0gv1rzc7VbbUWAzJfR1qR87/pNgv9NgmxtBMQ==",
 			"dev": true,
 			"requires": {
 				"JSONStream": "^1.0.4",
 				"is-text-path": "^1.0.1",
 				"lodash": "^4.17.15",
-				"meow": "^7.0.0",
+				"meow": "^8.0.0",
 				"split2": "^2.0.0",
-				"through2": "^3.0.0",
+				"through2": "^4.0.0",
 				"trim-off-newlines": "^1.0.0"
 			},
 			"dependencies": {
-				"through2": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-					"integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
-						"inherits": "^2.0.4",
-						"readable-stream": "2 || 3"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"through2": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+					"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+					"dev": true,
+					"requires": {
+						"readable-stream": "3"
 					}
 				}
 			}
@@ -3028,10 +2667,31 @@
 				"p-event": "^4.1.0"
 			}
 		},
+		"cross-spawn": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"dev": true,
+			"requires": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
+			}
+		},
 		"crypto-random-string": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
 			"dev": true
 		},
 		"currently-unhandled": {
@@ -3289,9 +2949,9 @@
 			}
 		},
 		"docsify-cli": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/docsify-cli/-/docsify-cli-4.4.1.tgz",
-			"integrity": "sha512-M5VU/8UCILz87D519KnURH3LA+A3RAAqj7ifDv4xOUf4c32QDkWSETS3yLmXlTNdxhATVi5P1fVklnvVW4uOyw==",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/docsify-cli/-/docsify-cli-4.4.2.tgz",
+			"integrity": "sha512-iCTRyKjjNiSroo5cgVkb/C86PsUEEsVV30PXp5GkzbcMG+mMxzBPmJ/8xukTLoeaQddEsSeSWW376eC2t4KQJw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
@@ -3300,43 +2960,16 @@
 				"cp-file": "^7.0.0",
 				"docsify": "^4.10.2",
 				"docsify-server-renderer": ">=4",
+				"enquirer": "^2.3.6",
 				"fs-extra": "^8.1.0",
 				"get-port": "^5.0.0",
 				"livereload": "^0.9.1",
 				"lru-cache": "^5.1.1",
 				"open": "^6.4.0",
 				"serve-static": "^1.12.1",
-				"update-notifier": "^3.0.1",
+				"update-notifier": "^4.1.0",
 				"yargonaut": "^1.1.2",
 				"yargs": "^14.2.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-					"dev": true
-				}
 			}
 		},
 		"docsify-server-renderer": {
@@ -3353,9 +2986,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -3379,18 +3012,18 @@
 			}
 		},
 		"dompurify": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.1.1.tgz",
-			"integrity": "sha512-NijiNVkS/OL8mdQL1hUbCD6uty/cgFpmNiuFxrmJ5YPH2cXrPKIewoixoji56rbZ6XBPmtM8GA8/sf9unlSuwg==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.2.tgz",
+			"integrity": "sha512-BsGR4nDLaC5CNBnyT5I+d5pOeaoWvgVeg6Gq/aqmKYWMPR07131u60I80BvExLAJ0FQEIBQ1BTicw+C5+jOyrg==",
 			"dev": true
 		},
 		"dot-prop": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-			"integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
 			"dev": true,
 			"requires": {
-				"is-obj": "^1.0.0"
+				"is-obj": "^2.0.0"
 			}
 		},
 		"duplexer": {
@@ -3474,6 +3107,15 @@
 				"once": "^1.4.0"
 			}
 		},
+		"enquirer": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "^4.1.1"
+			}
+		},
 		"env-paths": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
@@ -3502,9 +3144,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.17.7",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-			"integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+			"version": "1.18.0-next.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+			"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.1",
@@ -3512,6 +3154,7 @@
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.1",
 				"is-callable": "^1.2.2",
+				"is-negative-zero": "^2.0.0",
 				"is-regex": "^1.1.1",
 				"object-inspect": "^1.8.0",
 				"object-keys": "^1.1.1",
@@ -3545,6 +3188,12 @@
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
+		},
+		"escape-goat": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+			"integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+			"dev": true
 		},
 		"escape-html": {
 			"version": "1.0.3",
@@ -3603,155 +3252,14 @@
 				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"cli-cursor": {
-					"version": "3.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cli-cursor/-/cli-cursor-3.1.0.tgz",
-					"integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
-					"dev": true,
-					"requires": {
-						"restore-cursor": "^3.1.0"
-					}
-				},
-				"cli-width": {
-					"version": "3.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cli-width/-/cli-width-3.0.0.tgz",
-					"integrity": "sha1-ovSEN6LKqaIkNueUvwceyeYc7fY=",
-					"dev": true
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
-					"dev": true
-				},
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "5.7.1",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-							"dev": true
-						}
-					}
-				},
 				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
 					}
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
-					"dev": true
-				},
-				"figures": {
-					"version": "3.2.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/figures/-/figures-3.2.0.tgz",
-					"integrity": "sha1-YlwYvSk8YE3EqN2y/r8MiDQXRq8=",
-					"dev": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.5"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
-					"dev": true
-				},
-				"inquirer": {
-					"version": "7.3.3",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/inquirer/-/inquirer-7.3.3.tgz",
-					"integrity": "sha1-BNF2sq8Er8FXqD/XwQDpjuCq0AM=",
-					"dev": true,
-					"requires": {
-						"ansi-escapes": "^4.2.1",
-						"chalk": "^4.1.0",
-						"cli-cursor": "^3.1.0",
-						"cli-width": "^3.0.0",
-						"external-editor": "^3.0.3",
-						"figures": "^3.0.0",
-						"lodash": "^4.17.19",
-						"mute-stream": "0.0.8",
-						"run-async": "^2.4.0",
-						"rxjs": "^6.6.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0",
-						"through": "^2.3.6"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "4.1.0",
-							"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/chalk/-/chalk-4.1.0.tgz",
-							"integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						}
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
-					"dev": true
-				},
-				"mimic-fn": {
-					"version": "2.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mimic-fn/-/mimic-fn-2.1.0.tgz",
-					"integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
-					"dev": true
 				},
 				"ms": {
 					"version": "2.1.2",
@@ -3759,61 +3267,11 @@
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				},
-				"onetime": {
-					"version": "5.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/onetime/-/onetime-5.1.2.tgz",
-					"integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
-					}
-				},
-				"restore-cursor": {
-					"version": "3.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/restore-cursor/-/restore-cursor-3.1.0.tgz",
-					"integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
-					"dev": true,
-					"requires": {
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					},
-					"dependencies": {
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						}
-					}
-				},
 				"strip-json-comments": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
 				}
 			}
 		},
@@ -3904,14 +3362,6 @@
 				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "7.4.1",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/acorn/-/acorn-7.4.1.tgz",
-					"integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
-					"dev": true
-				}
 			}
 		},
 		"esprima": {
@@ -3979,47 +3429,18 @@
 			"dev": true
 		},
 		"execa": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
 				"is-stream": "^1.1.0",
 				"npm-run-path": "^2.0.0",
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "5.1.0",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cross-spawn/-/cross-spawn-5.1.0.tgz",
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
-					"dev": true,
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-					"dev": true
-				}
 			}
 		},
 		"expand-brackets": {
@@ -4233,6 +3654,15 @@
 			"integrity": "sha512-ZQJM4aifMpz6H19AW1VqvZ7l4pOE9p7i/3LyxgO2kp+PO/VcDYNqIHEMtkccqIhTXMKci4kjueJr/iCQEaT/Ww==",
 			"dev": true
 		},
+		"figures": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			}
+		},
 		"file-entry-cache": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
@@ -4361,6 +3791,17 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
+		"fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			}
+		},
 		"fs-minipass": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
@@ -4471,6 +3912,17 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
+		},
+		"get-intrinsic": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+			"integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
 		},
 		"get-pkg-repo": {
 			"version": "1.4.0",
@@ -4662,10 +4114,13 @@
 			"dev": true
 		},
 		"get-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"dev": true,
+			"requires": {
+				"pump": "^3.0.0"
+			}
 		},
 		"get-value": {
 			"version": "2.0.6",
@@ -4906,9 +4361,9 @@
 			}
 		},
 		"git-url-parse": {
-			"version": "11.3.0",
-			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.3.0.tgz",
-			"integrity": "sha512-i3XNa8IKmqnUqWBcdWBjOcnyZYfN3C1WRvnKI6ouFWwsXCZEnlgbwbm55ZpJ3OJMhfEP/ryFhqW8bBhej3C5Ug==",
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.4.0.tgz",
+			"integrity": "sha512-KlIa5jvMYLjXMQXkqpFzobsyD/V2K5DRHl5OAf+6oDFPlPLxrGDVQlIdI63c4/Kt6kai4kALENSALlzTGST3GQ==",
 			"dev": true,
 			"requires": {
 				"git-up": "^4.0.0"
@@ -4953,12 +4408,12 @@
 			"dev": true
 		},
 		"global-dirs": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
+			"integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
 			"dev": true,
 			"requires": {
-				"ini": "^1.3.4"
+				"ini": "^1.3.5"
 			}
 		},
 		"globals": {
@@ -4968,14 +4423,6 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-					"dev": true
-				}
 			}
 		},
 		"globby": {
@@ -4992,14 +4439,6 @@
 				"ignore": "^4.0.3",
 				"pify": "^4.0.1",
 				"slash": "^2.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				}
 			}
 		},
 		"good-listener": {
@@ -5029,17 +4468,6 @@
 				"p-cancelable": "^1.0.0",
 				"to-readable-stream": "^1.0.0",
 				"url-parse-lax": "^3.0.0"
-			},
-			"dependencies": {
-				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				}
 			}
 		},
 		"graceful-fs": {
@@ -5261,9 +4689,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -5317,9 +4745,9 @@
 			}
 		},
 		"import-fresh": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-			"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+			"integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
 			"dev": true,
 			"requires": {
 				"parent-module": "^1.0.0",
@@ -5406,6 +4834,93 @@
 				}
 			}
 		},
+		"inquirer": {
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+			"integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^4.1.0",
+				"cli-cursor": "^3.1.0",
+				"cli-width": "^3.0.0",
+				"external-editor": "^3.0.3",
+				"figures": "^3.0.0",
+				"lodash": "^4.17.19",
+				"mute-stream": "0.0.8",
+				"run-async": "^2.4.0",
+				"rxjs": "^6.6.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0",
+				"through": "^2.3.6"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -5469,9 +4984,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
-			"integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -5562,13 +5077,13 @@
 			}
 		},
 		"is-installed-globally": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+			"integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
 			"dev": true,
 			"requires": {
-				"global-dirs": "^0.1.0",
-				"is-path-inside": "^1.0.0"
+				"global-dirs": "^2.0.1",
+				"is-path-inside": "^3.0.1"
 			}
 		},
 		"is-negative-zero": {
@@ -5578,9 +5093,9 @@
 			"dev": true
 		},
 		"is-npm": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
-			"integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
+			"integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
 			"dev": true
 		},
 		"is-number": {
@@ -5590,19 +5105,16 @@
 			"dev": true
 		},
 		"is-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
 			"dev": true
 		},
 		"is-path-inside": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-			"dev": true,
-			"requires": {
-				"path-is-inside": "^1.0.1"
-			}
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+			"integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+			"dev": true
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
@@ -5780,10 +5292,19 @@
 			"dev": true
 		},
 		"jsonc-parser": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
-			"integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+			"integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
 			"dev": true
+		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
 		},
 		"jsonparse": {
 			"version": "1.3.1",
@@ -5900,10 +5421,10 @@
 				"type-fest": "^0.3.0"
 			},
 			"dependencies": {
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+				"type-fest": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
 					"dev": true
 				}
 			}
@@ -6074,9 +5595,9 @@
 			}
 		},
 		"marked": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-1.2.0.tgz",
-			"integrity": "sha512-tiRxakgbNPBr301ihe/785NntvYyhxlqcL3YaC8CaxJQh7kiaEtrN9B/eK2I2943Yjkh5gw25chYFDQhOMCwMA==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-1.2.5.tgz",
+			"integrity": "sha512-2AlqgYnVPOc9WDyWu7S5DJaEZsfk6dNh/neatQ3IHUW4QLutM/VPSH9lG7bif+XjFWc9K9XR3QvR+fXuECmfdA==",
 			"dev": true
 		},
 		"medium-zoom": {
@@ -6086,9 +5607,9 @@
 			"dev": true
 		},
 		"meow": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
-			"integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-8.0.0.tgz",
+			"integrity": "sha512-nbsTRz2fwniJBFgUkcdISq8y/q9n9VbiHYbfwklFh5V4V2uAcxtKQkDc0yCLPM/kP0d+inZBewn3zJqewHE7kg==",
 			"dev": true,
 			"requires": {
 				"@types/minimist": "^1.2.0",
@@ -6096,12 +5617,12 @@
 				"decamelize-keys": "^1.1.0",
 				"hard-rejection": "^2.1.0",
 				"minimist-options": "4.1.0",
-				"normalize-package-data": "^2.5.0",
+				"normalize-package-data": "^3.0.0",
 				"read-pkg-up": "^7.0.1",
 				"redent": "^3.0.0",
 				"trim-newlines": "^3.0.0",
-				"type-fest": "^0.13.1",
-				"yargs-parser": "^18.1.3"
+				"type-fest": "^0.18.0",
+				"yargs-parser": "^20.2.3"
 			},
 			"dependencies": {
 				"find-up": {
@@ -6114,6 +5635,15 @@
 						"path-exists": "^4.0.0"
 					}
 				},
+				"hosted-git-info": {
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
+					"integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
 				"locate-path": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -6121,6 +5651,27 @@
 					"dev": true,
 					"requires": {
 						"p-locate": "^4.1.0"
+					}
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"normalize-package-data": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
+					"integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "^3.0.6",
+						"resolve": "^1.17.0",
+						"semver": "^7.3.2",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"p-locate": {
@@ -6162,6 +5713,30 @@
 						"type-fest": "^0.6.0"
 					},
 					"dependencies": {
+						"hosted-git-info": {
+							"version": "2.8.8",
+							"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+							"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+							"dev": true
+						},
+						"normalize-package-data": {
+							"version": "2.5.0",
+							"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+							"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+							"dev": true,
+							"requires": {
+								"hosted-git-info": "^2.1.4",
+								"resolve": "^1.10.0",
+								"semver": "2 || 3 || 4 || 5",
+								"validate-npm-package-license": "^3.0.1"
+							}
+						},
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+							"dev": true
+						},
 						"type-fest": {
 							"version": "0.6.0",
 							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
@@ -6189,21 +5764,32 @@
 						}
 					}
 				},
+				"semver": {
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
 				"type-fest": {
-					"version": "0.13.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-					"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+					"version": "0.18.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+					"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+					"dev": true
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				},
 				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
+					"version": "20.2.4",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+					"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+					"dev": true
 				}
 			}
 		},
@@ -6339,6 +5925,12 @@
 				"mime-db": "1.44.0"
 			}
 		},
+		"mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true
+		},
 		"mimic-response": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -6412,20 +6004,6 @@
 				"pumpify": "^1.3.3",
 				"stream-each": "^1.1.0",
 				"through2": "^2.0.0"
-			},
-			"dependencies": {
-				"concat-stream": {
-					"version": "1.6.2",
-					"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/concat-stream/-/concat-stream-1.6.2.tgz",
-					"integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.2.2",
-						"typedarray": "^0.0.6"
-					}
-				}
 			}
 		},
 		"mixin-deep": {
@@ -6823,9 +6401,9 @@
 			}
 		},
 		"object-inspect": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-			"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+			"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
 			"dev": true
 		},
 		"object-keys": {
@@ -6844,47 +6422,26 @@
 			}
 		},
 		"object.assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
-			"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.0",
 				"has-symbols": "^1.0.1",
 				"object-keys": "^1.1.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-					"dev": true,
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
-					}
-				}
 			}
 		},
 		"object.getownpropertydescriptors": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz",
+			"integrity": "sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
+				"es-abstract": "^1.18.0-next.1"
 			}
 		},
 		"object.pick": {
@@ -6918,6 +6475,15 @@
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
+			}
+		},
+		"onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^2.1.0"
 			}
 		},
 		"open": {
@@ -7200,12 +6766,6 @@
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
-		"path-is-inside": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-			"dev": true
-		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -7225,6 +6785,14 @@
 			"dev": true,
 			"requires": {
 				"pify": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"performance-now": {
@@ -7240,9 +6808,9 @@
 			"dev": true
 		},
 		"pify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 			"dev": true
 		},
 		"pinkie": {
@@ -7354,12 +6922,6 @@
 				"genfun": "^5.0.0"
 			}
 		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
-		},
 		"psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -7404,6 +6966,15 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
+		},
+		"pupa": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+			"integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
+			"dev": true,
+			"requires": {
+				"escape-goat": "^2.0.0"
+			}
 		},
 		"q": {
 			"version": "1.5.1",
@@ -7510,6 +7081,12 @@
 						"pify": "^3.0.0",
 						"strip-bom": "^3.0.0"
 					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				}
 			}
 		},
@@ -7639,9 +7216,9 @@
 			"dev": true
 		},
 		"registry-auth-token": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
-			"integrity": "sha512-P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+			"integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
 			"dev": true,
 			"requires": {
 				"rc": "^1.2.8"
@@ -7718,12 +7295,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.18.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
-			"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.0.0",
+				"is-core-module": "^2.1.0",
 				"path-parse": "^1.0.6"
 			}
 		},
@@ -7769,6 +7346,16 @@
 			"dev": true,
 			"requires": {
 				"lowercase-keys": "^1.0.0"
+			}
+		},
+		"restore-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+			"dev": true,
+			"requires": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"ret": {
@@ -7851,20 +7438,12 @@
 			"dev": true
 		},
 		"semver-diff": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+			"integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
 			"dev": true,
 			"requires": {
-				"semver": "^5.0.3"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
+				"semver": "^6.3.0"
 			}
 		},
 		"send": {
@@ -8201,9 +7780,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
-			"integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
 			"dev": true
 		},
 		"split": {
@@ -8309,34 +7888,63 @@
 			"dev": true
 		},
 		"string-width": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
 			"dev": true,
 			"requires": {
-				"emoji-regex": "^7.0.1",
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^5.1.0"
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
 			}
 		},
 		"string.prototype.trimend": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-			"integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+			"integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5"
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3"
 			}
 		},
 		"string.prototype.trimstart": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-			"integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+			"integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5"
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3"
 			}
 		},
 		"string_decoder": {
@@ -8422,6 +8030,19 @@
 				"lodash": "^4.17.14",
 				"slice-ansi": "^2.1.0",
 				"string-width": "^3.0.0"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				}
 			}
 		},
 		"tar": {
@@ -8467,17 +8088,20 @@
 					"requires": {
 						"pify": "^3.0.0"
 					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				}
 			}
 		},
 		"term-size": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-			"dev": true,
-			"requires": {
-				"execa": "^0.7.0"
-			}
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+			"integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
+			"dev": true
 		},
 		"text-extensions": {
 			"version": "1.9.0",
@@ -8668,9 +8292,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-			"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 			"dev": true
 		},
 		"typedarray": {
@@ -8679,10 +8303,19 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
+		"typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"dev": true,
+			"requires": {
+				"is-typedarray": "^1.0.0"
+			}
+		},
 		"uglify-js": {
-			"version": "3.11.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.3.tgz",
-			"integrity": "sha512-wDRziHG94mNj2n3R864CvYw/+pc9y/RNImiTyrrf8BzgWn75JgFSwYvXrtZQMnMnOp/4UTrf3iCSQxSStPiByA==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.1.tgz",
+			"integrity": "sha512-o8lHP20KjIiQe5b/67Rh68xEGRrc2SRsCuuoYclXXoC74AfSRGblU1HKzJWH3HxPZ+Ort85fWHpSX7KwBUC9CQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -8729,12 +8362,12 @@
 			}
 		},
 		"unique-string": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+			"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
 			"dev": true,
 			"requires": {
-				"crypto-random-string": "^1.0.0"
+				"crypto-random-string": "^2.0.0"
 			}
 		},
 		"universal-user-agent": {
@@ -8745,6 +8378,12 @@
 			"requires": {
 				"os-name": "^3.1.0"
 			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -8799,23 +8438,75 @@
 			"dev": true
 		},
 		"update-notifier": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
-			"integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz",
+			"integrity": "sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==",
 			"dev": true,
 			"requires": {
-				"boxen": "^3.0.0",
-				"chalk": "^2.0.1",
-				"configstore": "^4.0.0",
+				"boxen": "^4.2.0",
+				"chalk": "^3.0.0",
+				"configstore": "^5.0.1",
 				"has-yarn": "^2.1.0",
 				"import-lazy": "^2.1.0",
 				"is-ci": "^2.0.0",
-				"is-installed-globally": "^0.1.0",
-				"is-npm": "^3.0.0",
+				"is-installed-globally": "^0.3.1",
+				"is-npm": "^4.0.0",
 				"is-yarn-global": "^0.3.0",
 				"latest-version": "^5.0.0",
-				"semver-diff": "^2.0.0",
-				"xdg-basedir": "^3.0.0"
+				"pupa": "^2.0.1",
+				"semver-diff": "^3.1.1",
+				"xdg-basedir": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"uri-js": {
@@ -8876,9 +8567,9 @@
 			"dev": true
 		},
 		"v8-compile-cache": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-			"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+			"integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -8912,12 +8603,12 @@
 			}
 		},
 		"vscode-json-languageservice": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.9.1.tgz",
-			"integrity": "sha512-oJkknkdCVitQ5XPSRa0weHjUxt8eSCptaL+MBQQlRsa6Nb8XnEY0S5wYnLUFHzEvKzwt01/LKk8LdOixWEXkNA==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.11.0.tgz",
+			"integrity": "sha512-QxI+qV97uD7HHOCjh3MrM1TfbdwmTXrMckri5Tus1/FQiG3baDZb2C9Y0y8QThs7PwHYBIQXcAc59ZveCRZKPA==",
 			"dev": true,
 			"requires": {
-				"jsonc-parser": "^2.3.1",
+				"jsonc-parser": "^3.0.0",
 				"vscode-languageserver-textdocument": "^1.0.1",
 				"vscode-languageserver-types": "3.16.0-next.2",
 				"vscode-nls": "^5.0.0",
@@ -9026,39 +8717,12 @@
 			}
 		},
 		"widest-line": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-			"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
 			"dev": true,
 			"requires": {
-				"string-width": "^2.1.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
+				"string-width": "^4.0.0"
 			}
 		},
 		"windows-release": {
@@ -9068,51 +8732,6 @@
 			"dev": true,
 			"requires": {
 				"execa": "^1.0.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"execa": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"word-wrap": {
@@ -9136,6 +8755,19 @@
 				"ansi-styles": "^3.2.0",
 				"string-width": "^3.0.0",
 				"strip-ansi": "^5.0.0"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				}
 			}
 		},
 		"wrappy": {
@@ -9154,14 +8786,15 @@
 			}
 		},
 		"write-file-atomic": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-			"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.2"
+				"is-typedarray": "^1.0.0",
+				"signal-exit": "^3.0.2",
+				"typedarray-to-buffer": "^3.1.5"
 			}
 		},
 		"write-json-file": {
@@ -9188,17 +8821,22 @@
 						"semver": "^5.6.0"
 					}
 				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				},
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
+				},
+				"write-file-atomic": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+					"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
+					}
 				}
 			}
 		},
@@ -9219,6 +8857,23 @@
 					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"write-file-atomic": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+					"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"write-json-file": {
@@ -9247,9 +8902,9 @@
 			}
 		},
 		"xdg-basedir": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
 			"dev": true
 		},
 		"xtend": {
@@ -9259,9 +8914,9 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
 			"dev": true
 		},
 		"yallist": {
@@ -9340,6 +8995,19 @@
 				"which-module": "^2.0.0",
 				"y18n": "^4.0.0",
 				"yargs-parser": "^15.0.1"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				}
 			}
 		},
 		"yargs-parser": {

--- a/packages/gasket-plugin-nextjs/test/config.test.js
+++ b/packages/gasket-plugin-nextjs/test/config.test.js
@@ -152,14 +152,6 @@ describe('createConfig', () => {
 
     describe('built-ins', () => {
 
-      it('excludes SSR only modules', () => {
-        result = config.webpack(webpackConfig, data);
-        assume(result).to.have.property('node');
-        assume(result.node).to.have.property('fs', 'empty');
-        assume(result.node).to.have.property('net', 'empty');
-        assume(result.node).to.have.property('tls', 'empty');
-      });
-
       it('configures SASS loader', () => {
         result = config.webpack(webpackConfig, data);
 

--- a/packages/gasket-plugin-redux/package.json
+++ b/packages/gasket-plugin-redux/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^17.0.1",
     "react-redux": "^7.1.0",
     "redux": "^4.0.4",
-    "webpack": "^4.44.1"
+    "webpack": "^5.9.0"
   },
   "peerDependencies": {
     "@gasket/plugin-log": "^5.0.0",

--- a/packages/gasket-plugin-webpack/index.js
+++ b/packages/gasket-plugin-webpack/index.js
@@ -2,17 +2,6 @@ const WebpackChain = require('webpack-chain');
 const webpackMerge = require('webpack-merge');
 const WebpackMetricsPlugin = require('./webpack-metrics-plugin');
 
-const webpackDefaults = {
-  //
-  // Exclude any modules from webpack bundling that are utilized server-side
-  //
-  node: {
-    fs: 'empty',
-    net: 'empty',
-    tls: 'empty'
-  }
-};
-
 /**
 * Creates the webpack config
 * @param  {Gasket} gasket The Gasket API
@@ -32,7 +21,6 @@ function initWebpack(gasket, webpackConfig, data) {
   webpackConfig = webpackMerge.smart(
     webpackConfig,
     { plugins: [new WebpackMetricsPlugin({ gasket })] },
-    webpackDefaults,      // Defaults above
     chain.toConfig(),     // Webpack chain from plugins (partial)
     config.webpack || {}  // Webpack config from user (partial)
   );

--- a/packages/gasket-plugin-webpack/test/plugin.test.js
+++ b/packages/gasket-plugin-webpack/test/plugin.test.js
@@ -66,7 +66,6 @@ describe('initWebpack hook', () => {
     assume(result).has.property('plugins');
     assume(result).has.property('module');
     assume(result).has.property('optimization');
-    assume(result).has.property('node');
   });
 
   it('returns webpack config object with configs merged', async function () {
@@ -79,7 +78,6 @@ describe('initWebpack hook', () => {
     assume(result).has.property('plugins');
     assume(result).has.property('module');
     assume(result).has.property('optimization');
-    assume(result).has.property('node');
     assume(result).has.property('newConfig1');
     assume(result).has.property('newConfig2');
   });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Fortunately, we were not doing too much with webpack config, so changes to support it are minimal. The only real change was to the default webpack config, which honestly was overly prescriptive. If apps do have such a scenario, they can describe node in their own weback 4 config, or use [resolve.fallback](https://webpack.js.org/configuration/resolve/#resolvefallback) as described by [webpack 5 docs](https://webpack.js.org/configuration/node/).

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/plugin-webpack**
- Remove `node` config defaults to support webpack 5

_The only changes are to an affected test and to use webpack 5 as dev dependency_

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

This was tested under a fresh local app and the canary app. I verified the changes when using next.js and webpack 5 with yarn resolutions. I then downgraded back to webpack 4 and verified the changes still work on it.
