### PR TITLE
Fix to use correct localesDir config

### DIFF
--- a/packages/gasket-plugin-intl/lib/express.js
+++ b/packages/gasket-plugin-intl/lib/express.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const { getIntlConfig } = require('./configure');
 const serveStaticMw = require('serve-static');
 
@@ -9,13 +8,12 @@ const serveStaticMw = require('serve-static');
  * @param {Object} app - Express app
  */
 module.exports = function express(gasket, app) {
-  const { root } = gasket.config;
-  const { outputDir, serveStatic, defaultPath } = getIntlConfig(gasket);
+  const { localesDir, serveStatic, defaultPath } = getIntlConfig(gasket);
 
   if (serveStatic) {
     const staticPath = serveStatic === true ? defaultPath : serveStatic;
 
-    app.use(staticPath, serveStaticMw(path.join(root, outputDir), {
+    app.use(staticPath, serveStaticMw(localesDir, {
       index: false,
       maxAge: '1y',
       immutable: true


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

When using `intl.serveStatic`, the plugin was looking to the wrong config property to get the path to the directory containing locale files.

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/plugin-intl**
- Fix to use configured `intl.localesDir` for serving static files

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Local app tested
- Updated unit tests
