### PR TITLE
App config available from @gasket/data

### DIFF
--- a/packages/gasket-nextjs/README.md
+++ b/packages/gasket-nextjs/README.md
@@ -32,7 +32,7 @@ This is the simplest and most common setup:
 ```jsx
 // pages/_document.js
 import Document from 'next/document';
-import { withGasketData } from '@gasket/next';
+import { withGasketData } from '@gasket/nextjs';
 
 export default withGasketData()(Document);
 ```

--- a/packages/gasket-plugin-config/README.md
+++ b/packages/gasket-plugin-config/README.md
@@ -169,6 +169,19 @@ module.exports = {
 };
 ```
 
+### Config with Public config
+
+If you are not using Redux, but still need access to config values in client-side code, you can define a `public` property in your `gasket.config.js`. The config plugin will return these `public` properties to your browser, to be accessed by the `@gasket/data` plugin.
+
+```js
+module.exports = {
+  public: {
+    test1: 'config values here',
+    test2: 'config values here'
+  }
+};
+```
+
 ## Lifecycles
 
 ### appEnvConfig

--- a/packages/gasket-plugin-config/README.md
+++ b/packages/gasket-plugin-config/README.md
@@ -181,7 +181,7 @@ module.exports = {
   }
 };
 ```
-The config plugin will return these `public` properties to your browser, to be accessed by the `@gasket/data` plugin, and used like so:
+The config plugin will return these `public` properties to your browser, to be accessed by `@gasket/data`, and used like so:
 
 ```js
 import gasketData from '@gasket/data';

--- a/packages/gasket-plugin-config/README.md
+++ b/packages/gasket-plugin-config/README.md
@@ -186,7 +186,7 @@ The config plugin will return these `public` properties to your browser, to be a
 ```js
 import gasketData from '@gasket/data';
 
-console.log(gasketData.test1); // config value 1 here
+console.log(gasketData.config.test1); // config value 1 here
 ```
 
 ## Lifecycles

--- a/packages/gasket-plugin-config/README.md
+++ b/packages/gasket-plugin-config/README.md
@@ -171,15 +171,22 @@ module.exports = {
 
 ### Config with Public config
 
-If you are not using Redux, but still need access to config values in client-side code, you can define a `public` property in your `gasket.config.js`. The config plugin will return these `public` properties to your browser, to be accessed by the `@gasket/data` plugin.
+If you are not using Redux, but still need access to config values in client-side code, you can define a `public` property in your `gasket.config.js`.
 
 ```js
 module.exports = {
   public: {
-    test1: 'config values here',
-    test2: 'config values here'
+    test1: 'config value 1 here',
+    test2: 'config value 2 here'
   }
 };
+```
+The config plugin will return these `public` properties to your browser, to be accessed by the `@gasket/data` plugin, and used like so:
+
+```js
+import gasketData from '@gasket/data';
+
+console.log(gasketData.test1); // config value 1 here
 ```
 
 ## Lifecycles

--- a/packages/gasket-plugin-config/README.md
+++ b/packages/gasket-plugin-config/README.md
@@ -181,7 +181,7 @@ module.exports = {
   }
 };
 ```
-The config plugin will return these `public` properties to your browser, to be accessed by `@gasket/data`, and used like so:
+The config plugin will return these `public` properties to your browser, to be accessed by `@gasket/data`. They are available as properties on `.config` and used like so:
 
 ```js
 import gasketData from '@gasket/data';

--- a/packages/gasket-plugin-config/lib/middleware.js
+++ b/packages/gasket-plugin-config/lib/middleware.js
@@ -17,15 +17,12 @@ function handler(gasket) {
         res);
 
       const { gasketData = {} } = res.locals;
-      let { config = {} } = gasketData;
-      let { public = {} } = config;
+      const { public: config = {} } = req.config;
 
-      const publicConfig = gasket.config.public || {};
-      public = merge(public, publicConfig);
-      config.public = merge(config.public || {}, public)
-      gasketData.config = merge(gasketData.config || {}, config);
+      if (Object.keys(config).length > 0 && config.constructor === Object) {
+        res.locals.gasketData = merge(gasketData, { config });
+      }
 
-      res.locals.gasketData = gasketData;
 
       return void next();
     } catch (err) {

--- a/packages/gasket-plugin-config/lib/middleware.js
+++ b/packages/gasket-plugin-config/lib/middleware.js
@@ -23,7 +23,6 @@ function handler(gasket) {
         res.locals.gasketData = merge(gasketData, { config });
       }
 
-
       return void next();
     } catch (err) {
       return void next(err);

--- a/packages/gasket-plugin-config/lib/middleware.js
+++ b/packages/gasket-plugin-config/lib/middleware.js
@@ -1,0 +1,42 @@
+const { ENV_CONFIG } = require('./constants');
+const merge = require('lodash.merge');
+
+/**
+ * Add middleware to gather config details
+ *
+ * @param {Gasket} gasket - The gasket API
+ * @returns {function} Express middleware to apply
+ */
+function handler(gasket) {
+  return async (req, res, next) => {
+    try {
+      req.config = await gasket.execWaterfall(
+        'appRequestConfig',
+        gasket[ENV_CONFIG],
+        req,
+        res);
+
+      const { gasketData = {} } = res.locals;
+      let { config = {} } = gasketData;
+      let { public = {} } = config;
+
+      const publicConfig = gasket.config.public || {};
+      public = merge(public, publicConfig);
+      config.public = merge(config.public || {}, public)
+      gasketData.config = merge(gasketData.config || {}, config);
+
+      res.locals.gasketData = gasketData;
+
+      return void next();
+    } catch (err) {
+      return void next(err);
+    }
+  };
+}
+
+module.exports = {
+  timing: {
+    before: ['@gasket/plugin-redux']
+  },
+  handler
+};

--- a/packages/gasket-plugin-config/lib/plugin.js
+++ b/packages/gasket-plugin-config/lib/plugin.js
@@ -2,6 +2,7 @@
 
 const mergeConfigFiles = require('./merge-config-files');
 const mergeRootConfig = require('./merge-root-config');
+const middleware = require('./middleware');
 const { ENV_CONFIG } = require('./constants');
 
 module.exports = {
@@ -13,27 +14,7 @@ module.exports = {
         mergeRootConfig(gasket, mergeConfigFiles(gasket))
       );
     },
-
-    middleware: {
-      timing: {
-        before: ['@gasket/plugin-redux']
-      },
-      handler(gasket) {
-        return async (req, res, next) => {
-          try {
-            req.config = await gasket.execWaterfall(
-              'appRequestConfig',
-              gasket[ENV_CONFIG],
-              req,
-              res);
-            return void next();
-          } catch (err) {
-            return void next(err);
-          }
-        };
-      }
-    },
-
+    middleware,
     initReduxState(gasket, state, req) {
       const { redux } = req.config || {};
       return {
@@ -41,7 +22,6 @@ module.exports = {
         config: redux
       };
     },
-
     metadata(gasket, meta) {
       const { configPath = 'config/' } = gasket.config;
       return {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
We need a way for app config to be made available in the browser, when Redux is not used. Today, teams can set config under a Redux property which will make it available in the Redux store.

For this change, we introduced a new special property (public) which will add its values to res.locals.gasketData.config, and thus be made available in the browser under with @gasket/data as gasketData.config.

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
Tests updated.