### PR TITLE
Fixes for selecting configured basePath

### DIFF
--- a/packages/gasket-plugin-intl/lib/configure.js
+++ b/packages/gasket-plugin-intl/lib/configure.js
@@ -5,6 +5,8 @@ const moduleDefaults = {
   excludes: ['cacache', 'yargs', 'axe-core']
 };
 
+const isDefined = o => typeof o !== 'undefined';
+
 /**
  * Shortcut to get the gasket.config.intl object
  *
@@ -28,9 +30,9 @@ function getIntlConfig(gasket) {
 function deprecatedOptions(gasket, intlConfig) {
   const { logger } = gasket;
   const { languageMap, defaultLanguage, assetPrefix } = intlConfig;
-  if (languageMap) logger.warning('DEPRECATED intl config `languageMap` - use `localesMap`');
-  if (defaultLanguage) logger.warning('DEPRECATED intl config `defaultLanguage` - use `defaultLocale`');
-  if (assetPrefix) logger.warning('DEPRECATED intl config `assetPrefix` - use `basePath`');
+  if (isDefined(languageMap)) logger.warning('DEPRECATED intl config `languageMap` - use `localesMap`');
+  if (isDefined(defaultLanguage)) logger.warning('DEPRECATED intl config `defaultLanguage` - use `defaultLocale`');
+  if (isDefined(assetPrefix)) logger.warning('DEPRECATED intl config `assetPrefix` - use `basePath`');
   return { languageMap, defaultLanguage, assetPrefix };
 }
 
@@ -60,9 +62,9 @@ module.exports = function configureHook(gasket, config) {
 
   const fullLocalesDir = path.join(root, localesDir);
 
-  const basePath = intlConfig.basePath || assetPrefix ||
-    nextConfig.basePath || nextConfig.assetPrefix ||
-    config.basePath || '';
+  const basePath = [intlConfig.basePath, assetPrefix,
+    nextConfig.assetPrefix, nextConfig.basePath,
+    config.basePath, ''].find(isDefined);
 
   let { modules = false } = intlConfig;
   if (modules) {

--- a/packages/gasket-plugin-intl/test/configure.test.js
+++ b/packages/gasket-plugin-intl/test/configure.test.js
@@ -67,6 +67,29 @@ describe('configure', function () {
     });
   });
 
+  it('can use root basePath', function () {
+    const results = configure(mockGasket, { root, basePath: 'from-root' });
+    assume(results.intl).property('basePath', 'from-root');
+  });
+
+  it('can use nextConfig.assetPrefix for basePath', function () {
+    const results = configure(mockGasket, { root, nextConfig: { assetPrefix: 'from-next' } });
+    assume(results.intl).property('basePath', 'from-next');
+  });
+
+  it('can use nextConfig.basePath for basePath', function () {
+    const results = configure(mockGasket, { root, nextConfig: { basePath: 'from-next' } });
+    assume(results.intl).property('basePath', 'from-next');
+  });
+
+  it(`intl.basePath can be empty string, overriding lesser configs`, function () {
+    let results = configure(mockGasket, { root, intl: { basePath: '' }, nextConfig: { assetPrefix: 'from-next' } });
+    assume(results.intl).property('basePath', '');
+
+    results = configure(mockGasket, { root, basePath: 'from-root', intl: { basePath: '' } });
+    assume(results.intl).property('basePath', '');
+  });
+
   it('adds env variables', function () {
     assume(process.env.GASKET_INTL_LOCALES_DIR).is.undefined;
     assume(process.env.GASKET_INTL_MANIFEST_FILE).is.undefined;
@@ -83,6 +106,9 @@ describe('configure', function () {
 
     configure(mockGasket, { root, intl: { defaultLanguage: 'fake' } });
     assume(mockGasket.logger.warning).calledWithMatch('defaultLanguage');
+
+    configure(mockGasket, { root, intl: { assetPrefix: 'fake' } });
+    assume(mockGasket.logger.warning).calledWithMatch('assetPrefix');
   });
 
   describe('getIntlConfig', function () {

--- a/packages/gasket-plugin-nextjs/index.js
+++ b/packages/gasket-plugin-nextjs/index.js
@@ -4,6 +4,8 @@ const { name, devDependencies } = require('./package');
 const { createConfig } = require('./config');
 const { pluginIdentifier } = require('@gasket/resolve');
 
+const isDefined = o => typeof o !== 'undefined';
+
 module.exports = {
   dependencies: ['@gasket/plugin-webpack'],
   name,
@@ -166,8 +168,8 @@ module.exports = {
     * @returns {Object} config
     */
     workbox: function (gasket) {
-      const { nextConfig = {}, basePath } = gasket.config;
-      const assetPrefix = nextConfig.assetPrefix || basePath || '';
+      const { nextConfig = {}, basePath: rootBasePath } = gasket.config;
+      const assetPrefix = [nextConfig.assetPrefix, nextConfig.basePath, rootBasePath, ''].find(isDefined);
 
       const parsed = assetPrefix ? url.parse(assetPrefix) : '';
       const joined = parsed ? url.format({ ...parsed, pathname: path.join(parsed.pathname, '_next/') }) : '_next/';

--- a/packages/gasket-plugin-nextjs/test/index.test.js
+++ b/packages/gasket-plugin-nextjs/test/index.test.js
@@ -409,6 +409,13 @@ describe('workbox hook', () => {
     const results = await plugin.hooks.workbox(gasketAPI);
     assume(results.modifyURLPrefix).to.have.property('.next/', `${assetPrefix}/_next/`);
   });
+
+  it('config modifies urls to use basePath', async () => {
+    const assetPrefix = '/from-root';
+    gasketAPI.config = { basePath: assetPrefix };
+    const results = await plugin.hooks.workbox(gasketAPI);
+    assume(results.modifyURLPrefix).to.have.property('.next/', `${assetPrefix}/_next/`);
+  });
 });
 
 function mockGasketApi() {

--- a/packages/gasket-plugin-workbox/README.md
+++ b/packages/gasket-plugin-workbox/README.md
@@ -43,9 +43,9 @@ Set the Workbox options, in the `gasket.config.js` under `workbox`.
 
 - `outputDir` - (string) path of directory to copy Workbox libraries to
   (default: `./build/workbox`)
-- `assetPrefix` - (string) change the default path to `/_workbox` endpoint by
+- `basePath` - (string) change the default path to `/_workbox` endpoint by
   adding a path prefix here. (default: ''). Used for setting up CDN support for
-  Workbox files. The `basePath` config will be used unless `assetPrefix` is set.
+  Workbox files.
 - `config`: (object) Any initial [workbox config options][generateSWString]
   which will be merged with those from any `workbox` lifecycle hooks.
 
@@ -110,7 +110,7 @@ appended to the service worker content in the [composeServiceWorker] hook from
 During the `build` hook, the Workbox libraries are copied to the build output
 directory so that they can be served by the app. The service worker will then
 import these scripts, with requests to the `/_workbox` static files served by
-the app. These can be set up to edge cache by setting the `assetPrefix` option.
+the app. These can be set up to edge cache by setting the `basePath` option.
 
 ## License
 

--- a/packages/gasket-plugin-workbox/lib/configure.js
+++ b/packages/gasket-plugin-workbox/lib/configure.js
@@ -1,6 +1,6 @@
 const {
   getWorkboxConfig,
-  getAssetPrefix
+  getBasePath
 } = require('./utils');
 
 /**
@@ -11,14 +11,18 @@ const {
  * @returns {Promise<Object>} config
  */
 module.exports = async function configure(gasket, config) {
+  const { logger } = gasket;
   const workbox = getWorkboxConfig({ config });
-  const assetPrefix = getAssetPrefix({ config });
+  const basePath = getBasePath({ config });
+
+  if ('assetPrefix' in workbox) logger.warning('DEPRECATED workbox config `assetPrefix` - use `basePath`');
+  workbox.basePath = basePath;
 
   const { version } = require('workbox-build/package');
   const libraryVersion = `workbox-v${version}`;
 
   const scriptUrl = [
-    ...(assetPrefix ? [assetPrefix] : []),
+    ...(basePath ? [basePath] : []),
     '_workbox',
     libraryVersion,
     'workbox-sw.js'

--- a/packages/gasket-plugin-workbox/lib/utils.js
+++ b/packages/gasket-plugin-workbox/lib/utils.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const merge = require('deepmerge');
 
+const isDefined = o => typeof o !== 'undefined';
+
 /**
  * Workbox defaults
  *
@@ -38,20 +40,22 @@ function getOutputDir(gasket) {
 }
 
 /**
- * Get the asset prefix from next, workbox, or basePath config.
+ * Get the base path from workbox, or root basePath config.
  * If found in both, the workbox config will be used.
  *
  * @param {Gasket} gasket - Gasket
  * @returns {string} prefix
  */
-function getAssetPrefix(gasket) {
-  const { workbox = {}, basePath } = gasket.config;
-  return workbox.assetPrefix || basePath || '';
+function getBasePath(gasket) {
+  const { workbox = {}, basePath: rootBasePath } = gasket.config;
+  const { basePath, assetPrefix } = workbox;
+
+  return [basePath, assetPrefix, rootBasePath, ''].find(isDefined);
 }
 
 module.exports = {
   defaultConfig,
   getWorkboxConfig,
   getOutputDir,
-  getAssetPrefix
+  getBasePath
 };

--- a/packages/gasket-plugin-workbox/test/configure.spec.js
+++ b/packages/gasket-plugin-workbox/test/configure.spec.js
@@ -6,6 +6,9 @@ describe('configure', () => {
 
   beforeAll(() => {
     mockGasket = {
+      logger: {
+        warning: jest.fn()
+      },
       config: {
         root: '/some-root'
       }
@@ -49,9 +52,18 @@ describe('configure', () => {
       ]));
   });
 
-  it('add assetPrefix to script path', async () => {
+  it('configures basePath with deprecated assetPrefix', async function () {
     mockGasket.config.workbox = {
       assetPrefix: '/some/prefix'
+    };
+    results = await configure(mockGasket, mockGasket.config);
+    expect(results.workbox).toHaveProperty('basePath', '/some/prefix');
+    expect(mockGasket.logger.warning).toHaveBeenCalledWith('DEPRECATED workbox config `assetPrefix` - use `basePath`');
+  });
+
+  it('add basePath to script path', async () => {
+    mockGasket.config.workbox = {
+      basePath: '/some/prefix'
     };
     results = await configure(mockGasket, mockGasket.config);
     expect(results.workbox.config).toHaveProperty('importScripts',

--- a/packages/gasket-plugin-workbox/test/utils.spec.js
+++ b/packages/gasket-plugin-workbox/test/utils.spec.js
@@ -27,10 +27,19 @@ describe('getWorkboxConfig', () => {
   });
 });
 
-describe('getAssetPrefix', () => {
+describe('getBasePath', () => {
+
+  it('returns the basePath from workbox config', () => {
+    const results = utils.getBasePath(setupGasket({
+      workbox: {
+        basePath: '//cdn-a'
+      }
+    }));
+    expect(results).toEqual('//cdn-a');
+  });
 
   it('returns the assetPrefix from workbox config', () => {
-    const results = utils.getAssetPrefix(setupGasket({
+    const results = utils.getBasePath(setupGasket({
       workbox: {
         assetPrefix: '//cdn-a'
       }
@@ -38,15 +47,15 @@ describe('getAssetPrefix', () => {
     expect(results).toEqual('//cdn-a');
   });
 
-  it('returns the assetPrefix from next config', () => {
-    const results = utils.getAssetPrefix(setupGasket({
+  it('returns the basePath from next config', () => {
+    const results = utils.getBasePath(setupGasket({
       basePath: '//cdn-b'
     }));
     expect(results).toEqual('//cdn-b');
   });
 
-  it('returns the assetPrefix from workbox config over next', () => {
-    const results = utils.getAssetPrefix(setupGasket({
+  it('returns the basePath from workbox config over next', () => {
+    const results = utils.getBasePath(setupGasket({
       workbox: {
         assetPrefix: '//cdn-a'
       },
@@ -56,7 +65,7 @@ describe('getAssetPrefix', () => {
   });
 
   it('returns empty string if not configured', () => {
-    const results = utils.getAssetPrefix(setupGasket({}));
+    const results = utils.getBasePath(setupGasket({}));
     expect(results).toEqual('');
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

In some cases, a user may want to "cancel" the root or lesser path base configurations for a plugin. To do this, setting the config property to `''` was resulting in a falsy comparison, thus falling back to the lesser base path.

This also aligns `basePath` as the preferred config property name for the Workbox plugin.

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/plugin-intl**
- Safer base path config selection

**@gasket/plugin-nextjs**
- Safer base path config selection

**@gasket/plugin-workbox**
- Deprecate assetPrefix in favor of basePath config property
- Safer base path config selection

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Updated unit tests