### PR TITLE
Filter falsy middleware

### DIFF
--- a/packages/gasket-plugin-express/index.js
+++ b/packages/gasket-plugin-express/index.js
@@ -57,7 +57,7 @@ module.exports = {
         app.use(compression());
       }
 
-      const middlewares = await gasket.exec('middleware', app);
+      const middlewares = (await gasket.exec('middleware', app)).filter(Boolean);
 
       debug('applied %s middleware layers to express', middlewares.length);
       middlewares.forEach((layer) => {
@@ -70,7 +70,7 @@ module.exports = {
 
       await gasket.exec('express', app);
 
-      const postRenderingStacks = await gasket.exec('errorMiddleware');
+      const postRenderingStacks = (await gasket.exec('errorMiddleware')).filter(Boolean);
       postRenderingStacks.forEach((stack) => app.use(stack));
 
       if (routes) {

--- a/packages/gasket-plugin-fastify/index.js
+++ b/packages/gasket-plugin-fastify/index.js
@@ -58,7 +58,7 @@ module.exports = {
         app.use(compression());
       }
 
-      const middlewares = await gasket.exec('middleware', app);
+      const middlewares = (await gasket.exec('middleware', app)).filter(Boolean);
 
       debug('applied %s middleware layers to fastify', middlewares.length);
       middlewares.forEach(layer => {
@@ -72,7 +72,7 @@ module.exports = {
       // allow consuming apps to directly append options to their server
       await gasket.exec('fastify', app);
 
-      const postRenderingStacks = await gasket.exec('errorMiddleware');
+      const postRenderingStacks = (await gasket.exec('errorMiddleware')).filter(Boolean);
       postRenderingStacks.forEach(stack => app.use(stack));
 
       return {

--- a/packages/gasket-plugin-fastify/test/plugin.test.js
+++ b/packages/gasket-plugin-fastify/test/plugin.test.js
@@ -53,15 +53,21 @@ describe('Plugin', function () {
 
 // eslint-disable-next-line max-statements
 describe('createServers', () => {
-  let gasket;
+  let gasket, lifecycles;
 
   beforeEach(() => {
     sinon.resetHistory();
 
+    lifecycles = {
+      middleware: sinon.stub().resolves([]),
+      errorMiddleware: sinon.stub().resolves([]),
+      fastify: sinon.stub().resolves()
+    };
+
     gasket = {
       logger: {},
       config: {},
-      exec: sinon.stub().resolves([])
+      exec: sinon.stub().callsFake((lifecycle, ...args) => lifecycles[lifecycle](args))
     };
   });
 
@@ -196,6 +202,28 @@ describe('createServers', () => {
       app.use,
       mw => mw === compressionMiddleware);
     assume(compressionUsage).to.be.null();
+  });
+
+  it('adds middleware from lifecycle (ignores falsy)', async () => {
+    await plugin.hooks.createServers(gasket, {});
+    assume(app.use).called(3);
+
+    sinon.resetHistory();
+    lifecycles.middleware.resolves([() => {}, null]);
+
+    await plugin.hooks.createServers(gasket, {});
+    assume(app.use).called(4);
+  });
+
+  it('adds errorMiddleware from lifecycle (ignores falsy)', async () => {
+    await plugin.hooks.createServers(gasket, {});
+    assume(app.use).called(3);
+
+    sinon.resetHistory();
+    lifecycles.errorMiddleware.resolves([() => {}, null]);
+
+    await plugin.hooks.createServers(gasket, {});
+    assume(app.use).called(4);
   });
 
   function findCall(aSpy, aPredicate) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Sometimes, a middleware lifecycle hook may return null or undefined if its logic determines no middleware should be added. For example:
```
module.exports = middlewareHook(gasket) {
  if(gasket.config.setting === true) {
    return function middleware(req, res, next) { ... }
  }
}
```

This PR filters falsy middleware results from being added, avoiding `TypeError: app.use() requires a middleware function` errors.

## Changelog

**@gasket/plugin-express**
- Filter falsy middleware from hooks

**@gasket/plugin-fastify**
- Filter falsy middleware from hooks

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Added unit tests
- Test in local app
