### PR TITLE
Added timing to express lifecycle.

### DIFF
--- a/packages/gasket-plugin-swagger/index.js
+++ b/packages/gasket-plugin-swagger/index.js
@@ -101,7 +101,7 @@ module.exports = {
      */
     express: {
       timing: {
-        after: ['@gasket/plugin-nextjs']
+        before: ['@gasket/plugin-nextjs']
       },
       handler: async function express(gasket, app) {
         const { swagger, root } = gasket.config;

--- a/packages/gasket-plugin-swagger/index.js
+++ b/packages/gasket-plugin-swagger/index.js
@@ -99,13 +99,18 @@ module.exports = {
      * @param {object} app - Express app instance
      * @async
      */
-    async express(gasket, app) {
-      const { swagger, root } = gasket.config;
-      const { ui = {}, apiDocsRoute, definitionFile } = swagger;
+    express: {
+      timing: {
+        after: ['@gasket/plugin-nextjs']
+      },
+      handler: async function express(gasket, app) {
+        const { swagger, root } = gasket.config;
+        const { ui = {}, apiDocsRoute, definitionFile } = swagger;
 
-      const swaggerSpec = await loadSwaggerSpec(root, definitionFile, gasket.logger);
+        const swaggerSpec = await loadSwaggerSpec(root, definitionFile, gasket.logger);
 
-      app.use(apiDocsRoute, swaggerUi.serve, swaggerUi.setup(swaggerSpec, ui));
+        app.use(apiDocsRoute, swaggerUi.serve, swaggerUi.setup(swaggerSpec, ui));
+      }
     },
     /**
      * Sets swagger plugin prop to true and adds swagger config to gasket.config

--- a/packages/gasket-plugin-swagger/test/index.test.js
+++ b/packages/gasket-plugin-swagger/test/index.test.js
@@ -175,7 +175,7 @@ describe('Swagger Plugin', () => {
     context('when target definition file is not found', () => {
       it('returns nothing', async () => {
         mockGasket.config.swagger.definitionFile = 'swagger.yaml';
-        const result = await plugin.hooks.express(mockGasket, mockApp);
+        const result = await plugin.hooks.express.handler(mockGasket, mockApp);
         assume(result).is.falsely();
       });
     });
@@ -184,33 +184,33 @@ describe('Swagger Plugin', () => {
       it('gasket.logger logs error', async () => {
         mockGasket.config.swagger.definitionFile = 'swagger.yaml';
         accessStub.rejects();
-        await plugin.hooks.express(mockGasket, mockApp);
+        await plugin.hooks.express.handler(mockGasket, mockApp);
         assume(mockGasket.logger.error).calledWith(`Missing ${mockGasket.config.swagger.definitionFile} file...`);
       });
     });
 
     it('loads the swagger spec yaml file', async () => {
       mockGasket.config.swagger.definitionFile = 'swagger.yaml';
-      await plugin.hooks.express(mockGasket, mockApp);
+      await plugin.hooks.express.handler(mockGasket, mockApp);
       assume(yamlSafeLoadStub).called();
     });
 
     it('only loads the swagger spec file once', async () => {
       mockGasket.config.swagger.definitionFile = 'swagger.yaml';
       assume(yamlSafeLoadStub).not.called();
-      await plugin.hooks.express(mockGasket, mockApp);
+      await plugin.hooks.express.handler(mockGasket, mockApp);
       assume(yamlSafeLoadStub).called(1);
-      await plugin.hooks.express(mockGasket, mockApp);
+      await plugin.hooks.express.handler(mockGasket, mockApp);
       assume(yamlSafeLoadStub).called(1);
     });
 
     it('loads the swagger spec json file', async () => {
-      await plugin.hooks.express(mockGasket, mockApp);
+      await plugin.hooks.express.handler(mockGasket, mockApp);
       assume(yamlSafeLoadStub).not.called();
     });
 
     it('sets the api docs route', async () => {
-      await plugin.hooks.express(mockGasket, mockApp);
+      await plugin.hooks.express.handler(mockGasket, mockApp);
       assume(mockApp.use).calledWith('/api-docs');
     });
   });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
An issue was reported where the `@gasket/plugin-nextjs` and `@gasket/plugin-swagger` plugins both hook the express lifecycle, and they don't have any mutual forced ordering since those plugins don't know about each other. `@gasket/plugin-nextjs` latches on to the catch-all route, so if it gets attached first it'll service the `/api/docs` route instead of the swagger handler, and will render a 404.

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->
Added timing to express lifecycle.
