### PR TITLE
Opt-in forwardRef for withLocaleRequired

### DIFF
--- a/packages/gasket-react-intl/README.md
+++ b/packages/gasket-react-intl/README.md
@@ -62,6 +62,7 @@ wrapped component will be rendered.
   - `loading` - (string|node) Content to render while loading, otherwise null.
   - `initialProps` - (boolean) Enable `getInitialProps` to load locale files
     during server-side rendering for Next.js pages. Defaults to `false`.
+  - `forwardRef` - (boolean) Add a ref to the connected wrapper component.
 
 #### Example
 

--- a/packages/gasket-react-intl/src/with-locale-required.js
+++ b/packages/gasket-react-intl/src/with-locale-required.js
@@ -42,10 +42,11 @@ function attachGetInitialProps(Wrapper, localePathPart) {
  * @param {object} [options] - Options
  * @param {React.Component} [options.loading=null] - Custom component to show while loading
  * @param {React.Component} [options.initialProps=false] - Preload locales during SSR with Next.js pages
+ * @param {React.Component} [options.forwardRef=false] - Forward refs
  * @returns {function} wrapper
  */
 export default function withLocaleRequired(localePathPart = defaultPath, options = {}) {
-  const { loading = null, initialProps = false } = options;
+  const { loading = null, initialProps = false, forwardRef = false } = options;
   /**
    * Wrap the component
    * @param {React.Component} Component - Component to wrap
@@ -73,16 +74,20 @@ export default function withLocaleRequired(localePathPart = defaultPath, options
     Wrapper.displayName = `withLocaleRequired(${ displayName })`;
     Wrapper.WrappedComponent = Component;
 
-    // Forward ref through the HOC
-    const ForwardRef = React.forwardRef((props, ref) => <Wrapper { ...props } forwardedRef={ ref }/>);
-    hoistNonReactStatics(ForwardRef, Component);
-    ForwardRef.displayName = `ForwardRef(withLocaleRequired/${ displayName }))`;
-    ForwardRef.WrappedComponent = Component;
+    let Result = Wrapper;
 
-    if (initialProps || 'getInitialProps' in Component) {
-      attachGetInitialProps(ForwardRef, localePathPart);
+    // Forward ref through the HOC
+    if (forwardRef) {
+      Result = React.forwardRef((props, ref) => <Wrapper { ...props } forwardedRef={ ref }/>);
+      hoistNonReactStatics(Result, Component);
+      Result.displayName = `ForwardRef(withLocaleRequired/${ displayName }))`;
+      Result.WrappedComponent = Component;
     }
 
-    return ForwardRef;
+    if (initialProps || 'getInitialProps' in Component) {
+      attachGetInitialProps(Result, localePathPart);
+    }
+
+    return Result;
   };
 }

--- a/packages/gasket-react-intl/test/with-locale-required.test.js
+++ b/packages/gasket-react-intl/test/with-locale-required.test.js
@@ -42,7 +42,12 @@ describe('withLocaleRequired', function () {
   });
 
   it('adds display name', function () {
-    assume(withLocaleRequired()(MockComponent)).property('displayName', 'ForwardRef(withLocaleRequired/MockComponent))');
+    assume(withLocaleRequired()(MockComponent)).property('displayName', 'withLocaleRequired(MockComponent)');
+  });
+
+  it('adds display name with ForwardRef', function () {
+    assume(withLocaleRequired('locales', { forwardRef: true })(MockComponent))
+      .property('displayName', 'ForwardRef(withLocaleRequired/MockComponent))');
   });
 
   it('hoists non-react statics', function () {
@@ -108,10 +113,10 @@ describe('withLocaleRequired', function () {
   });
 
   describe('#render', function () {
-    it('renders null if loading', function () {
+    it('renders empty if loading', function () {
       useLocaleRequiredStub.returns(LOADING);
       wrapper = doMount();
-      assume(wrapper.html()).eqls('');
+      assume(wrapper.html()).falsy();
     });
 
     it('renders custom loader if loading', function () {
@@ -146,7 +151,7 @@ describe('withLocaleRequired', function () {
         }
       }
 
-      const TestWrappedComponent = withLocaleRequired()(TestComponent);
+      const TestWrappedComponent = withLocaleRequired('locales', { forwardRef: true })(TestComponent);
 
       class TestRefComponent extends React.Component {
         constructor(...args) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

According to [the docs](https://reactjs.org/docs/forwarding-refs.html), forward refs are _typically not necessary for most components in the application._ Conflicts occur when trying to use `withLocaleRequired` alongside `connect` from react-redux, requiring the [forwardRef option](https://react-redux.js.org/api/connect#forwardref-boolean) to be set.

This PR makes `forwardRef` an opt-in feature for the HOC to handle the typical use case.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/react-intl**
- Add `forwardRef` opt-in option to `withLocaleRequired`

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Unit tests and local app testing