### PR TITLE
Avoid bundling serverLoadData

### DIFF
--- a/packages/gasket-helper-intl/docs/api.md
+++ b/packages/gasket-helper-intl/docs/api.md
@@ -3,13 +3,7 @@
 
 Name | Description
 ------ | -----------
-[LocaleUtils] | 
-
-## Constants
-
-Name | Description
------- | -----------
-[path] | NOTICE! These are common utilities used by packages in browser and this plugin. Do not rely on req, or window.
+[LocaleUtils] | Utility class for loading locale files
 
 ## Typedefs
 
@@ -26,6 +20,8 @@ Name | Description
 
 ## LocaleUtils
 
+Utility class for loading locale files
+
 **Kind**: global class  
 
 * [LocaleUtils]
@@ -34,12 +30,10 @@ Name | Description
     * [.formatLocalePath(localePathPart, locale)]
     * [.getLocalePath(localePathPart, locale)]
     * [.pathToUrl(localePath)]
-    * [.serverLoadData(localePathPath, locale, localesDir)]
+    * [.serverLoadData(localePathPart, locale, localesDir)]
 
 
 ### new LocaleUtils(config)
-
-Utility class for loading locale files
 
 
 | Param | Type | Description |
@@ -103,16 +97,17 @@ Add base path from window.gasket.intl or manifest if set to the locale path
 | localePath | [`LocalePath`] | URL path to a locale file |
 
 
-### localeUtils.serverLoadData(localePathPath, locale, localesDir)
+### localeUtils.serverLoadData(localePathPart, locale, localesDir)
 
-Load locale file(s) and return localesProps
+Load locale file(s) and return localesProps.
+Throws error if attempted to use in browser.
 
 **Kind**: instance method of [`LocaleUtils`]  
 **Returns**: [`LocalesProps`] - localesProps  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| localePathPath | [`LocalePathPart`] \| `Array.<LocalePathPart>` | Path(s) containing locale files |
+| localePathPart | [`LocalePathPart`] \| `Array.<LocalePathPart>` | Path(s) containing locale files |
 | locale | [`Locale`] | Locale to load |
 | localesDir | `string` | Disk path to locale files dir |
 
@@ -151,13 +146,6 @@ Enum for local status values
 
 **Kind**: static property of [`LocaleStatus`]  
 **Default**: `error`  
-
-## path
-
-NOTICE! These are common utilities used by packages in browser and this plugin.
-Do not rely on req, or window.
-
-**Kind**: global constant  
 
 ## LocalePathPart
 
@@ -271,7 +259,6 @@ Fetch status of a locale file
 <!-- LINKS -->
 
 [LocaleUtils]:#localeutils
-[path]:#path
 [LocalePathPart]:#localepathpart
 [LocalePath]:#localepath
 [Lang]:#lang
@@ -294,4 +281,4 @@ Fetch status of a locale file
 [.formatLocalePath(localePathPart, locale)]:#localeutilsformatlocalepathlocalepathpart-locale
 [.getLocalePath(localePathPart, locale)]:#localeutilsgetlocalepathlocalepathpart-locale
 [.pathToUrl(localePath)]:#localeutilspathtourllocalepath
-[.serverLoadData(localePathPath, locale, localesDir)]:#localeutilsserverloaddatalocalepathpath-locale-localesdir
+[.serverLoadData(localePathPart, locale, localesDir)]:#localeutilsserverloaddatalocalepathpart-locale-localesdir

--- a/packages/gasket-helper-intl/lib/index.js
+++ b/packages/gasket-helper-intl/lib/index.js
@@ -174,7 +174,7 @@ function LocaleUtils(config) {
    * Load locale file(s) and return localesProps.
    * Throws error if attempted to use in browser.
    *
-   * @param {LocalePathPart|LocalePathPart[]} localePathPath - Path(s) containing locale files
+   * @param {LocalePathPart|LocalePathPart[]} localePathPart - Path(s) containing locale files
    * @param {Locale} locale - Locale to load
    * @param {string} localesDir - Disk path to locale files dir
    * @returns {LocalesProps} localesProps

--- a/packages/gasket-helper-intl/lib/index.js
+++ b/packages/gasket-helper-intl/lib/index.js
@@ -3,9 +3,6 @@
  * Do not rely on req, or window.
  */
 
-const path = require('path');
-const merge = require('lodash.merge');
-
 /**
  * Partial URL representing a directory containing locale .json files
  * or a URL template with a `:locale` path param to a .json file.
@@ -86,7 +83,7 @@ const LocaleStatus = {
 const reLocalePathParam = /(\/[$:{]locale}?\/)/;
 
 /**
- * Utility class for loading locale files
+ * @classdesc Utility class for loading locale files
  *
  * @param {Object} config - Configuration
  * @param {LocaleManifest} config.manifest - Locale file manifest
@@ -172,46 +169,20 @@ function LocaleUtils(config) {
     return url;
   };
 
+  /* eslint-disable no-unused-vars, valid-jsdoc */
   /**
-   * Load locale file(s) and return localesProps
+   * Load locale file(s) and return localesProps.
+   * Throws error if attempted to use in browser.
    *
    * @param {LocalePathPart|LocalePathPart[]} localePathPath - Path(s) containing locale files
    * @param {Locale} locale - Locale to load
    * @param {string} localesDir - Disk path to locale files dir
    * @returns {LocalesProps} localesProps
    */
-  this.serverLoadData = (localePathPath, locale, localesDir) => {
-    if (Array.isArray(localePathPath)) {
-      const localesProps = localePathPath.map(p => this.serverLoadData(p, locale, localesDir));
-      return merge(...localesProps);
-    }
-
-    const localeFile = this.getLocalePath(localePathPath, locale);
-    const diskPath = path.join(localesDir, localeFile);
-    let messages;
-    let status;
-
-    try {
-      messages = require(diskPath);
-      status = LocaleStatus.LOADED;
-    } catch (e) {
-      console.error(e.message); // eslint-disable-line no-console
-      messages = {};
-      status = LocaleStatus.ERROR;
-    }
-
-    return {
-      locale,
-      messages: {
-        [locale]: {
-          ...messages
-        }
-      },
-      status: {
-        [localeFile]: status
-      }
-    };
+  this.serverLoadData = () => {
+    throw new Error('Not available in browser');
   };
+  /* eslint-enable */
 }
 
 module.exports = {

--- a/packages/gasket-helper-intl/lib/server.js
+++ b/packages/gasket-helper-intl/lib/server.js
@@ -1,0 +1,50 @@
+const path = require('path');
+const merge = require('lodash.merge');
+const { LocaleUtils, LocaleStatus } = require('./index');
+
+/**
+ * Server variant to load locale files from disk path
+ * @extends { LocaleUtils }
+ * @constructor
+ */
+function LocaleServerUtils() {
+  LocaleUtils.apply(this, arguments);
+
+  this.serverLoadData = (localePathPart, locale, localesDir) => {
+    if (Array.isArray(localePathPart)) {
+      const localesProps = localePathPart.map(p => this.serverLoadData(p, locale, localesDir));
+      return merge(...localesProps);
+    }
+
+    const localeFile = this.getLocalePath(localePathPart, locale);
+    const diskPath = path.join(localesDir, localeFile);
+    let messages;
+    let status;
+
+    try {
+      messages = require(diskPath);
+      status = LocaleStatus.LOADED;
+    } catch (e) {
+      console.error(e.message); // eslint-disable-line no-console
+      messages = {};
+      status = LocaleStatus.ERROR;
+    }
+
+    return {
+      locale,
+      messages: {
+        [locale]: {
+          ...messages
+        }
+      },
+      status: {
+        [localeFile]: status
+      }
+    };
+  };
+}
+
+module.exports = {
+  LocaleUtils: LocaleServerUtils,
+  LocaleStatus
+};

--- a/packages/gasket-helper-intl/package.json
+++ b/packages/gasket-helper-intl/package.json
@@ -2,7 +2,8 @@
   "name": "@gasket/helper-intl",
   "version": "6.0.0",
   "description": "Internal helpers used by loaders to resolve locale file paths",
-  "main": "lib",
+  "main": "lib/server.js",
+  "browser": "lib/index.js",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
@@ -12,7 +13,7 @@
     "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",
     "posttest": "npm run lint",
     "prepack": "npm run docs",
-    "docs": "jsdoc2md --plugin @godaddy/dmd --files lib/*.js > docs/api.md"
+    "docs": "jsdoc2md --plugin @godaddy/dmd --files lib/index.js > docs/api.md"
   },
   "repository": {
     "type": "git",

--- a/packages/gasket-helper-intl/test/index.test.js
+++ b/packages/gasket-helper-intl/test/index.test.js
@@ -1,170 +1,31 @@
 const assume = require('assume');
-const sinon = require('sinon');
 const path = require('path');
-
-const mockManifest = require('./fixtures/mock-manifest.json');
-const mockConfig = {};
 
 const { LocaleUtils } = require('../lib/index');
 
 describe('LocaleUtils', function () {
-  let utils;
 
-  beforeEach(function () {
-    sinon.stub(console, 'error');
-    mockConfig.manifest = { ...mockManifest, paths: { ...mockManifest.paths } };
-    utils = new LocaleUtils(mockConfig);
-  });
-
-  afterEach(function () {
-    sinon.restore();
-  });
-
-  describe('.formatLocalePath', function () {
-    it('adds locale json to root path', function () {
-      const results = utils.formatLocalePath('/locales', 'en-US');
-      assume(results).equals('/locales/en-US.json');
-    });
-
-    it('substitutes $locale in path template', function () {
-      const results = utils.formatLocalePath('/locales/$locale/page1.json', 'en-US');
-      assume(results).equals('/locales/en-US/page1.json');
-    });
-
-    it('substitutes :locale in path template', function () {
-      const results = utils.formatLocalePath('/locales/:locale/page1.json', 'en-US');
-      assume(results).equals('/locales/en-US/page1.json');
-    });
-
-    it('substitutes {locale} in path template', function () {
-      const results = utils.formatLocalePath('/locales/{locale}/page1.json', 'en-US');
-      assume(results).equals('/locales/en-US/page1.json');
-    });
-
-    it('ensures forward slash', function () {
-      const results = utils.formatLocalePath('locales', 'en-US');
-      assume(results).equals('/locales/en-US.json');
-    });
-
-    it('ensures no extra end slash', function () {
-      const results = utils.formatLocalePath('locales/', 'en-US');
-      assume(results).equals('/locales/en-US.json');
-    });
-  });
-
-  describe('.pathToUrl', function () {
-    it('add hash to url', function () {
-      const results = utils.pathToUrl('/locales/en-US.json');
-      assume(results).equals('/locales/en-US.json?v=10decbe');
-    });
-
-    it('does not add hash if localePath not in manifest', function () {
-      const results = utils.pathToUrl('/missing/en-US.json');
-      assume(results).equals('/missing/en-US.json');
-    });
-
-    it('returns url WITH base path', function () {
-      mockConfig.basePath = '/bogus';
-      utils = new LocaleUtils(mockConfig);
-      const results = utils.pathToUrl('/locales/en-US.json');
-      assume(results).equals('/bogus/locales/en-US.json?v=10decbe');
-    });
-
-    it('ignores trailing slash from basePath', function () {
-      mockConfig.basePath = '/bogus/';
-      utils = new LocaleUtils(mockConfig);
-      const results = utils.pathToUrl('/locales/en-US.json');
-      assume(results).equals('/bogus/locales/en-US.json?v=10decbe');
-    });
-
-    it('basePath can be a full URL', function () {
-      mockConfig.basePath = 'https://bogus.com/';
-      utils = new LocaleUtils(mockConfig);
-      const results = utils.pathToUrl('/locales/en-US.json');
-      assume(results).equals('https://bogus.com/locales/en-US.json?v=10decbe');
-    });
-  });
-
-  describe('.getLocalePath', function () {
-    it('returns formatted localePath', function () {
-      const results = utils.getLocalePath('/locales', 'en-US');
-      assume(results).equals('/locales/en-US.json');
-    });
-
-    it('falls back to lang if no localePath with region', function () {
-      mockConfig.manifest.paths['/locales/da.json'] = 'hash1234';
-      utils = new LocaleUtils(mockConfig);
-      const results = utils.getLocalePath('/locales', 'da-DK');
-      assume(results).equals('/locales/da.json');
-    });
-
-    it('falls back to lang if no localePath with script and region', function () {
-      mockConfig.manifest.paths['/locales/az.json'] = 'hash1234';
-      utils = new LocaleUtils(mockConfig);
-      const results = utils.getLocalePath('/locales', 'az-Cyrl-AZ');
-      assume(results).equals('/locales/az.json');
-    });
-
-    it('falls back to default locale if no localePath for locale', function () {
-      mockConfig.manifest.defaultLocale = 'fake';
-      mockConfig.manifest.paths['/locales/fake.json'] = 'hash1234';
-      utils = new LocaleUtils(mockConfig);
-      const results = utils.getLocalePath('/locales', 'da-DK');
-      assume(results).equals('/locales/fake.json');
-    });
-
-    it('returns localePath for mapped locales', function () {
-      mockConfig.manifest.paths['/locales/fake.json'] = 'hash1234';
-      mockConfig.manifest.localesMap = { 'da-DK': 'fake' };
-      utils = new LocaleUtils(mockConfig);
-      const results = utils.getLocalePath('/locales', 'da-DK');
-      assume(results).equals('/locales/fake.json');
-    });
-  });
+  require('./shared')(LocaleUtils);
 
   describe('.serverLoadData', function () {
+    let utils, mockConfig;
+
+    beforeEach(function () {
+      mockConfig = {
+        manifest: require('./fixtures/mock-manifest.json')
+      };
+      utils = new LocaleUtils(mockConfig);
+    });
+
+    afterEach(function () {
+      delete require.cache[require.resolve('./fixtures/mock-manifest.json')];
+    });
 
     const localesParentDir = path.resolve(__dirname, 'fixtures');
 
-    it('returns localesProps for other path part', async function () {
-      const results = utils.serverLoadData('/locales/extra', 'en-US', localesParentDir);
-      assume(results).eqls({
-        locale: 'en-US',
-        messages: { 'en-US': { gasket_extra: 'Extra' } },
-        status: { '/locales/extra/en-US.json': 'loaded' }
-      });
-    });
-
-    it('returns localesProps for multiple locale path parts', async function () {
-      const results = utils.serverLoadData(['/locales', '/locales/extra'], 'en-US', localesParentDir);
-      assume(results).eqls({
-        locale: 'en-US',
-        messages: { 'en-US': { gasket_welcome: 'Hello!', gasket_learn: 'Learn Gasket', gasket_extra: 'Extra' } },
-        status: {
-          '/locales/en-US.json': 'loaded',
-          '/locales/extra/en-US.json': 'loaded'
-        }
-      });
-    });
-
-    it('returns localesProps with error for missing path', async function () {
-      const results = utils.serverLoadData('/locales/missing', 'en-US', localesParentDir);
-      assume(results).eqls({
-        locale: 'en-US',
-        messages: { 'en-US': {} },
-        status: { '/locales/missing/en-US.json': 'error' }
-      });
-      // eslint-disable-next-line no-console
-      assume(console.error).is.calledWithMatch('Cannot find module');
-    });
-
-    it('returns localesProps for default if locale missing', async function () {
-      const results = utils.serverLoadData('/locales', 'fr-CA', localesParentDir);
-      assume(results).eqls({
-        locale: 'fr-CA',
-        messages: { 'fr-CA': { gasket_welcome: 'Hello!', gasket_learn: 'Learn Gasket' } },
-        status: { '/locales/en-US.json': 'loaded' }
-      });
+    it('throws in browser', async function () {
+      const call = () => utils.serverLoadData('/locales/extra', 'en-US', localesParentDir);
+      assume(call).throws('Not available in browser');
     });
   });
 });

--- a/packages/gasket-helper-intl/test/server.test.js
+++ b/packages/gasket-helper-intl/test/server.test.js
@@ -1,0 +1,66 @@
+const assume = require('assume');
+const path = require('path');
+
+const { LocaleUtils } = require('../lib/server');
+
+describe('LocaleUtils (Server)', function () {
+  require('./shared')(LocaleUtils);
+
+  describe('.serverLoadData', function () {
+    let utils, mockConfig;
+
+    beforeEach(function () {
+      mockConfig = {
+        manifest: require('./fixtures/mock-manifest.json')
+      };
+      utils = new LocaleUtils(mockConfig);
+    });
+
+    afterEach(function () {
+      delete require.cache[require.resolve('./fixtures/mock-manifest.json')];
+    });
+
+    const localesParentDir = path.resolve(__dirname, 'fixtures');
+
+    it('returns localesProps for other path part', async function () {
+      const results = utils.serverLoadData('/locales/extra', 'en-US', localesParentDir);
+      assume(results).eqls({
+        locale: 'en-US',
+        messages: { 'en-US': { gasket_extra: 'Extra' } },
+        status: { '/locales/extra/en-US.json': 'loaded' }
+      });
+    });
+
+    it('returns localesProps for multiple locale path parts', async function () {
+      const results = utils.serverLoadData(['/locales', '/locales/extra'], 'en-US', localesParentDir);
+      assume(results).eqls({
+        locale: 'en-US',
+        messages: { 'en-US': { gasket_welcome: 'Hello!', gasket_learn: 'Learn Gasket', gasket_extra: 'Extra' } },
+        status: {
+          '/locales/en-US.json': 'loaded',
+          '/locales/extra/en-US.json': 'loaded'
+        }
+      });
+    });
+
+    it('returns localesProps with error for missing path', async function () {
+      const results = utils.serverLoadData('/locales/missing', 'en-US', localesParentDir);
+      assume(results).eqls({
+        locale: 'en-US',
+        messages: { 'en-US': {} },
+        status: { '/locales/missing/en-US.json': 'error' }
+      });
+      // eslint-disable-next-line no-console
+      assume(console.error).is.calledWithMatch('Cannot find module');
+    });
+
+    it('returns localesProps for default if locale missing', async function () {
+      const results = utils.serverLoadData('/locales', 'fr-CA', localesParentDir);
+      assume(results).eqls({
+        locale: 'fr-CA',
+        messages: { 'fr-CA': { gasket_welcome: 'Hello!', gasket_learn: 'Learn Gasket' } },
+        status: { '/locales/en-US.json': 'loaded' }
+      });
+    });
+  });
+});

--- a/packages/gasket-helper-intl/test/shared.js
+++ b/packages/gasket-helper-intl/test/shared.js
@@ -1,0 +1,121 @@
+const assume = require('assume');
+const sinon = require('sinon');
+
+module.exports = function sharedTests(UtilClass) {
+  let utils, mockConfig;
+
+  beforeEach(function () {
+    sinon.stub(console, 'error');
+    mockConfig = {
+      manifest: require('./fixtures/mock-manifest.json')
+    };
+    utils = new UtilClass(mockConfig);
+  });
+
+  afterEach(function () {
+    delete require.cache[require.resolve('./fixtures/mock-manifest.json')];
+    sinon.restore();
+  });
+
+  describe('.formatLocalePath', function () {
+    it('adds locale json to root path', function () {
+      const results = utils.formatLocalePath('/locales', 'en-US');
+      assume(results).equals('/locales/en-US.json');
+    });
+
+    it('substitutes $locale in path template', function () {
+      const results = utils.formatLocalePath('/locales/$locale/page1.json', 'en-US');
+      assume(results).equals('/locales/en-US/page1.json');
+    });
+
+    it('substitutes :locale in path template', function () {
+      const results = utils.formatLocalePath('/locales/:locale/page1.json', 'en-US');
+      assume(results).equals('/locales/en-US/page1.json');
+    });
+
+    it('substitutes {locale} in path template', function () {
+      const results = utils.formatLocalePath('/locales/{locale}/page1.json', 'en-US');
+      assume(results).equals('/locales/en-US/page1.json');
+    });
+
+    it('ensures forward slash', function () {
+      const results = utils.formatLocalePath('locales', 'en-US');
+      assume(results).equals('/locales/en-US.json');
+    });
+
+    it('ensures no extra end slash', function () {
+      const results = utils.formatLocalePath('locales/', 'en-US');
+      assume(results).equals('/locales/en-US.json');
+    });
+  });
+
+  describe('.pathToUrl', function () {
+    it('add hash to url', function () {
+      const results = utils.pathToUrl('/locales/en-US.json');
+      assume(results).equals('/locales/en-US.json?v=10decbe');
+    });
+
+    it('does not add hash if localePath not in manifest', function () {
+      const results = utils.pathToUrl('/missing/en-US.json');
+      assume(results).equals('/missing/en-US.json');
+    });
+
+    it('returns url WITH base path', function () {
+      mockConfig.basePath = '/bogus';
+      utils = new UtilClass(mockConfig);
+      const results = utils.pathToUrl('/locales/en-US.json');
+      assume(results).equals('/bogus/locales/en-US.json?v=10decbe');
+    });
+
+    it('ignores trailing slash from basePath', function () {
+      mockConfig.basePath = '/bogus/';
+      utils = new UtilClass(mockConfig);
+      const results = utils.pathToUrl('/locales/en-US.json');
+      assume(results).equals('/bogus/locales/en-US.json?v=10decbe');
+    });
+
+    it('basePath can be a full URL', function () {
+      mockConfig.basePath = 'https://bogus.com/';
+      utils = new UtilClass(mockConfig);
+      const results = utils.pathToUrl('/locales/en-US.json');
+      assume(results).equals('https://bogus.com/locales/en-US.json?v=10decbe');
+    });
+  });
+
+  describe('.getLocalePath', function () {
+    it('returns formatted localePath', function () {
+      const results = utils.getLocalePath('/locales', 'en-US');
+      assume(results).equals('/locales/en-US.json');
+    });
+
+    it('falls back to lang if no localePath with region', function () {
+      mockConfig.manifest.paths['/locales/da.json'] = 'hash1234';
+      utils = new UtilClass(mockConfig);
+      const results = utils.getLocalePath('/locales', 'da-DK');
+      assume(results).equals('/locales/da.json');
+    });
+
+    it('falls back to lang if no localePath with script and region', function () {
+      mockConfig.manifest.paths['/locales/az.json'] = 'hash1234';
+      utils = new UtilClass(mockConfig);
+      const results = utils.getLocalePath('/locales', 'az-Cyrl-AZ');
+      assume(results).equals('/locales/az.json');
+    });
+
+    it('falls back to default locale if no localePath for locale', function () {
+      mockConfig.manifest.defaultLocale = 'fake';
+      mockConfig.manifest.paths['/locales/fake.json'] = 'hash1234';
+      utils = new UtilClass(mockConfig);
+      const results = utils.getLocalePath('/locales', 'da-DK');
+      assume(results).equals('/locales/fake.json');
+    });
+
+    it('returns localePath for mapped locales', function () {
+      mockConfig.manifest.paths['/locales/fake.json'] = 'hash1234';
+      mockConfig.manifest.localesMap = { 'da-DK': 'fake' };
+      utils = new UtilClass(mockConfig);
+      const results = utils.getLocalePath('/locales', 'da-DK');
+      assume(results).equals('/locales/fake.json');
+    });
+  });
+};

--- a/packages/gasket-plugin-intl/lib/middleware.js
+++ b/packages/gasket-plugin-intl/lib/middleware.js
@@ -64,11 +64,11 @@ module.exports = function middlewareHook(gasket) {
     /**
      * Load locale data and makes available from gasketData
      *
-     * @param {LocalePathPart|LocalePathPart[]} localePathPath - Path(s) containing locale files
+     * @param {LocalePathPart|LocalePathPart[]} localePathPart - Path(s) containing locale files
      * @returns {LocalesProps} localesProps
      */
-    req.withLocaleRequired = function withLocaleRequired(localePathPath = manifest.defaultPath) {
-      const localesProps = localeUtils.serverLoadData(localePathPath, locale, localesParentDir);
+    req.withLocaleRequired = function withLocaleRequired(localePathPart = manifest.defaultPath) {
+      const localesProps = localeUtils.serverLoadData(localePathPart, locale, localesParentDir);
       mergeGasketData(localesProps);
       return localesProps;
     };

--- a/packages/gasket-react-intl/src/next.js
+++ b/packages/gasket-react-intl/src/next.js
@@ -8,10 +8,10 @@ const localesParentDir = path.dirname(process.env.GASKET_INTL_LOCALES_DIR);
 /**
  * Load locale file(s) for Next.js static pages
  *
- * @param {LocalePathPart|LocalePathPart[]} localePathPath - Path(s) containing locale files
+ * @param {LocalePathPart|LocalePathPart[]} localePathPart - Path(s) containing locale files
  * @returns {function({}): Promise<{props: {localesProps: LocalesProps}}>} pageProps
  */
-export function intlGetStaticProps(localePathPath = manifest.defaultPath) {
+export function intlGetStaticProps(localePathPart = manifest.defaultPath) {
   return async ctx => {
     // provide by next i18n
     let { locale } = ctx;
@@ -19,7 +19,7 @@ export function intlGetStaticProps(localePathPath = manifest.defaultPath) {
     if (!locale) {
       locale = ctx.params.locale;
     }
-    const localesProps = localeUtils.serverLoadData(localePathPath, locale, localesParentDir);
+    const localesProps = localeUtils.serverLoadData(localePathPart, locale, localesParentDir);
 
     return {
       props: {
@@ -32,10 +32,10 @@ export function intlGetStaticProps(localePathPath = manifest.defaultPath) {
 /**
  * Load locale file(s) for Next.js static pages
  *
- * @param {LocalePathPart|LocalePathPart[]} localePathPath - Path(s) containing locale files
+ * @param {LocalePathPart|LocalePathPart[]} localePathPart - Path(s) containing locale files
  * @returns {function({}): Promise<{props: {localesProps: LocalesProps}}>} pageProps
  */
-export function intlGetServerSideProps(localePathPath = manifest.defaultPath) {
+export function intlGetServerSideProps(localePathPart = manifest.defaultPath) {
   return async ctx => {
     const { res } = ctx;
     // provide by next i18n
@@ -44,7 +44,7 @@ export function intlGetServerSideProps(localePathPath = manifest.defaultPath) {
     if (!locale && res.locals && res.locals.gasketData && res.locals.gasketData.intl) {
       locale = res.locals.gasketData.intl.locale;
     }
-    const localesProps = localeUtils.serverLoadData(localePathPath, locale, localesParentDir);
+    const localesProps = localeUtils.serverLoadData(localePathPart, locale, localesParentDir);
 
     return {
       props: {

--- a/packages/gasket-react-intl/src/with-locale-required.js
+++ b/packages/gasket-react-intl/src/with-locale-required.js
@@ -13,9 +13,9 @@ const { defaultLocale, defaultPath } = manifest;
  * will be fetched as normal.
  *
  * @param {React.ComponentType} Wrapper - The HOC
- * @param {LocalePathPart} localePathPath - Path containing locale files
+ * @param {LocalePathPart} localePathPart - Path containing locale files
  */
-function attachGetInitialProps(Wrapper, localePathPath) {
+function attachGetInitialProps(Wrapper, localePathPart) {
   const { WrappedComponent } = Wrapper;
 
   Wrapper.getInitialProps = async (ctx) => {
@@ -25,7 +25,7 @@ function attachGetInitialProps(Wrapper, localePathPath) {
     if (res) {
       const { locale = defaultLocale } = res.locals.gasketData.intl || {};
       const localesParentDir = path.dirname(res.locals.localesDir);
-      localesProps = localeUtils.serverLoadData(localePathPath, locale, localesParentDir);
+      localesProps = localeUtils.serverLoadData(localePathPart, locale, localesParentDir);
     }
 
     return {
@@ -38,13 +38,13 @@ function attachGetInitialProps(Wrapper, localePathPath) {
 /**
  * Make an HOC that loads a locale file before rendering wrapped component
  *
- * @param {LocalePathPart} localePathPath - Path containing locale files
+ * @param {LocalePathPart} localePathPart - Path containing locale files
  * @param {object} [options] - Options
  * @param {React.Component} [options.loading=null] - Custom component to show while loading
  * @param {React.Component} [options.initialProps=false] - Preload locales during SSR with Next.js pages
  * @returns {function} wrapper
  */
-export default function withLocaleRequired(localePathPath = defaultPath, options = {}) {
+export default function withLocaleRequired(localePathPart = defaultPath, options = {}) {
   const { loading = null, initialProps = false } = options;
   /**
    * Wrap the component
@@ -64,7 +64,7 @@ export default function withLocaleRequired(localePathPath = defaultPath, options
     function Wrapper(props) {
       // eslint-disable-next-line react/prop-types
       const { forwardedRef, ...rest } = props;
-      const loadState = useLocaleRequired(localePathPath);
+      const loadState = useLocaleRequired(localePathPart);
       if (loadState === LocaleStatus.LOADING) return loading;
       return <Component { ...rest } ref={ forwardedRef }/>;
     }
@@ -80,7 +80,7 @@ export default function withLocaleRequired(localePathPath = defaultPath, options
     ForwardRef.WrappedComponent = Component;
 
     if (initialProps || 'getInitialProps' in Component) {
-      attachGetInitialProps(ForwardRef, localePathPath);
+      attachGetInitialProps(ForwardRef, localePathPart);
     }
 
     return ForwardRef;


### PR DESCRIPTION
## Summary

This makes sure the `LocaleUtils.serverLoadData` does not become bundled in browser builds. This avoids a Webpack warning `Critical dependency: the request of a dependency is an expression`, as well as reduces bundle sizes a tiny bit.

I also found and fixed a variable name typo....

## Changelog

**@gasket/helper-intl**
- Expose server variant of LocaleUtils to avoid bundling `serverLoadData` method

## Test Plan

- Local app testing
- Added unit test
