### PR TITLE
Added check for locales config to determine fallbackLocale.

### DIFF
--- a/packages/gasket-helper-intl/lib/index.js
+++ b/packages/gasket-helper-intl/lib/index.js
@@ -95,7 +95,7 @@ const trim = localePath => localePath.replace(reLeadingSlash, '');
 function LocaleUtils(config) {
   const { manifest } = config;
   const { basePath = manifest.basePath } = config;
-  const { defaultLocale = 'en', localesMap, paths } = manifest;
+  const { defaultLocale = 'en', localesMap, paths, locales } = manifest;
   const defaultLang = defaultLocale.split('-')[0];
 
   /**
@@ -148,6 +148,10 @@ function LocaleUtils(config) {
   this.getLocalePath = (localePathPart, locale) => {
     const mappedLocale = localesMap && localesMap[locale] || locale;
     let fallbackLocale = mappedLocale;
+
+    if (locales && !locales.includes(mappedLocale)) {
+      fallbackLocale = defaultLocale;
+    }
 
     while (fallbackLocale !== null) {
       const localePath = this.formatLocalePath(localePathPart, fallbackLocale);

--- a/packages/gasket-helper-intl/test/shared.js
+++ b/packages/gasket-helper-intl/test/shared.js
@@ -110,6 +110,23 @@ module.exports = function sharedTests(UtilClass) {
       assume(results).equals('/locales/fake.json');
     });
 
+    it('falls back to default locale if requested locale does not exist in locales config', function () {
+      mockConfig.manifest.defaultLocale = 'fake';
+      mockConfig.manifest.paths['locales/fake.json'] = 'hash1234';
+      mockConfig.manifest.locales = ['not-this', 'or-this'];
+      utils = new UtilClass(mockConfig);
+      const results = utils.getLocalePath('/locales', 'da-DK');
+      assume(results).equals('/locales/fake.json');
+    });
+
+    it('does not fallback to default locale if requested locale exists in locales config', function () {
+      mockConfig.manifest.defaultLocale = 'fake';
+      mockConfig.manifest.locales = ['da-DK'];
+      utils = new UtilClass(mockConfig);
+      const results = utils.getLocalePath('/locales', 'da-DK');
+      assume(results).equals('/locales/da-DK.json');
+    });
+
     it('returns localePath for mapped locales', function () {
       mockConfig.manifest.paths['locales/fake.json'] = 'hash1234';
       mockConfig.manifest.localesMap = { 'da-DK': 'fake' };


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Currently, the @gasket/plugin-intl allows configuring a supported locales array, for the purpose of passing along to Next.js for i18n routing of static pages. A suitable requested feature is to also use this for other non-Next static pages. In the @gasket/helper-intl, we should fallback to the defaultLocale when supported locales are specified and the requested locale is not included.

https://github.com/godaddy/gasket/issues/269

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->
Added check for locales config to determine fallbackLocale.
## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
Updated unit tests.