### PR TITLE
Trace debugging for gasket engine

### DIFF
--- a/packages/gasket-engine/CHANGELOG.md
+++ b/packages/gasket-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/engine`
 
+- Add ability to do debug tracing for the plugin lifecycle
+
 ### 6.0.0
 
 - Remove package name fallbacks ([#227])

--- a/packages/gasket-engine/README.md
+++ b/packages/gasket-engine/README.md
@@ -145,6 +145,10 @@ const pluginEngine = new PluginEngine(gasketConfig, { resolveFrom });
 The above will resolve all Plugins and Presets from within `./someapp` instead
 of resolving relative to the current directory.
 
+## Tracing
+
+The Gasket engine uses the [`debug`](https://www.npmjs.com/package/debug) package to trace the plugin lifecycle. If you set the `DEBUG` environment variable to `gasket:engine` you'll see additional output in `stderr` indicating when things are invoked.
+
 ## License
 
 [MIT](./LICENSE.md)

--- a/packages/gasket-engine/package.json
+++ b/packages/gasket-engine/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/godaddy/gasket/tree/master/packages/gasket-engine",
   "dependencies": {
     "@gasket/resolve": "^6.0.0",
-    "debug": "4.3.1"
+    "debug": "^4.3.1"
   },
   "devDependencies": {
     "eslint": "^7.17.0",

--- a/packages/gasket-engine/package.json
+++ b/packages/gasket-engine/package.json
@@ -35,7 +35,8 @@
   },
   "homepage": "https://github.com/godaddy/gasket/tree/master/packages/gasket-engine",
   "dependencies": {
-    "@gasket/resolve": "^6.0.0"
+    "@gasket/resolve": "^6.0.0",
+    "debug": "4.3.1"
   },
   "devDependencies": {
     "eslint": "^7.17.0",


### PR DESCRIPTION
Enables debug output for the gasket plugin lifecycle.

Sample output:

```
~/Code/guac-admin(gasket-upgrade) » DEBUG=gasket:engine npx gasket local                                                                                jpage@LTTC-2Q6Q1Z2
  gasket:engine exec initOclif +0ms
  gasket:engine   @gasket/plugin-command:initOclif +1ms
  gasket:engine   exec getCommands +1ms
  gasket:engine     @gasket/plugin-start:getCommands +0ms
  gasket:engine     @gasket/plugin-analyze:getCommands +0ms
  gasket:engine     @gasket/plugin-docs:getCommands +0ms
  gasket:engine     @godaddy/gasket-plugin-rigor:getCommands +0ms
  gasket:engine exec init +4ms
  gasket:engine   @gasket/plugin-lifecycle:init +1ms
  gasket:engine   @gasket/plugin-metadata:init +0ms
  gasket:engine   execApply metadata +28ms
  gasket:engine   @gasket/plugin-intl:init +0ms
  gasket:engine     @gasket/plugin-command:metadata +68ms
  gasket:engine     @gasket/plugin-lifecycle:metadata +1ms
  gasket:engine     @gasket/plugin-metadata:metadata +0ms
  gasket:engine     @gasket/plugin-start:metadata +0ms
  gasket:engine     @gasket/plugin-analyze:metadata +0ms
  gasket:engine     @gasket/plugin-config:metadata +0ms
  gasket:engine     @gasket/plugin-docs:metadata +0ms
  gasket:engine     @gasket/plugin-express:metadata +0ms
  gasket:engine     @gasket/plugin-https:metadata +1ms
  gasket:engine     @gasket/plugin-intl:metadata +0ms
  gasket:engine     @gasket/plugin-log:metadata +0ms
  gasket:engine     @gasket/plugin-nextjs:metadata +0ms
  gasket:engine     @gasket/plugin-redux:metadata +0ms
  gasket:engine     @gasket/plugin-webpack:metadata +0ms
  gasket:engine     @godaddy/gasket-plugin-auth:metadata +0ms
  gasket:engine     @godaddy/gasket-plugin-rigor:metadata +1ms
  gasket:engine     @godaddy/gasket-plugin-traffic:metadata +0ms
  gasket:engine     @godaddy/gasket-plugin-uxp:metadata +0ms
  gasket:engine     @godaddy/gasket-plugin-visitor:metadata +0ms
  gasket:engine   @gasket/plugin-log:init +47ms
  gasket:engine   exec logTransports +1ms
  gasket:engine execWaterfall configure +19ms
  gasket:engine   @gasket/plugin-nextjs:configure +0ms
  gasket:engine   @gasket/plugin-docs:configure +1ms
  gasket:engine   @gasket/plugin-intl:configure +0ms
  gasket:engine   @gasket/plugin-redux:configure +0ms
  gasket:engine   @godaddy/gasket-plugin-auth:configure +0ms
  gasket:engine   @godaddy/gasket-plugin-rigor:configure +1ms
  gasket:engine   @godaddy/gasket-plugin-uxp:configure +0ms
  gasket:engine exec build +0ms
  gasket:engine   @gasket/plugin-intl:build +0ms
(node:23343) [DEP0106] DeprecationWarning: crypto.createCipher is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:23343) Warning: Use Cipheriv for counter mode of aes-256-ctr
info: build:locales: Wrote locales manifest.
  gasket:engine   @gasket/plugin-nextjs:build +6ms
  gasket:engine   @godaddy/gasket-plugin-uxp:build +0ms
warning: @ux/uxcore2 update available from 2002.3.3 to 2100.0.3
  gasket:engine exec preboot +3s
  gasket:engine   @gasket/plugin-config:preboot +0ms
  gasket:engine   execWaterfall appEnvConfig +1ms
  gasket:engine exec start +0ms
  gasket:engine   @gasket/plugin-https:start +0ms
  gasket:engine   execWaterfall createServers +1ms
  gasket:engine     @gasket/plugin-express:createServers +0ms
  gasket:engine     exec middleware +4ms
  gasket:engine       @godaddy/gasket-plugin-auth:middleware +0ms
  gasket:engine       @godaddy/gasket-plugin-traffic:middleware +1ms
  gasket:engine       @godaddy/gasket-plugin-visitor:middleware +0ms
  gasket:engine       middleware.js:middleware +0ms
  gasket:engine       @gasket/plugin-config:middleware +0ms
  gasket:engine       @gasket/plugin-intl:middleware +0ms
  gasket:engine       @godaddy/gasket-plugin-rtl-css:middleware +0ms
  gasket:engine       @godaddy/gasket-plugin-uxp:middleware +1ms
  gasket:engine       @gasket/plugin-redux:middleware +4ms
  gasket:engine       @godaddy/gasket-plugin-security:middleware +34ms
notice: ContentSecurityPolicy is disabled for `gasket local`.
  gasket:engine     exec express +0ms
  gasket:engine       @gasket/plugin-intl:express +0ms
  gasket:engine       @godaddy/gasket-plugin-auth:express +1ms
  gasket:engine       @godaddy/gasket-plugin-healthcheck:express +0ms
  gasket:engine       @gasket/plugin-nextjs:express +0ms
  gasket:engine       execWaterfall nextConfig +62ms
  gasket:engine         @godaddy/gasket-plugin-rtl-css:nextConfig +0ms
  gasket:engine         next-config.js:nextConfig +0ms
  gasket:engine       exec next +1ms
  gasket:engine       execSync webpackChain +836ms
  gasket:engine       execSync webpack +3ms
  gasket:engine         @gasket/plugin-analyze:webpack +0ms
  gasket:engine         @gasket/plugin-intl:webpack +0ms
  gasket:engine         @gasket/plugin-redux:webpack +1ms
  gasket:engine         @godaddy/gasket-plugin-uxp:webpack +0ms
  gasket:engine         webpack.js:webpack +0ms
  gasket:engine       execSync webpackChain +17ms
  gasket:engine       execSync webpack +1ms
  gasket:engine         @gasket/plugin-analyze:webpack +1ms
  gasket:engine         @gasket/plugin-intl:webpack +0ms
  gasket:engine         @gasket/plugin-redux:webpack +0ms
  gasket:engine         @godaddy/gasket-plugin-uxp:webpack +0ms
  gasket:engine         webpack.js:webpack +0ms
info  - automatically enabled Fast Refresh for 1 custom loader
info  - Using external babel configuration from /home/jpage/Code/guac-admin/.babelrc
  gasket:engine       exec metrics +4s
  gasket:engine         @godaddy/gasket-plugin-visitor:metrics +1ms
event - compiled successfully
  gasket:engine         exec nextExpress +341ms
  gasket:engine       exec errorMiddleware +1ms
  gasket:engine     execWaterfall terminus +0ms
  gasket:engine   exec servers +5ms
info: Server started at https://local.admin.instantpage.int.dev-godaddy.com:8443/
```
