### PR TITLE
fixed locale fallback

### DIFF
--- a/packages/gasket-helper-intl/lib/index.js
+++ b/packages/gasket-helper-intl/lib/index.js
@@ -81,6 +81,8 @@ const LocaleStatus = {
 };
 
 const reLocalePathParam = /(\/[$:{]locale}?\/)/;
+const reLeadingSlash = /^\//;
+const trim = localePath => localePath.replace(reLeadingSlash, '');
 
 /**
  * @classdesc Utility class for loading locale files
@@ -149,8 +151,7 @@ function LocaleUtils(config) {
 
     while (fallbackLocale !== null) {
       const localePath = this.formatLocalePath(localePathPart, fallbackLocale);
-      const localePathTrimmed = localePath.replace('/', '');
-      if (localePathTrimmed in paths) return localePath;
+      if (trim(localePath) in paths) return localePath;
       fallbackLocale = this.getFallbackLocale(fallbackLocale);
     }
     return this.formatLocalePath(localePathPart, mappedLocale);
@@ -164,12 +165,8 @@ function LocaleUtils(config) {
    * @method
    */
   this.pathToUrl = (localePath) => {
-    let url = localePath;
-    const localePathTrimmed = localePath.replace(/^\//, '');
-    if (basePath) {
-      url = basePath.replace(/\/$/, '') + '/' + localePathTrimmed;
-    }
-    const hash = paths[localePathTrimmed];
+    let url = basePath ? basePath.replace(/\/$/, '') + localePath : localePath;
+    const hash = paths[trim(localePath)];
     if (hash) url += `?v=${ hash }`;
     return url;
   };

--- a/packages/gasket-helper-intl/lib/index.js
+++ b/packages/gasket-helper-intl/lib/index.js
@@ -149,7 +149,8 @@ function LocaleUtils(config) {
 
     while (fallbackLocale !== null) {
       const localePath = this.formatLocalePath(localePathPart, fallbackLocale);
-      if (localePath in paths) return localePath;
+      const localePathTrimmed = localePath.replace('/', '');
+      if (localePathTrimmed in paths) return localePath;
       fallbackLocale = this.getFallbackLocale(fallbackLocale);
     }
     return this.formatLocalePath(localePathPart, mappedLocale);
@@ -163,8 +164,12 @@ function LocaleUtils(config) {
    * @method
    */
   this.pathToUrl = (localePath) => {
-    let url = basePath ? basePath.replace(/\/$/, '') + localePath : localePath;
-    const hash = paths[localePath];
+    let url = localePath;
+    const localePathTrimmed = localePath.replace(/^\//, '');
+    if (basePath) {
+      url = basePath.replace(/\/$/, '') + '/' + localePathTrimmed;
+    }
+    const hash = paths[localePathTrimmed];
     if (hash) url += `?v=${ hash }`;
     return url;
   };

--- a/packages/gasket-helper-intl/test/fixtures/mock-manifest.json
+++ b/packages/gasket-helper-intl/test/fixtures/mock-manifest.json
@@ -3,7 +3,7 @@
   "localesPath": "/locales",
   "defaultLocale": "en-US",
   "paths": {
-    "/locales/en-US.json": "10decbe",
-    "/locales/fr-FR.json": "21047f1"
+    "locales/en-US.json": "10decbe",
+    "locales/fr-FR.json": "21047f1"
   }
 }

--- a/packages/gasket-helper-intl/test/shared.js
+++ b/packages/gasket-helper-intl/test/shared.js
@@ -89,14 +89,14 @@ module.exports = function sharedTests(UtilClass) {
     });
 
     it('falls back to lang if no localePath with region', function () {
-      mockConfig.manifest.paths['/locales/da.json'] = 'hash1234';
+      mockConfig.manifest.paths['locales/da.json'] = 'hash1234';
       utils = new UtilClass(mockConfig);
       const results = utils.getLocalePath('/locales', 'da-DK');
       assume(results).equals('/locales/da.json');
     });
 
     it('falls back to lang if no localePath with script and region', function () {
-      mockConfig.manifest.paths['/locales/az.json'] = 'hash1234';
+      mockConfig.manifest.paths['locales/az.json'] = 'hash1234';
       utils = new UtilClass(mockConfig);
       const results = utils.getLocalePath('/locales', 'az-Cyrl-AZ');
       assume(results).equals('/locales/az.json');
@@ -104,14 +104,14 @@ module.exports = function sharedTests(UtilClass) {
 
     it('falls back to default locale if no localePath for locale', function () {
       mockConfig.manifest.defaultLocale = 'fake';
-      mockConfig.manifest.paths['/locales/fake.json'] = 'hash1234';
+      mockConfig.manifest.paths['locales/fake.json'] = 'hash1234';
       utils = new UtilClass(mockConfig);
       const results = utils.getLocalePath('/locales', 'da-DK');
       assume(results).equals('/locales/fake.json');
     });
 
     it('returns localePath for mapped locales', function () {
-      mockConfig.manifest.paths['/locales/fake.json'] = 'hash1234';
+      mockConfig.manifest.paths['locales/fake.json'] = 'hash1234';
       mockConfig.manifest.localesMap = { 'da-DK': 'fake' };
       utils = new UtilClass(mockConfig);
       const results = utils.getLocalePath('/locales', 'da-DK');


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Locale fallback was not working because the `paths` object key and the localePath were formatted differently.  `localePath` had a leading slash. The `paths` object key does not.

## Changelog

**@gasket/helper-intl**
- Removed forward slash from localePath when looking up entry from the manifest paths in `getLocalePath` and `pathToUrl`

## Test Plan

- Updated Unit tests 
