### PR TITLE
Make @gasket/plugin-log and @gasket/log slightly more flexible

### DIFF
--- a/packages/gasket-log/client.js
+++ b/packages/gasket-log/client.js
@@ -13,11 +13,11 @@ export default class Log {
    * @param {Object} options configuration.
    * @private
    */
-  constructor({ level, namespace } = {}) {
+  constructor({ level, levels = Log.levels, namespace } = {}) {
     this.namespace = Array.isArray(namespace) ? namespace : [namespace];
-    this.level = ~Log.levels.indexOf(level) ? level : 'info';
+    this.level = ~levels.indexOf(level) ? level : 'info';
 
-    Log.levels.forEach(lvl => {
+    levels.forEach(lvl => {
       this[lvl] = diagnostics(['gasket', lvl, ...this.namespace].filter(Boolean).join(':'));
     });
   }
@@ -38,7 +38,7 @@ export default class Log {
 
 /**
 * Prefix for all messages send to fluentd.
-* TODO (@swaagie) add support for sending aggegrated messages.
+* TODO (@swaagie) add support for sending aggregated messages.
 *
 * @type {String}
 */

--- a/packages/gasket-log/server.js
+++ b/packages/gasket-log/server.js
@@ -66,26 +66,7 @@ class Log {
    * @private
    */
   format() {
-    if (this.local) {
-      return format.combine(
-        reduxLogger(),
-        format.colorize(),
-        format.splat(),
-        format.simple()
-      );
-    }
-
-    //
-    // Remark (@indexzero): in the event that redux logging is not
-    // turned off (i.e. configureMakeStore({ reducers })) AND level
-    // is manually set to 'debug' not having `inlineColors` here
-    // may cause issues.
-    //
-    return format.combine(
-      format.splat(),
-      format.label({ label: this.prefix }),
-      format.json()
-    );
+    return this.options.format || Log.getDefaultFormat(this.local, this.prefix);
   }
 
   /**
@@ -101,6 +82,10 @@ class Log {
     }
 
     return [new transports.Console()];
+  }
+
+  get levels() {
+    return this.options.levels || Log.levels;
   }
 
   /**
@@ -138,8 +123,9 @@ class Log {
    * @public
    */
   spawn() {
+    const levels = this.levels;
     const winston = createLogger({
-      levels: config.syslog.levels,
+      levels,
       level: this.level,
       silent: this.silent,
       format: this.format(),
@@ -149,8 +135,8 @@ class Log {
     //
     // Create proxies per loglevel to each method in winston.
     //
-    Object.keys(config.syslog.levels).forEach(level => {
-      this[level] = winston[level].bind(this.winston);
+    Object.keys(levels).forEach(level => {
+      this[level] = winston[level].bind(winston);
     });
 
     return this.winston = winston;
@@ -158,7 +144,7 @@ class Log {
 }
 
 /**
- * Default prefix for all messages send to fluentd.
+ * Default prefix for all messages.
  *
  * @type {String}
  */
@@ -177,5 +163,30 @@ Log.Console = transports.Console;
 Log.format = {
   color: reduxLogger
 };
+
+Log.levels = { ...config.syslog.levels };
+
+Log.getDefaultFormat = function getDefaultFormat(local, prefix) {
+  if (local) {
+    return format.combine(
+      reduxLogger(),
+      format.colorize(),
+      format.splat(),
+      format.simple()
+    );
+  }
+
+  //
+  // Remark (@indexzero): in the event that redux logging is not
+  // turned off (i.e. configureMakeStore({ reducers })) AND level
+  // is manually set to 'debug' not having `inlineColors` here
+  // may cause issues.
+  //
+  return format.combine(
+    format.splat(),
+    format.label({ label: prefix }),
+    format.json()
+  );
+}
 
 module.exports = Log;

--- a/packages/gasket-log/server.js
+++ b/packages/gasket-log/server.js
@@ -124,6 +124,7 @@ class Log {
    */
   spawn() {
     const levels = this.levels;
+    Log.ensureMinimalLevels(levels);
     const winston = createLogger({
       levels,
       level: this.level,
@@ -165,6 +166,14 @@ Log.format = {
 };
 
 Log.levels = { ...config.syslog.levels };
+
+Log.ensureMinimalLevels = function ensureMinimalLevels(levels) {
+  const missingLevels = Object.keys(Log.levels).filter(
+    lvl => !Object.prototype.hasOwnProperty.call(levels, lvl));
+  if (missingLevels.length > 0) {
+    throw new Error(`'levels' is missing necessary levels: ${ missingLevels.join(', ') }`);
+  }
+};
 
 Log.getDefaultFormat = function getDefaultFormat(local, prefix) {
   if (local) {

--- a/packages/gasket-log/server.js
+++ b/packages/gasket-log/server.js
@@ -187,6 +187,6 @@ Log.getDefaultFormat = function getDefaultFormat(local, prefix) {
     format.label({ label: prefix }),
     format.json()
   );
-}
+};
 
 module.exports = Log;

--- a/packages/gasket-log/test/client.test.js
+++ b/packages/gasket-log/test/client.test.js
@@ -20,13 +20,6 @@ describe('Log', function () {
     assume(log).to.be.instanceof(Log);
   });
 
-  it('exposes methods for syslog levels', function () {
-    Object.keys(config.syslog.levels)
-      .forEach(lvl => {
-        assume(Log.levels).includes(lvl);
-      });
-  });
-
   it('has predefined prefix', function () {
     assume(Log.prefix).to.equal('client');
   });
@@ -75,6 +68,26 @@ describe('Log', function () {
         'Simple log message',
         { additional: 'metadata' }
       ]);
+    });
+  });
+
+  describe('.levels', function () {
+    function assumeDefaultLevels() {
+      Object.keys(config.syslog.levels)
+        .forEach(lvl => {
+          assume(Log.levels).includes(lvl);
+          assume(log[lvl]).to.be.a('function');
+        });
+    }
+
+    it('exposes methods for default syslog levels', function () {
+      assumeDefaultLevels();
+    });
+
+    it('allows custom levels', function () {
+      log = new Log({ levels: [...Log.levels, 'weirdStuff'] });
+      assumeDefaultLevels();
+      assume(log.weirdStuff).to.be.a('function');
     });
   });
 });

--- a/packages/gasket-log/test/server.test.js
+++ b/packages/gasket-log/test/server.test.js
@@ -139,6 +139,31 @@ describe('Log', function () {
         format.json()
       ]);
     });
+
+    it('allows for custom formats', function () {
+      const spy = sinon.spy(format, 'combine');
+
+      const myFormat = format.json();
+      log = new Log({ local: false, format: myFormat });
+      const logFormat = log.format();
+
+      assume(spy.callCount).to.equal(0);
+      assume(logFormat).to.be.equal(myFormat);
+    });
+  });
+
+  describe('.levels', function () {
+    it('provides default levels', function () {
+      assume(Log.levels).to.deep.equal(config.syslog.levels);
+      assume(log.levels).to.deep.equal(config.syslog.levels);
+    });
+
+    it('allows custom levels', function () {
+      log = new Log({ local: false, levels: { ...Log.levels, weirdStuff: 1337 } });
+      assume(Log.levels).to.deep.equal(config.syslog.levels);
+      assume(log.levels).to.deep.equal({ ...Log.levels, weirdStuff: 1337 });
+      assume(log.weirdStuff).to.be.a('function');
+    });
   });
 
   describe('.transports', function () {

--- a/packages/gasket-log/test/server.test.js
+++ b/packages/gasket-log/test/server.test.js
@@ -158,6 +158,11 @@ describe('Log', function () {
       assume(log.levels).to.deep.equal(config.syslog.levels);
     });
 
+    it('throws if expected levels are not supplied in custom levels', function () {
+      assume(() => new Log({ local: false, levels: { weirdStuff: 1337 } }))
+        .to.throw(`'levels' is missing necessary levels: emerg, alert, crit, error, warning, notice, info, debug`);
+    });
+
     it('allows custom levels', function () {
       log = new Log({ local: false, levels: { ...Log.levels, weirdStuff: 1337 } });
       assume(Log.levels).to.deep.equal(config.syslog.levels);

--- a/packages/gasket-plugin-log/README.md
+++ b/packages/gasket-plugin-log/README.md
@@ -7,13 +7,13 @@ the logger itself, see [@gasket/log].
 
 #### New apps
 
-```
+```shell
 gasket create <app-name> --plugins @gasket/plugin-log
 ```
 
 #### Existing apps
 
-```
+```shell
 npm i @gasket/plugin-log @gasket/log
 ```
 

--- a/packages/gasket-plugin-log/README.md
+++ b/packages/gasket-plugin-log/README.md
@@ -71,13 +71,23 @@ subset of these properties are configurable through `gasket`.
 | `level`      | `'info'` (`'debug'` in ENV=local)     | Log only if `info.level`less than or equal to this level |
 | `transports` | `[new Console()]` _(Console logging)_ | Set of logging targets for `info` messages               |
 | `silent`     | `false`                               | If true, all logs are suppressed                         |
+| `levels`     | `winston.config.syslog.levels`        | Levels (and colors) representing log priorities          |
+| `format`      | Gasket-defined format                | Formatting for messages (see: [Formats])                 |
+
+> **Note:** While `levels` are configurable, if you specify your own levels,
+> you should specify a superset of the default levels (available
+> as `Log.levels`) above to ensure you're gasket application functions
+> successfully. You are also responsible for calling `winston.addColors` for
+> any additional levels that you provide.
+
+> **Note:** While `format` is configurable, it is recommended that you call
+> `format.combine` with your custom formats and the result of
+> `Log.getDefaultFormat(local,prefix)` to maintain the consistent functionality
 
 **Not Configurable in `gasket`**
 
 | Name          | Fixed Value                    | Description                                     |
 |:--------------|:-------------------------------|:------------------------------------------------|
-| `levels`      | `winston.config.syslog.levels` | Levels (and colors) representing log priorities |
-| `format`      | Gasket-defined format          | Formatting for `info` messages (see: [Formats]) |
 | `exitOnError` | `true`                         | Ensures uncaught errors trigger `process.exit`  |
 
 #### Example adding custom Winston transports


### PR DESCRIPTION
Without doing any breaking changes to rework how logging is done for gasket apps, this felt like the a decent approach to accomplish what I needed in my gasket application.

## Summary

I've made `@gasket/log` allow for sending in both custom `levels` and `format` properties for winston configuration. I've made `@gasket/log` also expose out some additional static properties so that the original/default values can be used to combine however the user wishes.

The issue I was trying to solve was that I needed to have an additional custom level on top of what gasket provided out of the box and also some additional custom formatters. I could have made this be `additionalLevels` and `additionalFormat` and internally done the combine work, but this seemed more flexible and a better API, but I'm open to something like that as well.

## Changelog

```md
- Allow for `levels` and `format` to be set on `@gasket/log`
```

## Test Plan

Existing tests all pass. I've added some additional tests to verify that `levels` and `format` were used appropriately if provided.
