### PR TITLE
Protect against accesses of `res.locals.gasketData` when not defined

### DIFF
--- a/packages/gasket-plugin-intl/CHANGELOG.md
+++ b/packages/gasket-plugin-intl/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-intl`
 
+- Add additional safety checks around accessing gasketData
+
 ### 6.0.4
 
 - Fix to use defaultPath in workbox lifecycle ([#254])

--- a/packages/gasket-plugin-intl/lib/service-worker-cache-key.js
+++ b/packages/gasket-plugin-intl/lib/service-worker-cache-key.js
@@ -5,6 +5,16 @@
  */
 module.exports = async function serviceWorkerCacheKey() {
   return function getLocale(req, res) {
-    return res.locals.gasketData.intl.locale;
+    const {
+      locals: {
+        gasketData: {
+          intl: {
+            locale
+          } = {}
+        } = {}
+      } = {}
+    } = res;
+
+    return locale;
   };
 };

--- a/packages/gasket-plugin-intl/lib/workbox.js
+++ b/packages/gasket-plugin-intl/lib/workbox.js
@@ -42,7 +42,11 @@ module.exports = async function workbox(gasket, config, context) {
   const { res } = context;
 
   // since we cannot determine a users' locale at build time, exit early
-  if (!res) return {};
+  if (!res
+    || !res.locals
+    || !res.locals.gasketData
+    || !res.locals.gasketData.intl
+  ) return {};
 
   const { locale } = res.locals.gasketData.intl;
 

--- a/packages/gasket-plugin-intl/test/service-worker-cache-key.test.js
+++ b/packages/gasket-plugin-intl/test/service-worker-cache-key.test.js
@@ -26,4 +26,12 @@ describe('serviceWorkerCacheKey', function () {
     result = getLocale(req, res);
     assume(result).equals(expectedLocale);
   });
+
+  it('does not fail if gasketData is not fully populated', async function () {
+    const req = {};
+    const res = { locals: {}};
+
+    const getLocale = await serviceWorkerCacheKey();
+    assume(() => getLocale(req, res)).does.not.throw();
+  });
 });

--- a/packages/gasket-plugin-intl/test/service-worker-cache-key.test.js
+++ b/packages/gasket-plugin-intl/test/service-worker-cache-key.test.js
@@ -29,7 +29,7 @@ describe('serviceWorkerCacheKey', function () {
 
   it('does not fail if gasketData is not fully populated', async function () {
     const req = {};
-    const res = { locals: {}};
+    const res = { locals: {} };
 
     const getLocale = await serviceWorkerCacheKey();
     assume(() => getLocale(req, res)).does.not.throw();

--- a/packages/gasket-plugin-intl/test/workbox.test.js
+++ b/packages/gasket-plugin-intl/test/workbox.test.js
@@ -105,6 +105,19 @@ describe('workbox', function () {
     assume(result.manifestTransforms[0]).property('name', 'encodeLocaleUrls');
   });
 
+  it('does not assume gasketData to be populated', async function () {
+    delete mockContext.res.locals.gasketData;
+    let error = null;
+
+    try {
+      await workbox(mockGasket, mockConfig, mockContext);
+    } catch (err) {
+      error = err;
+    }
+
+    assume(error).to.equal(null);
+  });
+
   describe('makeEncodeLocaleUrls', function () {
     let encodeLocaleUrls, mockEntry, mockManifest;
 

--- a/packages/gasket-react-intl/CHANGELOG.md
+++ b/packages/gasket-react-intl/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/react-intl`
 
+- Fix crash that occurs when building static pages
+
 ### 6.0.9
 
 - Adjust peerDependencies ([#262])

--- a/packages/gasket-react-intl/src/with-locale-required.js
+++ b/packages/gasket-react-intl/src/with-locale-required.js
@@ -22,7 +22,7 @@ function attachGetInitialProps(Wrapper, localePathPart) {
     const { res } = ctx;
     let localesProps;
 
-    if (res) {
+    if (res && res.locals && res.locals.gasketData) {
       const { locale = defaultLocale } = res.locals.gasketData.intl || {};
       const localesParentDir = path.dirname(res.locals.localesDir);
       localesProps = localeUtils.serverLoadData(localePathPart, locale, localesParentDir);

--- a/packages/gasket-react-intl/test/with-locale-required.test.js
+++ b/packages/gasket-react-intl/test/with-locale-required.test.js
@@ -110,6 +110,27 @@ describe('withLocaleRequired', function () {
         }
       });
     });
+
+    it('handles missing gasketData', async function () {
+      MockComponent.getInitialProps = sinon.stub().returns({ bogus: true });
+      const wrapped = withLocaleRequired('locales', { initialProps: true })(MockComponent);
+
+      const ctx = {
+        res: {
+          locals: {
+            localesDir: path.join(__dirname, 'fixtures', 'locales')
+          }
+        }
+      };
+
+      let error = null;
+      try {
+        await wrapped.getInitialProps(ctx);
+      } catch (err) {
+        error = err;
+      }
+      assume(error).to.equal(null);
+    });
   });
 
   describe('#render', function () {


### PR DESCRIPTION
When a static page is built, even the 404 page, it uses `_app.js`. If this app is using a `@gasket/react-intl` HOC with `initialProps: true`, it attempts to read the locale from `gasketData` which is undefined.