### PR TITLE
Opt-in Intl support for getInitialProps

### DIFF
--- a/packages/gasket-plugin-intl/lib/middleware.js
+++ b/packages/gasket-plugin-intl/lib/middleware.js
@@ -75,6 +75,8 @@ module.exports = function middlewareHook(gasket) {
       return messages[id] || defaultMessage || id;
     };
 
+    res.locals.localesDir = localesDir;
+
     next();
   };
 };

--- a/packages/gasket-plugin-intl/test/middleware.test.js
+++ b/packages/gasket-plugin-intl/test/middleware.test.js
@@ -93,6 +93,12 @@ describe('middleware', function () {
       assume(res.locals.gasketData.intl).property('basePath', '/some/base/path');
     });
 
+    it('res.locals has configured localesDir', async function () {
+      layer = middlewareHook(mockGasket);
+      await layer(req, res, next);
+      assume(res.locals).property('localesDir', mockGasket.config.intl.localesDir);
+    });
+
     describe('req.withLocaleRequired', function () {
       it('method is added to req', async function () {
         await layer(req, res, next);

--- a/packages/gasket-react-intl/README.md
+++ b/packages/gasket-react-intl/README.md
@@ -57,6 +57,8 @@ wrapped component will be rendered.
   [locales path] in the plugin docs.
 - `[options]` - (object) Optional configuration
   - `loading` - (string|node) Content to render while loading, otherwise null.
+  - `initialProps` - (boolean) Enable `getInitialProps` to load locale files
+    during server-side rendering for Next.js pages. Defaults to `false`.
 
 #### Example
 
@@ -186,6 +188,31 @@ export default Component;
 export const getServerSideProps = intlGetServerSideProps('/locales');
 ```
 
+One caveat to using `getServerSideProps` is that the locales will be fetched for
+page changes in the browser as well. Since a locale file should only be loaded
+once for an app, consider using `getInitialProps` instead for loading during
+server rendering.
+
+### getInitialProps
+
+To enable `getInitialProps` for preloading locale files during server-side
+rendering if Next.js pages, you can set the `initialProps` options to `true`.
+
+#### Example
+
+```jsx
+import { withLocaleRequired } from '@gasket/react-intl';
+import { FormattedMessage } from 'react-intl';
+
+const Component = props => <h1><FormattedMessage id='welcome'/></h1>
+
+export default withLocaleRequired('/locales', { initialProps: true })(Component);
+```
+
+This cannot be combined with `getServerSideProps`, so in those cases where you
+need it, another option to preload locale props during SSR is with
+[req.withLocaleRequired].
+
 <!-- LINKS -->
 
 [withIntlProvider]:#withintlprovider
@@ -197,6 +224,7 @@ export const getServerSideProps = intlGetServerSideProps('/locales');
 [@gasket/plugin-intl]:/packages/gasket-plugin-intl/README.md
 [locales path]:/packages/gasket-plugin-intl/README.md#locales-path
 [split locales]:/packages/gasket-plugin-intl/README.md#split-locales
+[req.withLocaleRequired]:/packages/gasket-plugin-intl/README.md#withlocalerequired
 
 [react-intl]:https://formatjs.io/docs/react-intl
 [getStaticProps]:https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation

--- a/packages/gasket-react-intl/src/with-locale-required.js
+++ b/packages/gasket-react-intl/src/with-locale-required.js
@@ -1,19 +1,51 @@
 import React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
+import path from 'path';
 import { manifest } from './config';
-import { LOADING } from './utils';
+import { LOADING, localeUtils } from './utils';
 import { useGasketIntl } from './hooks';
+
+const { defaultLocale, defaultPath } = manifest;
+
+/**
+ * Sets up and attaches the getInitialProps static method which preloads locale
+ * files during SSR for Next.js pages. For browser routing, the locale files
+ * will be fetched as normal.
+ *
+ * @param {React.ComponentType} Wrapper - The HOC
+ * @param {LocalePathPart} localePathPath - Path containing locale files
+ */
+function attachGetInitialProps(Wrapper, localePathPath) {
+  const { WrappedComponent } = Wrapper;
+
+  Wrapper.getInitialProps = async (ctx) => {
+    const { res } = ctx;
+    let localesProps;
+
+    if (res) {
+      const { locale = defaultLocale } = res.locals.gasketData.intl || {};
+      const localesParentDir = path.dirname(res.locals.localesDir);
+      localesProps = localeUtils.serverLoadData(localePathPath, locale, localesParentDir);
+    }
+
+    return {
+      ...(localesProps ? { localesProps } : {}),
+      ...(WrappedComponent.getInitialProps ? await WrappedComponent.getInitialProps(ctx) : {})
+    };
+  };
+}
 
 /**
  * Make an HOC that loads a locale file before rendering wrapped component
  *
- * @param {LocalePathPart} localesPath - Path containing locale files
+ * @param {LocalePathPart} localePathPath - Path containing locale files
  * @param {object} [options] - Options
- * @param {React.Component} [options.loading] - Custom component to show while loading
+ * @param {React.Component} [options.loading=null] - Custom component to show while loading
+ * @param {React.Component} [options.initialProps=false] - Preload locales during SSR with Next.js pages
  * @returns {function} wrapper
  */
-export default function withLocaleRequired(localesPath = manifest.defaultPath, options = {}) {
-  const { loading = null } = options;
+export default function withLocaleRequired(localePathPath = defaultPath, options = {}) {
+  const { loading = null, initialProps = false } = options;
   /**
    * Wrap the component
    * @param {React.Component} Component - Component to wrap
@@ -27,13 +59,19 @@ export default function withLocaleRequired(localesPath = manifest.defaultPath, o
      * @returns {JSX.Element} element
      */
     function Wrapper(props) {
-      const loadState = useGasketIntl(localesPath);
+      const loadState = useGasketIntl(localePathPath);
       if (loadState === LOADING) return loading;
       return <Component { ...props } />;
     }
 
-    Wrapper.displayName = `withLocaleRequired(${ Component.displayName || Component.name || 'Component' })`;
     hoistNonReactStatics(Wrapper, Component);
+    Wrapper.displayName = `withLocaleRequired(${ Component.displayName || Component.name || 'Component' })`;
+    Wrapper.WrappedComponent = Component;
+
+    if (initialProps || 'getInitialProps' in Component) {
+      attachGetInitialProps(Wrapper, localePathPath);
+    }
+
     return Wrapper;
   };
 }

--- a/packages/gasket-react-intl/test/with-locale-required.test.js
+++ b/packages/gasket-react-intl/test/with-locale-required.test.js
@@ -14,7 +14,7 @@ const MockComponent = class extends React.Component {
 };
 
 describe('withLocaleRequired', function () {
-  let mockConfig, useGasketIntlStub, withLocaleRequired, wrapper, serverLoadDataStub;
+  let mockConfig, useGasketIntlStub, withLocaleRequired, wrapper;
 
   const doMount = (...args) => {
     const Wrapped = withLocaleRequired(...args)(MockComponent);
@@ -23,7 +23,6 @@ describe('withLocaleRequired', function () {
 
   beforeEach(function () {
     useGasketIntlStub = sinon.stub();
-    serverLoadDataStub = sinon.stub();
     mockConfig = {
       defaultLocale: 'en-US',
       manifest: { ...mockManifest, paths: { ...mockManifest.paths } },


### PR DESCRIPTION
## Summary

Per #224, upon implementing `getServerSideProps` for intl, we found it to not be as performant as the previous `getInitialProps` implementation. The reason being is that with `getServerSideProps`, props are fetched with each browser route to the page. This is wasteful since locale files should really only be loaded once.

This introduces an opt-in `initialProps` option to the HOC, allowing `getInitialProps` to be added for Next.js pages which will preload locale files during SSR.

## Changelog

**@gasket/react-intl**
- Add `initialProps` options for enabled getInitialProps to preload locale files

**@gasket/plugin-intl**
- Attach the configured `localesDir` to `res.locals` for use during SSR

## Test Plan

- Local testing in dummy app
- Updated unit tests

