### PR TITLE
Config placeholder reducer

### DIFF
--- a/packages/gasket-redux/README.md
+++ b/packages/gasket-redux/README.md
@@ -78,6 +78,30 @@ const reducers = require('./reducers'); // apps reducers
 module.exports = configureMakeStore({ reducers });
 ```
 
+#### Example: initial state
+
+If you are adding keys to the initial state without reducers, you make get
+an `unexpected key found in previous state` error. In this case consider using
+[@gasket/data] for these static-like values, or register placeholder reducers
+in your store.
+
+```diff
+// ./store.js
+
+const { configureMakeStore } = require('@gasket/redux');
+const myReducers = require('./reducers'); // apps reducers
+
+const reducers = {
+  ...myReducers,
++  custom: f => f || null
+};
+
+const initialState = { custom: 'example' };
+
+module.exports = configureMakeStore({ initialState, reducers });
+```
+
+
 #### Example: adding middleware in a custom path (redux-saga)
 
 ```js
@@ -142,4 +166,4 @@ module.exports = configureMakeStore({ reducers, thunkMiddleware })
 <!-- LINKS -->
 
 [combined]: https://redux.js.org/api/combinereducers
-
+[@gasket/data]: /packages/gasket-data/README.md

--- a/packages/gasket-redux/src/placeholder-reducers.js
+++ b/packages/gasket-redux/src/placeholder-reducers.js
@@ -11,7 +11,10 @@
  * @returns {Object} placeholder reducers
  */
 export default function placeholderReducers(reducers = {}, preloadedState = {}) {
-  return Object.keys(preloadedState).reduce((acc, cur) => {
+  const keys = new Set(Object.keys(preloadedState));
+  keys.add('config'); // from @gasket/plugin-config
+
+  return Array.from(keys).reduce((acc, cur) => {
     if (!(cur in reducers)) acc[cur] = f => f || preloadedState[cur] || null;
     return acc;
   }, {});

--- a/packages/gasket-redux/test/configure-make-store.spec.js
+++ b/packages/gasket-redux/test/configure-make-store.spec.js
@@ -104,7 +104,6 @@ describe('configureMakeStore', () => {
 
   it('sets a default root reducer if no reducers passed', () => {
     configureMakeStore()();
-    expect(combineReducersSpy).not.toHaveBeenCalled();
     expect(createStoreSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Object), expect.any(Function));
   });
 
@@ -116,7 +115,10 @@ describe('configureMakeStore', () => {
 
   it('adds placeholder reducers', () => {
     configureMakeStore({ initialState: { bogus: true } })();
-    expect(combineReducersSpy).toHaveBeenCalledWith({ bogus: expect.any(Function) });
+    expect(combineReducersSpy).toHaveBeenCalledWith({
+      bogus: expect.any(Function),
+      config: expect.any(Function) // default added for @gasket/plugin-redux
+    });
   });
 
   it('allows custom rootReducer', () => {

--- a/packages/gasket-redux/test/placeholder-reducers.spec.js
+++ b/packages/gasket-redux/test/placeholder-reducers.spec.js
@@ -1,6 +1,6 @@
 import placeholderReducers  from '../src/placeholder-reducers';
 
-describe('placeholdReducers', () => {
+describe('placeholderReducers', () => {
   let results, mockReducers, mockState;
   beforeEach(() => {
     mockReducers = {
@@ -16,15 +16,21 @@ describe('placeholdReducers', () => {
     expect(results).toEqual(expect.any(Object));
   });
 
-  it('returns empty object if no initial state', () => {
+  it('always returns default config reducer', () => {
     results = placeholderReducers(mockReducers);
-    expect(results).toEqual({});
+    expect(results).toHaveProperty('config', expect.any(Function));
   });
 
-  it('returns empty object if initial state keys match reducers', () => {
+  it('does not return config reducer if custom one set', () => {
+    mockReducers.config = f => f;
+    results = placeholderReducers(mockReducers);
+    expect(results).not.toHaveProperty('config');
+  });
+
+  it('does not include placeholder initial state keys match reducers', () => {
     mockState.group1 = 'bogus';
     results = placeholderReducers(mockReducers, mockState);
-    expect(results).toEqual({});
+    expect(results).not.toHaveProperty('group1');
   });
 
   it('returns placeholder reducer if initial state does not have matching reducer', () => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

`@gasket/redux` creates placeholder reducers for keys from the initial state without reducers. For example, the `config` state from `@gasket/plugin-redux`. This breaks down with `next-redux-wrapper` in the browser since that initial state isn't present until HYDRATE. In this case, `@gasket/redux` cannot detect what placeholder reducers are needed, so the user must provide them.

This PR automatically adds a placeholder for `config`, and adds docs for any custom state keys.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/redux**
- Add default placeholder for `config` in the initial state

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Local app and unit tests