### PR TITLE
Fix locale related bugs

### DIFF
--- a/docs/upgrade-to-6.md
+++ b/docs/upgrade-to-6.md
@@ -505,6 +505,24 @@ const Component = props => <h1><FormattedMessage id='welcome'/></h1>
 + export default withLocaleRequired('/locales', { initialProps: true })(Component);
 ```
 
+### eslintConfig Update
+
+You will need to add a new `settings` object to the `eslintConfig` property in your `package.json`, which will need to have the `localeFiles` attribute set to an array containing the path to your `en-US.json` locale file:
+
+```diff
+// package.json
+
+{
+  "eslintConfig": {
++    "settings": {
++      "localeFiles": [
++        "public/locales/en-US.json"
++      ]
++    }
+  }
+}
+```
+
 ## Static Progressive Web App Changes
 
 ### Update Lifecycle Signatures with Context Object

--- a/docs/upgrade-to-6.md
+++ b/docs/upgrade-to-6.md
@@ -13,8 +13,8 @@ demonstrate what to look for:
 "dependencies": {
 -    "@gasket/fetch": "^5.0.2",
 +    "@gasket/fetch": "^6.0.0",
--    "@gasket/intl": "^5.5.0",
-+    "@gasket/intl": "^6.0.0",
+-    "@gasket/data": "^5.5.0",
++    "@gasket/data": "^6.0.0",
 -    "@gasket/plugin-workbox": "^5.4.1",
 +    "@gasket/plugin-workbox": "^6.0.0",
 }
@@ -293,6 +293,31 @@ module.exports = {
 }
 ```
 
+#### eslintConfig Update
+
+This update is only necessary when moving locale files to the `public/`
+directory, and when using the [@godaddy/eslint-plugin-react-intl] package with
+react-intl functions/components. 
+
+You will need to add a new `settings` object to your eslint config file or
+`eslintConfig` property in your `package.json`. The settings will need to have a
+`localeFiles` attribute set to an array containing the path to your primary
+locale file:
+
+```diff
+// package.json
+
+{
+  "eslintConfig": {
++    "settings": {
++      "localeFiles": [
++        "public/locales/en-US.json"
++      ]
++    }
+  }
+}
+```
+
 ### Module files
 
 If your app used locale files from NPM module dependencies, this is an opt-in
@@ -505,24 +530,6 @@ const Component = props => <h1><FormattedMessage id='welcome'/></h1>
 + export default withLocaleRequired('/locales', { initialProps: true })(Component);
 ```
 
-### eslintConfig Update
-
-You will need to add a new `settings` object to the `eslintConfig` property in your `package.json`, which will need to have the `localeFiles` attribute set to an array containing the path to your `en-US.json` locale file:
-
-```diff
-// package.json
-
-{
-  "eslintConfig": {
-+    "settings": {
-+      "localeFiles": [
-+        "public/locales/en-US.json"
-+      ]
-+    }
-  }
-}
-```
-
 ## Static Progressive Web App Changes
 
 ### Update Lifecycle Signatures with Context Object
@@ -681,3 +688,4 @@ _Impacted Plugins/Packages: `@gasket/resolve`, `@gasket/engine`_
 [react-redux]: https://github.com/reduxjs/react-redux
 [resolve.fallback]: https://webpack.js.org/configuration/resolve/#resolvefallback
 [Webpack 5 docs]: https://webpack.js.org/configuration/node/
+[@godaddy/eslint-plugin-react-intl]: https://github.com/godaddy/eslint-plugin-react-intl

--- a/packages/gasket-plugin-lint/lib/code-styles.js
+++ b/packages/gasket-plugin-lint/lib/code-styles.js
@@ -43,7 +43,12 @@ const godaddy = {
 
     if (hasReactIntl) {
       pkg.add('devDependencies', (await gatherDevDeps('@godaddy/eslint-plugin-react-intl')));
-      pkg.add('eslintConfig', { extends: ['plugin:@godaddy/react-intl/recommended'] });
+      pkg.add('eslintConfig', {
+        extends: ['plugin:@godaddy/react-intl/recommended'],
+        settings: {
+          localeFiles: ['public/locales/en-US.json']
+        }
+      });
     }
 
     if (addStylelint) {

--- a/packages/gasket-plugin-lint/test/code-styles.test.js
+++ b/packages/gasket-plugin-lint/test/code-styles.test.js
@@ -92,7 +92,10 @@ describe('code styles', () => {
         '@godaddy/eslint-plugin-react-intl': sinon.match.string
       });
       assume(pkgAdd).calledWithMatch('eslintConfig', {
-        extends: ['plugin:@godaddy/react-intl/recommended']
+        extends: ['plugin:@godaddy/react-intl/recommended'],
+        settings: {
+          localeFiles: ['public/locales/en-US.json']
+        }
       });
     });
 

--- a/packages/gasket-react-intl/src/config.js
+++ b/packages/gasket-react-intl/src/config.js
@@ -1,13 +1,10 @@
 /* eslint-disable no-process-env */
-const path = require('path');
-
 /**
  * @type {LocaleManifest}
  */
-const manifest = process.env.TEST_LOCALE_PATH ?
-  path.join(process.cwd(), process.env.TEST_LOCALE_PATH)
-  : require(process.env.GASKET_INTL_MANIFEST_FILE);
-
+const manifest = process.env.GASKET_INTL_MANIFEST_FILE ?
+  require(process.env.GASKET_INTL_MANIFEST_FILE) :
+  {};
 const isBrowser = typeof window !== 'undefined';
 const clientData = isBrowser && require('@gasket/data')?.intl || {};
 

--- a/packages/gasket-react-intl/src/config.js
+++ b/packages/gasket-react-intl/src/config.js
@@ -1,7 +1,13 @@
+/* eslint-disable no-process-env */
+const path = require('path');
+
 /**
  * @type {LocaleManifest}
  */
-const manifest = require(process.env.GASKET_INTL_MANIFEST_FILE); // eslint-disable-line no-process-env
+const manifest = process.env.TEST_LOCALE_PATH ?
+  path.join(process.cwd(), process.env.TEST_LOCALE_PATH)
+  : require(process.env.GASKET_INTL_MANIFEST_FILE);
+
 const isBrowser = typeof window !== 'undefined';
 const clientData = isBrowser && require('@gasket/data')?.intl || {};
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
We discovered 2 small bugs when testing (mocha only) and linting an application:
1. `npm run lint` returned
```bash
Error: Error while loading rule '@godaddy/react-intl/id-missing': ENOENT: no such file or directory, lstat 'locales/en-US.json'
```
2. `npm run test` returned
```bash
TypeError [ERR_INVALID_ARG_TYPE]: The "id" argument must be of type string. Received type undefined
```
## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->
Added `settings` property to `eslintConfig` for locale file path. Returning an empty object when GASKET_INTL_MANIFEST_FILE is not available.
## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
Updated unit test.