### PR TITLE
New webpackConfig lifecycle

### DIFF
--- a/packages/gasket-plugin-intl/test/fixtures/locales/mock-manifest.json
+++ b/packages/gasket-plugin-intl/test/fixtures/locales/mock-manifest.json
@@ -1,9 +1,1 @@
-{
-  "basePath": "",
-  "defaultPath": "/locales",
-  "defaultLocale": "en-US",
-  "paths": {
-    "locales/en-US.json": "10decbe",
-    "locales/fr-FR.json": "21047f1"
-  }
-}
+{"basePath":"","defaultPath":"/locales","defaultLocale":"en-US","locales":["en-US","fr-FR","fr-CH"],"localesMap":{"fr-CH":"fr-FR"},"paths":{"locales/en-US.json":"10decbe","locales/extra/en-US.json":"ff5a352","locales/extra/fr-FR.json":"2155926","locales/fr-FR.json":"21047f1"}}

--- a/packages/gasket-plugin-intl/test/fixtures/locales/mock-manifest.json
+++ b/packages/gasket-plugin-intl/test/fixtures/locales/mock-manifest.json
@@ -1,1 +1,9 @@
-{"basePath":"","defaultPath":"/locales","defaultLocale":"en-US","locales":["en-US","fr-FR","fr-CH"],"localesMap":{"fr-CH":"fr-FR"},"paths":{"locales/en-US.json":"10decbe","locales/extra/en-US.json":"ff5a352","locales/extra/fr-FR.json":"2155926","locales/fr-FR.json":"21047f1"}}
+{
+  "basePath": "",
+  "defaultPath": "/locales",
+  "defaultLocale": "en-US",
+  "paths": {
+    "locales/en-US.json": "10decbe",
+    "locales/fr-FR.json": "21047f1"
+  }
+}

--- a/packages/gasket-plugin-nextjs/test/config.test.js
+++ b/packages/gasket-plugin-nextjs/test/config.test.js
@@ -247,6 +247,7 @@ describe('createConfig', () => {
 function mockGasketApi() {
   return {
     execWaterfall: stub().returnsArg(1),
+    execWaterfallSync: stub().returnsArg(1),
     exec: stub().resolves({}),
     execSync: stub().returns([]),
     logger: {

--- a/packages/gasket-plugin-webpack/README.md
+++ b/packages/gasket-plugin-webpack/README.md
@@ -131,8 +131,8 @@ Executed after `webpack-chain` and `webpack`, it receives four parameters:
 1. The gasket API
 2. A webpack config object
 3. An options object with properties:
-   * `webpack` - The webpack API
-   * `nextOptions` - The [next.js webpack config options](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config)
+   * `webpack` - The webpack API.
+   * `context` - Additional context about the webpack configuration being generated. For example, in next.js apps, this is the [next.js webpack config options](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config).
    * `webpackMerge` - `The [`webpack-merge`](https://github.com/survivejs/webpack-merge/tree/v4.2.2) API, version 4.
 
 A hook should return a new webpack config object derived from the original. The usage of the `webpack-merge` API is recommended when doing so since properly handling the overloaded types within webpack config properties can be tricky. We recommend avoiding `webpack-merge` methods that have been deprecated in version 5 since a future version of this plugin may update to a new breaking version of `webpack-merge`.
@@ -142,7 +142,7 @@ A hook should return a new webpack config object derived from the original. The 
 function webpackHook(
   gasket,
   config,
-  { nextOptions: { isServer }, webpack, webpackMerge }
+  { context: { isServer }, webpack, webpackMerge }
 ) {
   return isServer
     ? config

--- a/packages/gasket-plugin-webpack/README.md
+++ b/packages/gasket-plugin-webpack/README.md
@@ -130,10 +130,11 @@ Executed after `webpack-chain` and `webpack`, it receives four parameters:
 
 1. The gasket API
 2. A webpack config object
-3. An options object with properties:
+3. A context object with the following properties:
    * `webpack` - The webpack API.
-   * `context` - Additional context about the webpack configuration being generated. For example, in next.js apps, this is the [next.js webpack config options](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config).
    * `webpackMerge` - `The [`webpack-merge`](https://github.com/survivejs/webpack-merge/tree/v4.2.2) API, version 4.
+   * `...additionalContext` - Additional context may be exposed. For example, in next.js apps, the [next.js webpack config options](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config) are included.
+   
 
 A hook should return a new webpack config object derived from the original. The usage of the `webpack-merge` API is recommended when doing so since properly handling the overloaded types within webpack config properties can be tricky. We recommend avoiding `webpack-merge` methods that have been deprecated in version 5 since a future version of this plugin may update to a new breaking version of `webpack-merge`.
 

--- a/packages/gasket-plugin-webpack/README.md
+++ b/packages/gasket-plugin-webpack/README.md
@@ -59,7 +59,7 @@ module.exports = {
 };
 ```
 
-This config can be further modified by interacting with the [`webpack`](#webpack)
+This config can be further modified by interacting with the [`webpackMerge`](#webpackMerge)
 lifecycle.
 
 ## API
@@ -87,6 +87,8 @@ const config = initWebpack(gasket, webpackConfig, data);
 
 ### webpackChain
 
+DEPRECATED - we suggest using the [`webpackMerge`](#webpackMerge) lifecycle instead; this may be removed in a future version.
+
 Executed before the `webpack` lifecycle, allows you to easily create the initial
 webpack configuration using a chaining syntax that is provided by the
 `webpack-chain` library. The resulting configuration is then merged with:
@@ -97,6 +99,8 @@ webpack configuration using a chaining syntax that is provided by the
 The result of this will be passed into the `webpack` hook as base configuration.
 
 ### webpack
+
+DEPRECATED - we suggest using the [`webpackMerge`](#webpackMerge) lifecycle instead; this may be removed in a future version.
 
 Executed after `webpack-chain` lifecycle. It receives the full webpack config as
 first argument. It can be used to add additional configurations to webpack.
@@ -117,6 +121,34 @@ function webpackHook(gasket, config) {
   );
 
   return config;
+}
+```
+
+### webpackMerge
+
+Executed after `webpack-chain` and `webpack`, it receives four parameters:
+
+1. The gasket API
+2. A webpack config object
+3. The [next.js config options](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config)
+4. The [`webpack-merge`](https://github.com/survivejs/webpack-merge/tree/v4.2.2) API, version 4.
+
+A hook should return a new webpack config object derived from the original. The usage of the `webpack-merge` API is recommended when doing so since properly handling the overloaded types within webpack config properties can be tricky. We recommend avoiding `webpack-merge` methods that have been deprecated in version 5 since a future version of this plugin may update to a new breaking version of `webpack-merge`.
+
+
+```js
+const { DefinePlugin } = require('webpack');
+
+function webpackHook(gasket, config, { isServer }, webpackMerge) {
+  return isServer
+    ? config
+    : webpackMerge.merge(config, {
+      plugins: [
+        new DefinePlugin({
+          MEANING_OF_LIFE: 42
+        })
+      ]
+    });
 }
 ```
 

--- a/packages/gasket-plugin-webpack/README.md
+++ b/packages/gasket-plugin-webpack/README.md
@@ -140,10 +140,10 @@ A hook should return a new webpack config object derived from the original. The 
 
 
 ```js
-function webpackHook(
+function webpackConfigHook(
   gasket,
   config,
-  { context: { isServer }, webpack, webpackMerge }
+  { isServer, webpack, webpackMerge }
 ) {
   return isServer
     ? config

--- a/packages/gasket-plugin-webpack/README.md
+++ b/packages/gasket-plugin-webpack/README.md
@@ -59,7 +59,7 @@ module.exports = {
 };
 ```
 
-This config can be further modified by interacting with the [`webpackMerge`](#webpackMerge)
+This config can be further modified by interacting with the [`webpackConfig`](#webpackConfig)
 lifecycle.
 
 ## API
@@ -87,7 +87,7 @@ const config = initWebpack(gasket, webpackConfig, data);
 
 ### webpackChain
 
-DEPRECATED - we suggest using the [`webpackMerge`](#webpackMerge) lifecycle instead; this may be removed in a future version.
+DEPRECATED - we suggest using the [`webpackConfig`](#webpackConfig) lifecycle instead; this may be removed in a future version.
 
 Executed before the `webpack` lifecycle, allows you to easily create the initial
 webpack configuration using a chaining syntax that is provided by the
@@ -100,7 +100,7 @@ The result of this will be passed into the `webpack` hook as base configuration.
 
 ### webpack
 
-DEPRECATED - we suggest using the [`webpackMerge`](#webpackMerge) lifecycle instead; this may be removed in a future version.
+DEPRECATED - we suggest using the [`webpackConfig`](#webpackConfig) lifecycle instead; this may be removed in a future version.
 
 Executed after `webpack-chain` lifecycle. It receives the full webpack config as
 first argument. It can be used to add additional configurations to webpack.
@@ -124,27 +124,31 @@ function webpackHook(gasket, config) {
 }
 ```
 
-### webpackMerge
+### webpackConfig
 
 Executed after `webpack-chain` and `webpack`, it receives four parameters:
 
 1. The gasket API
 2. A webpack config object
-3. The [next.js config options](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config)
-4. The [`webpack-merge`](https://github.com/survivejs/webpack-merge/tree/v4.2.2) API, version 4.
+3. An options object with properties:
+   * `webpack` - The webpack API
+   * `nextOptions` - The [next.js webpack config options](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config)
+   * `webpackMerge` - `The [`webpack-merge`](https://github.com/survivejs/webpack-merge/tree/v4.2.2) API, version 4.
 
 A hook should return a new webpack config object derived from the original. The usage of the `webpack-merge` API is recommended when doing so since properly handling the overloaded types within webpack config properties can be tricky. We recommend avoiding `webpack-merge` methods that have been deprecated in version 5 since a future version of this plugin may update to a new breaking version of `webpack-merge`.
 
 
 ```js
-const { DefinePlugin } = require('webpack');
-
-function webpackHook(gasket, config, { isServer }, webpackMerge) {
+function webpackHook(
+  gasket,
+  config,
+  { nextOptions: { isServer }, webpack, webpackMerge }
+) {
   return isServer
     ? config
     : webpackMerge.merge(config, {
       plugins: [
-        new DefinePlugin({
+        new webpack.DefinePlugin({
           MEANING_OF_LIFE: 42
         })
       ]

--- a/packages/gasket-plugin-webpack/index.js
+++ b/packages/gasket-plugin-webpack/index.js
@@ -35,7 +35,7 @@ function initWebpack(gasket, initConfig, context) {
   return execWaterfallSync(
     'webpackConfig',
     mergedConfig,
-    { webpack, context, webpackMerge }
+    { ...context, webpack, webpackMerge }
   );
 }
 

--- a/packages/gasket-plugin-webpack/index.js
+++ b/packages/gasket-plugin-webpack/index.js
@@ -6,11 +6,11 @@ const { name, devDependencies } = require('./package');
 /**
 * Creates the webpack config
 * @param  {Gasket} gasket The Gasket API
-* @param {Object} chainConfig Initial webpack config
+* @param {Object} webpackConfig Initial webpack config
 * @param {Object} data Additional info
 * @returns {Object} Final webpack config
 */
-function initWebpack(gasket, chainConfig, data) {
+function initWebpack(gasket, webpackConfig, data) {
   const { execSync, execWaterfallSync, config } = gasket;
 
   const chain = new WebpackChain();
@@ -19,8 +19,8 @@ function initWebpack(gasket, chainConfig, data) {
   //
   // Merge defaults with gasket.config webpack.
   //
-  chainConfig = webpackMerge.smart(
-    chainConfig,
+  const chainConfig = webpackMerge.smart(
+    webpackConfig,
     { plugins: [new WebpackMetricsPlugin({ gasket })] },
     chain.toConfig(),     // Webpack chain from plugins (partial)
     config.webpack || {}  // Webpack config from user (partial)

--- a/packages/gasket-plugin-webpack/index.js
+++ b/packages/gasket-plugin-webpack/index.js
@@ -6,18 +6,18 @@ const { name, devDependencies } = require('./package');
 
 /**
 * Creates the webpack config
-* @param  {Gasket} gasket The Gasket API
-* @param {Object} initConfig Initial webpack config
-* @param {Object} nextOptions Additional info
-* @returns {Object} Final webpack config
+* @param  {Gasket} gasket     The Gasket API
+* @param {Object} initConfig  Initial webpack config
+* @param {Object} context     Additional context-specific information
+* @returns {Object}           Final webpack config
 */
-function initWebpack(gasket, initConfig, nextOptions) {
+function initWebpack(gasket, initConfig, context) {
   const { execSync, execWaterfallSync, config } = gasket;
 
   const standardPlugins = { plugins: [new WebpackMetricsPlugin({ gasket })] };
 
   const chain = new WebpackChain();
-  execSync('webpackChain', chain, nextOptions);
+  execSync('webpackChain', chain, context);
 
   const baseConfig = webpackMerge.smart(
     initConfig,
@@ -26,7 +26,7 @@ function initWebpack(gasket, initConfig, nextOptions) {
     config.webpack || {}      // From gasket config file (partial)
   );
 
-  const configPartials = execSync('webpack', baseConfig, nextOptions).filter(Boolean);
+  const configPartials = execSync('webpack', baseConfig, context).filter(Boolean);
   const mergedConfig = webpackMerge.smart(
     baseConfig,
     ...configPartials
@@ -35,7 +35,7 @@ function initWebpack(gasket, initConfig, nextOptions) {
   return execWaterfallSync(
     'webpackConfig',
     mergedConfig,
-    { webpack, nextOptions, webpackMerge }
+    { webpack, context, webpackMerge }
   );
 }
 

--- a/packages/gasket-plugin-webpack/test/plugin.test.js
+++ b/packages/gasket-plugin-webpack/test/plugin.test.js
@@ -66,10 +66,10 @@ describe('create hook', () => {
 });
 
 describe('initWebpack hook', () => {
-  let gasket, nextOptions;
+  let gasket, context;
 
   beforeEach(() => {
-    nextOptions = {
+    context = {
       defaultLoaders: {}
     };
     gasket = mockGasketApi();
@@ -77,7 +77,7 @@ describe('initWebpack hook', () => {
 
   it('executes the `webpackChain` and `webpack` lifecycles', function () {
     const webpackConfig = { ...baseWebpackConfig };
-    plugin.initWebpack(gasket, webpackConfig, nextOptions);
+    plugin.initWebpack(gasket, webpackConfig, context);
 
     assume(gasket.execSync.firstCall).has.been.calledWith('webpackChain');
     assume(gasket.execSync.secondCall).has.been.calledWith('webpack');
@@ -85,7 +85,7 @@ describe('initWebpack hook', () => {
 
   it('returns webpack config object', function () {
     const webpackConfig = { ...baseWebpackConfig };
-    const result = plugin.initWebpack(gasket, webpackConfig, nextOptions);
+    const result = plugin.initWebpack(gasket, webpackConfig, context);
 
     assume(result).is.an('object');
     assume(result).has.property('plugins');
@@ -97,7 +97,7 @@ describe('initWebpack hook', () => {
     const mockConfigs = [{ newConfig1: 'newConfig1Value' }, { newConfig2: 'newConfig2Value' }];
     gasket.execSync.withArgs('webpack').returns(mockConfigs);
     const webpackConfig = { ...baseWebpackConfig };
-    const result = plugin.initWebpack(gasket, webpackConfig, nextOptions);
+    const result = plugin.initWebpack(gasket, webpackConfig, context);
 
     assume(result).is.an('object');
     assume(result).has.property('plugins');
@@ -116,12 +116,12 @@ describe('initWebpack hook', () => {
       webpackMerge.smart.returns(smartMergedConfig);
       gasket.execWaterfallSync.withArgs('webpackConfig').returns(updatedConfig);
 
-      const config = plugin.initWebpack(gasket, originalConfig, nextOptions);
+      const config = plugin.initWebpack(gasket, originalConfig, context);
 
       assume(gasket.execWaterfallSync).has.been.calledWith(
         'webpackConfig',
         smartMergedConfig,
-        { nextOptions, webpackMerge, webpack });
+        { context, webpackMerge, webpack });
       assume(config).equals(updatedConfig);
     } finally {
       smartMerge.restore();

--- a/packages/gasket-plugin-webpack/test/plugin.test.js
+++ b/packages/gasket-plugin-webpack/test/plugin.test.js
@@ -121,7 +121,7 @@ describe('initWebpack hook', () => {
       assume(gasket.execWaterfallSync).has.been.calledWith(
         'webpackConfig',
         smartMergedConfig,
-        { context, webpackMerge, webpack });
+        { ...context, webpackMerge, webpack });
       assume(config).equals(updatedConfig);
     } finally {
       smartMerge.restore();

--- a/packages/gasket-plugin-webpack/test/plugin.test.js
+++ b/packages/gasket-plugin-webpack/test/plugin.test.js
@@ -107,15 +107,25 @@ describe('initWebpack hook', () => {
   });
 
   it('does custom merging through a webpackMerge lifecycle', function () {
-    const originalConfig = { ...baseWebpackConfig };
-    const updatedConfig = { mock: 'config' };
-    gasket.execWaterfallSync.withArgs('webpackMerge').returns(updatedConfig);
+    const smartMerge = stub(webpackMerge, 'smart');
+    try {
+      const originalConfig = { ...baseWebpackConfig };
+      const smartMergedConfig = { mock: 'smartMerge' };
+      const updatedConfig = { mock: 'config' };
+      webpackMerge.smart.returns(smartMergedConfig);
+      gasket.execWaterfallSync.withArgs('webpackMerge').returns(updatedConfig);
 
-    const config = plugin.initWebpack(gasket, originalConfig, data);
+      const config = plugin.initWebpack(gasket, originalConfig, data);
 
-    assume(gasket.execWaterfallSync)
-      .has.been.calledWith('webpackMerge', originalConfig, data, webpackMerge);
-    assume(config).equas(updatedConfig);
+      assume(gasket.execWaterfallSync).has.been.calledWith(
+        'webpackMerge',
+        smartMergedConfig,
+        data,
+        webpackMerge);
+      assume(config).equals(updatedConfig);
+    } finally {
+      smartMerge.restore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Add a `webpackConfig` lifecycle that gives users more control on how they want to merge webpack mutations in with the existing config.

Currently a user must formulate a config fragment that relies on a "smart" merge from `webpack-merge`, but that smart merge feature is going away. With this new lifecycle, users are passed a `webpack-merge` instance so they can use whatever techniques for merging they prefer or even do the merge through plain JavaScript.
