### PR TITLE
Fix local dev environment inheritance

### DIFF
--- a/packages/gasket-utils/CHANGELOG.md
+++ b/packages/gasket-utils/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `@gasket/utils`
 
+
+- Fixed issue where an `environments` section of config files was doing proper inheritance of dev environment settings for the `local` environment.
+
 ### 6.0.13
 
 - Added --legacy-peer-deps flag to install cli. ([#275])

--- a/packages/gasket-utils/lib/apply-env-overrides.js
+++ b/packages/gasket-utils/lib/apply-env-overrides.js
@@ -14,35 +14,29 @@ function applyEnvironmentOverrides(gasketConfig, config, localFile) {
   const { env, root } = gasketConfig;
   // Separate environment-specific config from other config
   const { environments = {}, ...baseConfig } = config;
-
-  // Iterate over any `.` delimited parts (e.g. `production.subEnv`) and
-  // merge any corresponding config within `environments` into the
-  // configuration of this command.
+  const isLocalEnv = env === 'local';
   const envParts = env.split('.');
-  let normalizedConfig = envParts.reduce((acc, part, i) => {
-    return defaultsDeep({},
-      environments[envParts.slice(0, i + 1).join('.')],
-      acc);
-  }, baseConfig);
 
-  // Special case for the local environment, which inherits from the
-  // development environment
-  if (env === 'local') {
-    const devConfig = environments.development || environments.dev;
-    if (devConfig) {
-      normalizedConfig = defaultsDeep({}, normalizedConfig, devConfig);
-    }
+  const configs = [
 
     // For git-ignorable changes, merge in optional `.local` file
-    if (localFile) {
-      const localOverrides = tryRequire(path.join(root, localFile));
-      if (localOverrides) {
-        normalizedConfig = defaultsDeep({}, localOverrides, normalizedConfig);
-      }
-    }
-  }
+    isLocalEnv && localFile && tryRequire(path.join(root, localFile)),
 
-  return normalizedConfig;
+    // Iterate over any `.` delimited parts (e.g. `production.subEnv`) and
+    // merge any corresponding configs within `environments`
+    ...envParts
+      .map((_, i) => environments[envParts.slice(0, i + 1).join('.')])
+      .reverse(),
+
+    // Special case for the local environment, which inherits from the
+    // development environment
+    isLocalEnv && (environments.development || environments.dev),
+
+    baseConfig
+
+  ].filter(Boolean);
+
+  return defaultsDeep({}, ...configs);
 }
 
 module.exports = applyEnvironmentOverrides;

--- a/packages/gasket-utils/test/apply-env-overrides.test.js
+++ b/packages/gasket-utils/test/apply-env-overrides.test.js
@@ -134,6 +134,30 @@ describe('applyEnvironmentOverrides', () => {
 
   it('local inherits from development env', () => {
     mockGasketConfig.env = 'local';
+
+    mockConfig.someService.requestRate = 5000;
+    mockConfig.environments = {
+      dev: {
+        someService: {
+          url: 'https://some-dev-test.url/',
+          requestRate: 9000
+        }
+      }
+    };
+
+    results = applyEnvironmentOverrides(mockGasketConfig, mockConfig);
+    assume(results).eqls({
+      someService: {
+        url: 'https://some-dev-test.url/',
+        requestRate: 9000
+      }
+    });
+  });
+
+  it('local inherits from development env, supporting local specific settings', () => {
+    mockGasketConfig.env = 'local';
+
+    mockConfig.someService.requestRate = 5000;
     mockConfig.environments = {
       dev: {
         someService: {


### PR DESCRIPTION
Fix broken inheritance of the dev environment for local

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

I observed that given this `app.config.js` file:

```js
module.exports = {
  someUrl: 'https://example.com/',
  environments: {
    dev: {
      someUrl: 'https://dev.example.com/'
    },
    test: {
      someUrl: 'https://test.example.com/'
    }
  }
}
```

...the configuration when doing a `gasket local` was resolving to:

```js
{ someUrl: 'https://example.com/' }
```

...instead of the expected:

```js
{ someUrl: 'https://dev.example.com/' }
```