### PR TITLE
Cleaner safer check for existing store instances

### DIFF
--- a/docs/upgrade-to-6.md
+++ b/docs/upgrade-to-6.md
@@ -137,7 +137,8 @@ is used.
 ```diff
 // redux/store.js
 
-const { configureMakeStore } = require('@gasket/redux');
+- const { configureMakeStore } = require('@gasket/redux');
++ const { configureMakeStore, getOrCreateStore } = require('@gasket/redux');
 + const { HYDRATE, createWrapper } = require('next-redux-wrapper');
 + const merge = require('lodash.merge')
 
@@ -152,11 +153,14 @@ const reducers = {
 
 - module.exports = configureMakeStore({ reducers });
 + const makeStore = configureMakeStore({ rootReducer, reducers });
-+ const nextRedux = createWrapper(({ req }) => makeStore({}, { req }));
++ const nextRedux = createWrapper(getOrCreateStore(makeStore));
 
 + module.exports = makeStore;
 + module.exports.nextRedux = nextRedux;
 ```
+
+The `getOrCreateStore` helper will check if a store instance exists on context
+and return it, or make a new one if not.
 
 In addition to exporting the `makeStore` function, you'll want to export the
 `nextRedux` wrapper for use in your app code.
@@ -297,7 +301,7 @@ module.exports = {
 
 This update is only necessary when moving locale files to the `public/`
 directory, and when using the [@godaddy/eslint-plugin-react-intl] package with
-react-intl functions/components. 
+react-intl functions/components.
 
 You will need to add a new `settings` object to your eslint config file or
 `eslintConfig` property in your `package.json`. The settings will need to have a
@@ -689,3 +693,4 @@ _Impacted Plugins/Packages: `@gasket/resolve`, `@gasket/engine`_
 [resolve.fallback]: https://webpack.js.org/configuration/resolve/#resolvefallback
 [Webpack 5 docs]: https://webpack.js.org/configuration/node/
 [@godaddy/eslint-plugin-react-intl]: https://github.com/godaddy/eslint-plugin-react-intl
+

--- a/packages/gasket-plugin-nextjs/docs/redux.md
+++ b/packages/gasket-plugin-nextjs/docs/redux.md
@@ -1,43 +1,46 @@
 # State Management with Redux
 
-There are two ways to manage the client-side state in a Next.js based Gasket app.
-You can either use the React component state or use Redux.
+There are two ways to manage the client-side state in a Next.js based Gasket
+app. You can either use the React component state or use Redux.
 
-**React state** is managed within a component. If it's needed in another sub-component,
-you will have to pass it explicitly through props and if those values need to be updated
-by these sub-components than they will have to use callback functions to update it.
+**React state** is managed within a component. If it's needed in another
+sub-component, you will have to pass it explicitly through props and if those
+values need to be updated by these sub-components than they will have to use
+callback functions to update it.
 
-This works out well normally, until you have a multi-level component structure where
-component state has to be received and passed down through every component in the middle,
-just so some child component can access and use that state value.
+This works out well normally, until you have a multi-level component structure
+where component state has to be received and passed down through every component
+in the middle, just so some child component can access and use that state value.
 
-Also, since React state is managed within a component, the state data is lost once the
-component is unmounted. So moving from page to page will re-initialize the state data.
+Also, since React state is managed within a component, the state data is lost
+once the component is unmounted. So moving from page to page will re-initialize
+the state data.
 
-On the other hand, **Redux state** is maintained globally. Any component that needs
-that value can connect to the store and read it from there. Also, updating the state
-value is as simple as dispatching an `action`.
+On the other hand, **Redux state** is maintained globally. Any component that
+needs that value can connect to the store and read it from there. Also, updating
+the state value is as simple as dispatching an `action`.
 
 ## When to use Redux
 
-So it may feel like using Redux should *always* be the way to go. However, we have to
-be careful about that, as there are some drawbacks of using Redux too much. It may
-have negative performance implications. It will increase the complexity of your
-application, making it harder to refactor, and also likely reduce the re-usability of
-your components.
+So it may feel like using Redux should *always* be the way to go. However, we
+have to be careful about that, as there are some drawbacks of using Redux too
+much. It may have negative performance implications. It will increase the
+complexity of your application, making it harder to refactor, and also likely
+reduce the re-usability of your components.
 
 *So when should we absolutely use Redux?*
 
 - If a state value is needed across pages.
 
-- If a state value is initialized with server side rendering and later used from client.
-Before we go any further, please take a moment to review How to use [@gasket/redux].
+- If a state value is initialized with server side rendering and later used from
+  client. Before we go any further, please take a moment to review How to use
+  [@gasket/redux].
 
 #### Example 1: Keep data in Redux state
 
 In this example `store.js` creates a Redux store, and attaches a reducer from
-`redux-reducer.js`. `ComponentA` invokes the actions from `redux-actions.js`
-and `ComponentB` connects to Redux store to read the current count.
+`redux-reducer.js`. `ComponentA` invokes the actions from `redux-actions.js` and
+`ComponentB` connects to Redux store to read the current count.
 
 <details><summary>component-a.js</summary>
 <p>
@@ -192,11 +195,12 @@ module.exports = {
 <details><summary>redux/store.js</summary>
 <p>
 
-This file will have been generated for you by default. Your job will
-merely be to include the app's reducers.
+This file will have been generated for you by default. Your job will merely be
+to include the app's reducers.
 
 ```diff
-const { configureMakeStore } = require('@gasket/redux');
+- const { configureMakeStore } = require('@gasket/redux');
++ const { configureMakeStore, getOrCreateStore } = require('@gasket/redux');
 const { HYDRATE, createWrapper } = require('next-redux-wrapper');
 + const incrementReducers = require('./redux-reducer');
 
@@ -206,14 +210,14 @@ const reducers = {
 };
 
 const makeStore = configureMakeStore({ rootReducer, reducers });
-const nextRedux = createWrapper(({ req }) => makeStore({}, { req }));
+const nextRedux = createWrapper(getOrCreateStore(makeStore));
 
 module.exports = makeStore;
 module.exports.nextRedux = nextRedux;
 ```
 
-See the section below on [next-redux-wrapper v6] if you have an existing
-app and want to use the latest [automatic optimization] changes from Next.js.
+See the section below on [next-redux-wrapper v6] if you have an existing app and
+want to use the latest [automatic optimization] changes from Next.js.
 
 </p>
 </details>
@@ -242,8 +246,8 @@ export default IndexPage;
 
 #### Example 2: Initialize state value with SSR
 
-Initialize Redux state from server side by dispatching a Redux action.
-Modified `pages/index.js` shown below.
+Initialize Redux state from server side by dispatching a Redux action. Modified
+`pages/index.js` shown below.
 
 ```diff
 import React from 'react';
@@ -275,7 +279,8 @@ If you are coming from a version of [next-redux-wrapper] prior to v6, you will
 need to make the following changes to your existing store.
 
 ```diff
-const { configureMakeStore } = require('@gasket/redux');
+- const { configureMakeStore } = require('@gasket/redux');
++ const { configureMakeStore, getOrCreateStore } = require('@gasket/redux');
 const incrementReducers = require('./redux-reducer');
 + const { HYDRATE, createWrapper } = require('next-redux-wrapper');
 
@@ -288,20 +293,26 @@ const makeStore = configureMakeStore({
 +  rootReducer,
   reducers
 });
-+ const nextRedux = createWrapper(({ req }) => makeStore({}, { req }));
++ const nextRedux = createWrapper(getOrCreateStore(makeStore));
 
 module.exports = makeStore;
 + module.exports.nextRedux = nextRedux;
 ```
 
+The `createWrapper` function accepts the Next.js [AppContext]. We can use the
+`getOrCreateStore` helper which will return a function that checks if an
+existing store is on available on context, such as from [@gasket/plugin-redux],
+and return it. If there is not a store, a new one will be created from the
+provided `makeStore` argument.
+
 You can now continue to use `getInitialProps` in your pages, or move to use
 `getStaticProps` or `getServerSideProps` as in the [SSR example] by import
 `nextRedux` export from the store file.
 
-When it comes to the `rootReducer`, you can use this to handle [state hydration].
-There are a few different approaches for this, but the generated default and
-example above should suffice for the most part. See the `next-redux-wrapper`
-docs for other [state hydration] examples.
+When it comes to the `rootReducer`, you can use this to handle
+[state hydration]. There are a few different approaches for this, but the
+generated default and example above should suffice for the most part. See the
+`next-redux-wrapper` docs for other [state hydration] examples.
 
 As an example, if your Gasket app and/or plugins set up the initial Redux state
 for a request, such as with the [initReduxState] lifecycle, then this state will
@@ -322,3 +333,4 @@ object.
 [next-redux-wrapper]: https://github.com/kirill-konshin/next-redux-wrapper
 [state hydration]: https://github.com/kirill-konshin/next-redux-wrapper#state-reconciliation-during-hydration
 [Redux DevTools]: https://github.com/reduxjs/redux-devtools
+

--- a/packages/gasket-plugin-nextjs/generator/redux/redux/store.js
+++ b/packages/gasket-plugin-nextjs/generator/redux/redux/store.js
@@ -1,4 +1,4 @@
-const { configureMakeStore } = require('@gasket/redux');
+const { configureMakeStore, getOrCreateStore } = require('@gasket/redux');
 const { HYDRATE, createWrapper } = require('next-redux-wrapper');
 const merge = require('lodash.merge')
 {{{reduxReducers.imports}}}
@@ -12,7 +12,7 @@ const reducers = {
 };
 
 const makeStore = configureMakeStore({ rootReducer, reducers });
-const nextRedux = createWrapper(({ req }) => makeStore({}, { req }));
+const nextRedux = createWrapper(getOrCreateStore(makeStore));
 
 module.exports = makeStore;
 module.exports.nextRedux = nextRedux;

--- a/packages/gasket-redux/README.md
+++ b/packages/gasket-redux/README.md
@@ -10,14 +10,20 @@ npm i @gasket/redux
 
 ## Functions
 
-- `configureMakeStore(options, [postCreate])` - Returns a makeStore function
+### configureMakeStore
 
-### Parameters
+Set up Redux store configuration and return a `makeStore` function
+
+**Signature**
+
+- `configureMakeStore(options, [postCreate]): makeStore`
+
+**Props**
 
 - `options` - (object) Options object
   - `initialState` - (object) Optionally set any preloaded state
-  - `reducers` - (object) Map of identifiers and reducer functions which will
-    be [combined].
+  - `reducers` - (object) Map of identifiers and reducer functions which will be
+    [combined].
   - `rootReducer` - (function) Optional entry reducer. If returned state is
     unchanged, it will pass through to combined `reducers`.
   - `middleware` - (function[]) Additional redux middleware to apply
@@ -27,10 +33,26 @@ npm i @gasket/redux
 - `postCreate` - (function) Executed after the store is create the resulting
   store as the argument
 
-### Return Value
+**Return Value**
 
 - `makeStore` - (function) Creates the redux store for each server-side request
   and once on the client, hydrating with the state from the server.
+
+### getOrCreateStore
+
+Creates a helper to check if an existing store is in the context, otherwise it
+will make a new instance. Context can include a `store` property directly or on
+`req` and can be Next.js App or Page context.
+
+**Signature**
+
+- `getOrCreateStore(makeStore): (context) => Store`
+
+**Props**
+
+- `makeStore` - (function) Creates the redux store for each server-side request
+  and once on the client, hydrating with the state from the server. Will only
+  be called if an existing store is not found within the context.
 
 ## Usage
 
@@ -120,3 +142,4 @@ module.exports = configureMakeStore({ reducers, thunkMiddleware })
 <!-- LINKS -->
 
 [combined]: https://redux.js.org/api/combinereducers
+

--- a/packages/gasket-redux/src/get-or-create-store.js
+++ b/packages/gasket-redux/src/get-or-create-store.js
@@ -1,0 +1,18 @@
+/**
+ * Helper to check for an existing store on context, otherwise make a new instance.
+ *
+ * @param {function} fallbackMakeStore - A makeStore function to create new stores
+ * @returns {function(object): Store} getOrCreateStore
+ */
+export default function getOrCreateStore(fallbackMakeStore) {
+  return function checkContext(ctx = {}) {
+    // normalize Page and App context from Next.js
+    const _ctx = ctx.ctx || ctx;
+    // If there's a req object check for store
+    if (_ctx.req && _ctx.req.store) return _ctx.req.store;
+    // Check if store is directly on context
+    if (_ctx.store) return _ctx.store;
+    // Otherwise create new instance
+    return fallbackMakeStore();
+  };
+}

--- a/packages/gasket-redux/src/index.js
+++ b/packages/gasket-redux/src/index.js
@@ -1,5 +1,7 @@
 import configureMakeStore from './configure-make-store';
+import getOrCreateStore from './get-or-create-store';
 
 export {
-  configureMakeStore
+  configureMakeStore,
+  getOrCreateStore
 };

--- a/packages/gasket-redux/test/get-or-create-store.spec.js
+++ b/packages/gasket-redux/test/get-or-create-store.spec.js
@@ -1,0 +1,40 @@
+import getOrCreateStore  from '../src/get-or-create-store';
+
+const newStore = 'NEW STORE';
+const existingStore = 'EXISTING STORE';
+
+describe('getOrCreateStore', () => {
+  let makeStore;
+  beforeEach(() => {
+    makeStore = jest.fn().mockReturnValue(newStore);
+  });
+
+  it('returns an function', () => {
+    const results = getOrCreateStore(makeStore);
+    expect(results).toEqual(expect.any(Function));
+  });
+
+  it('returns existing store from appCtx.ctx.req', () => {
+    const wrapper = getOrCreateStore(makeStore);
+    const results = wrapper({ ctx: { req: { store: existingStore } } });
+    expect(results).toEqual(existingStore);
+  });
+
+  it('returns existing store from ctx.req', () => {
+    const wrapper = getOrCreateStore(makeStore);
+    const results = wrapper({ req: { store: existingStore } });
+    expect(results).toEqual(existingStore);
+  });
+
+  it('returns existing store from ctx', () => {
+    const wrapper = getOrCreateStore(makeStore);
+    const results = wrapper({ store: existingStore });
+    expect(results).toEqual(existingStore);
+  });
+
+  it('creates new store', () => {
+    const wrapper = getOrCreateStore(makeStore);
+    const results = wrapper();
+    expect(results).toEqual(newStore);
+  });
+});


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

In the updated generated code for setting up `next-redux-wrapper`, it was incorrectly checking for an existing Redux store instance on `ctx.req.store`. The context that is provided to the wrapper, is the Next.js [App Context](https://nextjs.org/docs/advanced-features/custom-app), so we need to step in to `appCtx.ctx.req.store`.

This provides a helper function to handle this and other edge cases and makes the generated setup code a little cleaner and easier to bug-fix.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/redux**
- Provide `getOrCreateStore` for finding existing store instances on a context

**@gasket/plugin-nextjs**
- Generate new store files using `getOrCreateStore`

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Updated unit tests
- Local app testings