### PR TITLE
Support for Next i18n routing

### DIFF
--- a/packages/gasket-react-intl/src/with-intl-provider.js
+++ b/packages/gasket-react-intl/src/with-intl-provider.js
@@ -92,7 +92,10 @@ export default function withIntlProvider() {
         merge(state, localesProps);
       }
 
-      const locale = localesProps?.locale || getActiveLocale();
+      const locale = localesProps?.locale ||
+        // Support for Next.js i18n routing
+        props.router?.locale || // eslint-disable-line react/prop-types
+        getActiveLocale();
 
       const { status } = state;
       const messages = (state.messages || {})[locale];

--- a/packages/gasket-react-intl/test/with-intl-provider.test.js
+++ b/packages/gasket-react-intl/test/with-intl-provider.test.js
@@ -95,6 +95,15 @@ describe('withIntlProvider', function () {
       assume(result.prop('locale')).eqls('fr-FR');
       assume(result.prop('messages')).eqls({ bogus: 'BOGUS' });
     });
+
+    it('IntlProvider uses Next.js router locale if set', function () {
+      testProps.router = {
+        locale: 'fr-FR'
+      };
+      wrapper = doMount(testProps);
+      const result = wrapper.find(IntlProvider);
+      assume(result.prop('locale')).eqls('fr-FR');
+    });
   });
 
   describe('reducer', function () {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Support for fetching the correct locale file when `withLocaleRequired` is used alongside [Next.js built-in i18n routing](https://nextjs.org/docs/advanced-features/i18n-routing) but without GSP or GSSP functions.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/react-intl**
- Support for locale from Next i18n routing

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- local app + unit test