### PR TITLE
Support Next i18n Routing

### DIFF
--- a/packages/gasket-plugin-intl/lib/build-manifest.js
+++ b/packages/gasket-plugin-intl/lib/build-manifest.js
@@ -20,7 +20,7 @@ module.exports = async function buildManifest(gasket) {
   const { logger } = gasket;
   const { localesDir, manifestFilename } = getIntlConfig(gasket);
   const tgtFile = path.join(localesDir, manifestFilename);
-  const { basePath, defaultPath, defaultLocale, localesMap } = getIntlConfig(gasket);
+  const { basePath, defaultPath, defaultLocale, locales, localesMap } = getIntlConfig(gasket);
 
   // find all the .json files except the manifest
   const files = (await glob('**/*.json', { cwd: localesDir }))
@@ -49,6 +49,7 @@ module.exports = async function buildManifest(gasket) {
     basePath,
     defaultPath,
     defaultLocale,
+    locales,
     localesMap,
     paths
   };

--- a/packages/gasket-plugin-intl/lib/configure.js
+++ b/packages/gasket-plugin-intl/lib/configure.js
@@ -26,9 +26,9 @@ function getIntlConfig(gasket) {
 function deprecatedOptions(gasket, intlConfig) {
   const { logger } = gasket;
   const { languageMap, defaultLanguage, assetPrefix } = intlConfig;
-  if (languageMap) logger.warn('DEPRECATED intl config `languageMap` - use `localesMap`');
-  if (defaultLanguage) logger.warn('DEPRECATED intl config `defaultLanguage` - use `defaultLocale`');
-  if (assetPrefix) logger.warn('DEPRECATED intl config `assetPrefix` - use `basePath`');
+  if (languageMap) logger.warning('DEPRECATED intl config `languageMap` - use `localesMap`');
+  if (defaultLanguage) logger.warning('DEPRECATED intl config `defaultLanguage` - use `defaultLocale`');
+  if (assetPrefix) logger.warning('DEPRECATED intl config `assetPrefix` - use `basePath`');
   return { languageMap, defaultLanguage, assetPrefix };
 }
 
@@ -45,6 +45,7 @@ module.exports = function configureHook(gasket, config) {
   const intlConfig = { ...getIntlConfig({ config }) };
 
   const { languageMap, defaultLanguage, assetPrefix } = deprecatedOptions(gasket, intlConfig);
+  const { nextConfig = {} } = config;
 
   // get user defined config and apply defaults
   const {
@@ -57,9 +58,8 @@ module.exports = function configureHook(gasket, config) {
 
   const fullLocalesDir = path.join(root, localesDir);
 
-  const { next = {} } = config;
   const basePath = intlConfig.basePath || assetPrefix ||
-    next.basePath || next.assetPrefix ||
+    nextConfig.basePath || nextConfig.assetPrefix ||
     config.basePath || '';
 
   let { modules = false } = intlConfig;

--- a/packages/gasket-plugin-intl/package.json
+++ b/packages/gasket-plugin-intl/package.json
@@ -38,7 +38,8 @@
     "intl": "^1.2.5",
     "loader-utils": "^1.1.0",
     "lodash.merge": "^4.6.0",
-    "url-join": "^4.0.0"
+    "url-join": "^4.0.0",
+    "@hapi/accept": "^5.0.1"
   },
   "devDependencies": {
     "@gasket/helper-intl": "^6.0.0-canary.3",

--- a/packages/gasket-plugin-intl/test/build-manifest.test.js
+++ b/packages/gasket-plugin-intl/test/build-manifest.test.js
@@ -18,6 +18,7 @@ describe('buildManifest', function () {
           basePath: '',
           defaultPath: '/locales',
           defaultLocale: 'en-US',
+          locales: ['en-US', 'fr-FR', 'fr-CH'],
           localesMap: {
             'fr-CH': 'fr-FR'
           },
@@ -52,7 +53,7 @@ describe('buildManifest', function () {
     const output = getOutput();
     const keys = Object.keys(output);
     assume(keys).eqls([
-      'basePath', 'defaultPath', 'defaultLocale', 'localesMap', 'paths'
+      'basePath', 'defaultPath', 'defaultLocale', 'locales', 'localesMap', 'paths'
     ]);
   });
 

--- a/packages/gasket-plugin-intl/test/configure.test.js
+++ b/packages/gasket-plugin-intl/test/configure.test.js
@@ -16,7 +16,7 @@ describe('configure', function () {
   const root = '/path/to/root';
   const mockGasket = {
     logger: {
-      warn: sinon.stub()
+      warning: sinon.stub()
     },
     config: {
       root
@@ -79,10 +79,10 @@ describe('configure', function () {
 
   it('logs deprecation warnings', function () {
     configure(mockGasket, { root, intl: { languageMap: { foo: 'bar' } } });
-    assume(mockGasket.logger.warn).calledWithMatch('languageMap');
+    assume(mockGasket.logger.warning).calledWithMatch('languageMap');
 
     configure(mockGasket, { root, intl: { defaultLanguage: 'fake' } });
-    assume(mockGasket.logger.warn).calledWithMatch('defaultLanguage');
+    assume(mockGasket.logger.warning).calledWithMatch('defaultLanguage');
   });
 
   describe('getIntlConfig', function () {

--- a/packages/gasket-plugin-intl/test/middleware.test.js
+++ b/packages/gasket-plugin-intl/test/middleware.test.js
@@ -48,19 +48,27 @@ describe('middleware', function () {
 
     it('executes expected lifecycle', async function () {
       await layer(req, res, next);
-      assume(mockGasket.execWaterfall).calledWith('intlLocale', 'fr-FR', req, res);
+      assume(mockGasket.execWaterfall).calledWith('intlLocale', 'fr-FR', { req, res });
+    });
+
+    it('passes first accepted from supported locales', async function () {
+      mockGasket.config.intl.locales = ['de'];
+      layer = middlewareHook(mockGasket);
+      req.headers['accept-language'] = 'fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5';
+      await layer(req, res, next);
+      assume(mockGasket.execWaterfall).calledWith('intlLocale', 'de', { req, res });
     });
 
     it('passes first accept-header', async function () {
       req.headers['accept-language'] = 'fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5';
       await layer(req, res, next);
-      assume(mockGasket.execWaterfall).calledWith('intlLocale', 'fr-CH', req, res);
+      assume(mockGasket.execWaterfall).calledWith('intlLocale', 'fr-CH', { req, res });
     });
 
     it('passes defaultLocale if no accept-header', async function () {
       delete req.headers['accept-language'];
       await layer(req, res, next);
-      assume(mockGasket.execWaterfall).calledWith('intlLocale', 'en-US', req, res);
+      assume(mockGasket.execWaterfall).calledWith('intlLocale', 'en-US', { req, res });
     });
 
     it('attaches gasketData to res.locals', async function () {

--- a/packages/gasket-plugin-nextjs/README.md
+++ b/packages/gasket-plugin-nextjs/README.md
@@ -21,6 +21,7 @@ npm i @gasket/plugin-nextjs next react react-dom
 Modify `plugins` section of your `gasket.config.js`:
 
 ```diff
+// gasket.config.js
 module.exports = {
   plugins: {
     add: [
@@ -32,8 +33,8 @@ module.exports = {
 
 ## Configuration
 
-- Instead of adding a dedicated `next.config.js`, the `next` property within
-  `gasket.config.js` is used. Everything you can configure in the
+- Instead of adding a dedicated `next.config.js`, the `nextConfig` property
+  within `gasket.config.js` is used. Everything you can configure in the
   [next.config] can be added here.
 
 It is also possible for apps to config Next.js using the `gasket.config.js`
@@ -57,7 +58,7 @@ module.exports = {
 }
 ```
 
-### Example with plugins
+#### Example with plugins
 
 ```js
 const withSass = require('@zeit/next-sass');
@@ -72,6 +73,48 @@ module.exports = {
   }))
 }
 ```
+
+### Internationalized Routing
+
+When using this plugin along with [@gasket/plugin-intl] to determine and provide
+locale files, be sure to set the [i18n config] for `defaultLocale` and supported
+`locales` in the `intl` plugin config, instead of the `nextConfig`. This will be
+used by the Gasket Intl plugin, and also passed along with the Next config for
+i18n routing.
+
+```diff
+// gasket.config.js
+module.exports = {
+  intl: {
++    defaultLocale: 'en-US',
++    locales: ['en-US', 'fr', 'nl-NL']
+  },
+  nextConfig: {
+    i18n: {
+-    locales: ['en-US', 'fr', 'nl-NL'],
+-    defaultLocale: 'en-US',
+    domains: [
+      {
+        domain: 'example.com',
+        defaultLocale: 'en-US',
+      },
+      {
+        domain: 'example.nl',
+        defaultLocale: 'nl-NL',
+      },
+      {
+        domain: 'example.fr',
+        defaultLocale: 'fr',
+      },
+    ],
+    }
+  }
+}
+```
+
+Also note when using [@gasket/plugin-intl] to determine the locale, that the
+`NEXT_LOCALE` cookie will have no effect. You can, of course, hook the [intlLocale]
+lifecycle in an app to enable that behavior if desired.
 
 ## Lifecycles
 
@@ -149,5 +192,9 @@ module.exports = {
 
 <!--[next.config]-->
 [nextConfig lifecycle]:#nextconfig
-[next.config]: https://nextjs.org/docs#custom-configuration
+[@gasket/plugin-intl]: /packages/gasket-plugin-intl/README.md
+[intlLocale]: /packages/gasket-plugin-intl/README.md#intllocale
 [webpack plugin]:/packages/gasket-plugin-webpack/README.md
+[next.config]: https://nextjs.org/docs#custom-configuration
+[i18n config]: https://nextjs.org/docs/advanced-features/i18n-routing#getting-started
+

--- a/packages/gasket-plugin-nextjs/config.js
+++ b/packages/gasket-plugin-nextjs/config.js
@@ -1,6 +1,32 @@
 const { initWebpack } = require('@gasket/plugin-webpack');
 
 /**
+ * Bring forward configuration from intl plugin to config for next.
+ *
+ * @param {Gasket} gasket - The gasket API
+ * @param {object} config - Configuration to pass to Nextjs
+ * @private
+ */
+function forwardIntlConfig(gasket, config) {
+  const { intl: intlConfig = {} } = gasket.config;
+
+  const { logger } = gasket;
+  // Carry over defaultLocale and locales from intl config
+  if (intlConfig.locales) {
+    if (config.i18n.locales) {
+      logger.warning('Gasket config has both `intl.locales` (preferred) and `nextConfig.i18n.locales`');
+    }
+    config.i18n.locales = intlConfig.locales;
+  }
+  if (intlConfig.defaultLocale) {
+    if (config.i18n.locales) {
+      logger.warning('Gasket config has both `intl.defaultLocale` (preferred) and `nextConfig.i18n.defaultLocale`');
+    }
+    config.i18n.defaultLocale = intlConfig.defaultLocale;
+  }
+}
+
+/**
  * Small helper function that creates nextjs configuration from the gasket
  * configuration.
  *
@@ -10,16 +36,24 @@ const { initWebpack } = require('@gasket/plugin-webpack');
  * @private
  */
 function createConfig(gasket, includeWebpackConfig = true) {
-  const { config } = gasket;
-  // prefer clearer property name with fall back
-  const { nextConfig = config.next || {} } = config;
+  const { nextConfig = {} } = gasket.config;
+  const { i18n = {} } = nextConfig;
+
+  const config = {
+    poweredByHeader: false,
+    ...nextConfig,
+    // make a copy of i18n for mutating
+    i18n: { ...i18n }
+  };
+
+  forwardIntlConfig(gasket, config);
 
   if (includeWebpackConfig) {
-    const { webpack: existingWebpack } = nextConfig;
+    const { webpack: existingWebpack } = config;
     //
     // Add webpack property to nextConfig and wrap existing
     //
-    nextConfig.webpack = function webpack(webpackConfig, data) {
+    config.webpack = function webpack(webpackConfig, data) {
       if (typeof existingWebpack === 'function') {
         webpackConfig = existingWebpack(webpackConfig, data);
       }
@@ -27,9 +61,7 @@ function createConfig(gasket, includeWebpackConfig = true) {
     };
   }
 
-  nextConfig.poweredByHeader = false;
-
-  return gasket.execWaterfall('nextConfig', nextConfig);
+  return gasket.execWaterfall('nextConfig', config);
 }
 
 module.exports = {

--- a/packages/gasket-plugin-nextjs/index.js
+++ b/packages/gasket-plugin-nextjs/index.js
@@ -102,6 +102,21 @@ module.exports = {
 
       await exec('nextExpress', { next: app, express: expressApp });
 
+      // If the Gasket Intl Plugin is used to determine the locale, then we need
+      // to let NextJS know that it has already been detected. We can do this by
+      // forcing the `NEXT_LOCALE` cookie:
+      // https://github.com/vercel/next.js/blob/canary/docs/advanced-features/i18n-routing.md#leveraging-the-next_locale-cookie
+      expressApp.use(function setNextLocale(req, res, next) {
+        if (res.locals && res.locals.gasketData && res.locals.gasketData.intl) {
+          const { locale } = res.locals.gasketData.intl;
+          if (locale) {
+            req.headers.cookie = (req.headers.cookie || '') + `;NEXT_LOCALE=${locale}`;
+          }
+        }
+        next();
+      });
+
+      // TODO: (@kinetifex) we no longer support next-routes - remove this
       const { root, routes } = gasket.config || {};
       const routesModulePath = path.join(root, routes || './routes');
       let ssr;

--- a/packages/gasket-react-intl/src/next.js
+++ b/packages/gasket-react-intl/src/next.js
@@ -13,7 +13,12 @@ const localesParentDir = path.dirname(process.env.GASKET_INTL_LOCALES_DIR);
  */
 export function intlGetStaticProps(localePathPath = manifest.defaultPath) {
   return async ctx => {
-    const { params: { locale } } = ctx;
+    // provide by next i18n
+    let { locale } = ctx;
+    // otherwise, check for locale in path params
+    if (!locale) {
+      locale = ctx.params.locale;
+    }
     const localesProps = localeUtils.serverLoadData(localePathPath, locale, localesParentDir);
 
     return {
@@ -33,7 +38,12 @@ export function intlGetStaticProps(localePathPath = manifest.defaultPath) {
 export function intlGetServerSideProps(localePathPath = manifest.defaultPath) {
   return async ctx => {
     const { res } = ctx;
-    const { locale } = res.locals.gasketData.intl || {};
+    // provide by next i18n
+    let { locale } = ctx;
+    // otherwise, check gasketData
+    if (!locale && res.locals && res.locals.gasketData && res.locals.gasketData.intl) {
+      locale = res.locals.gasketData.intl.locale;
+    }
     const localesProps = localeUtils.serverLoadData(localePathPath, locale, localesParentDir);
 
     return {

--- a/packages/gasket-react-intl/test/next.test.js
+++ b/packages/gasket-react-intl/test/next.test.js
@@ -105,6 +105,19 @@ describe('Next.js functions', function () {
         }
       });
     });
+
+    it('uses locale on context from builtin i18n routing', async function () {
+      const results = await next.intlGetStaticProps('/locales')({ locale: 'fr-CA' });
+      assume(results).eqls({
+        props: {
+          localesProps: {
+            locale: 'fr-CA',
+            messages: { 'fr-CA': { gasket_welcome: 'Hello!', gasket_learn: 'Learn Gasket' } },
+            status: { '/locales/en-US.json': 'loaded' }
+          }
+        }
+      });
+    });
   });
 
   describe('intlGetServerSideProps', function () {
@@ -172,6 +185,19 @@ describe('Next.js functions', function () {
     it('returns localesProps for default if locale missing', async function () {
       res.locals.gasketData.intl.locale = 'fr-CA';
       const results = await next.intlGetServerSideProps('/locales')({ res });
+      assume(results).eqls({
+        props: {
+          localesProps: {
+            locale: 'fr-CA',
+            messages: { 'fr-CA': { gasket_welcome: 'Hello!', gasket_learn: 'Learn Gasket' } },
+            status: { '/locales/en-US.json': 'loaded' }
+          }
+        }
+      });
+    });
+
+    it('uses locale on context from builtin i18n routing', async function () {
+      const results = await next.intlGetServerSideProps('/locales')({ locale: 'fr-CA', res });
       assume(results).eqls({
         props: {
           localesProps: {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

This tunes up the intl and nextjs plugins to support Next.js's new [internationalized routing](https://nextjs.org/docs/advanced-features/i18n-routing). The Gasket Intl plugin is still used to determine the locale and then passes config along to Next.js. The GSP and GSSP functions now allow for `locale` to be provided via context or path param.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/plugin-intl**
- Add `locales` config to specify a list of supported locales
- Adjust `intlLocale` lifecycle to provide extras in a context object

**@gasket/react-intl**
- Next GSP and GSSP functions support for `locale` from context or path param.

**@gasket/plugin-nextjs**
- Configures `next` as `nextConfig` with deprecation warning
- Force sets the `NEXT_LOCALE` cookie if locale predetermine by Intl plugin
  - Until alternative, see: https://github.com/vercel/next.js/issues/20281
- Forwards `defaultLocale` and `locales` from intl config to next app config

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Local app testing
- Updated unit tests