### PR TITLE
[minor] correct fallback strategy

### DIFF
--- a/packages/gasket-helper-intl/CHANGELOG.md
+++ b/packages/gasket-helper-intl/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `@gasket/helper-intl`
 
+- Adjust fallback strategy
+- Added missing test dependency for assume-sinon
+
 ### 6.0.14
 
 - Added check for locales config to determine fallbackLocale. ([#276])

--- a/packages/gasket-helper-intl/lib/index.js
+++ b/packages/gasket-helper-intl/lib/index.js
@@ -100,6 +100,12 @@ function LocaleUtils(config) {
 
   /**
    * Fallback to the lang part of a locale or to defaultLocale.
+   * Strategy is:
+   *  <locale>
+   *  <locale lang (if doesn't match default lang)>
+   *  <default locale (if a locale)>
+   *  <default lang>
+   *  null
    *
    * Here's an example using da-DK/da with en-US as defaultLocale
    * da-DK ==> da ==> en-US ==> en ==> null
@@ -110,7 +116,13 @@ function LocaleUtils(config) {
    */
   this.getFallbackLocale = (locale = '') => {
     if (locale.indexOf('-') > 0) {
-      return locale.split('-')[0];
+      const language = locale.split('-')[0];
+
+      if (defaultLocale.indexOf('-') > 0 && locale !== defaultLocale && language === defaultLang) {
+        return defaultLocale;
+      }
+
+      return language;
     }
 
     if (locale !== defaultLang) {

--- a/packages/gasket-helper-intl/package.json
+++ b/packages/gasket-helper-intl/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "test": "npm run test:runner",
-    "test:runner": "mocha --require setup-env \"test/*.test.js\"",
+    "test:runner": "mocha --require test/setup.js --require setup-env \"test/*.test.js\"",
     "test:watch": "npm run test:runner -- --watch",
     "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",
     "posttest": "npm run lint",
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@godaddy/dmd": "^1.0.0",
     "assume": "^2.3.0",
+    "assume-sinon": "1.1.0",
     "eslint": "^7.17.0",
     "eslint-config-godaddy": "^4.0.1",
     "eslint-plugin-json": "^2.1.2",

--- a/packages/gasket-helper-intl/test/index.test.js
+++ b/packages/gasket-helper-intl/test/index.test.js
@@ -28,4 +28,45 @@ describe('LocaleUtils', function () {
       assume(call).throws('Not available in browser');
     });
   });
+
+  describe('.getFallbackLocale', function () {
+    let utils, mockConfig;
+
+    beforeEach(function () {
+      mockConfig = {
+        manifest: require('./fixtures/mock-manifest.json')
+      };
+    });
+
+    afterEach(function () {
+      delete require.cache[require.resolve('./fixtures/mock-manifest.json')];
+    });
+
+    [
+      ['fr-CA', 'fr', 'en-US'],
+      ['fr', 'en-US', 'en-US'],
+      ['fr-CA', 'fr', 'en'],
+      ['fr', 'en', 'en'],
+      ['en-CA', 'en-US', 'en-US'],
+      ['en-CA', 'en', 'en'],
+      ['en-US', 'en', 'en-US'],
+      ['en-US', 'en', 'en'],
+      ['en', null, 'en-US'],
+      ['en', null, 'en']
+    ].forEach(
+      function ([locale, expected, defaultLocale]) {
+        it(
+          `properly falls back to ${expected} when the locale is ${locale} and the default locale is ${defaultLocale}`,
+          function () {
+            mockConfig.manifest.defaultLocale = defaultLocale;
+            utils = new LocaleUtils(mockConfig);
+
+            const actual = utils.getFallbackLocale(locale);
+
+            assume(actual).to.equal(expected);
+          }
+        );
+      }
+    );
+  });
 });

--- a/packages/gasket-helper-intl/test/setup.js
+++ b/packages/gasket-helper-intl/test/setup.js
@@ -1,0 +1,4 @@
+const assume = require('assume');
+const assumeSinon = require('assume-sinon');
+
+assume.use(assumeSinon);

--- a/packages/gasket-helper-intl/test/shared.js
+++ b/packages/gasket-helper-intl/test/shared.js
@@ -102,6 +102,19 @@ module.exports = function sharedTests(UtilClass) {
       assume(results).equals('/locales/az.json');
     });
 
+    it(
+      'falls back to default locale if no localePath for locale if ' +
+      'language matches before falling back to language',
+      function () {
+        mockConfig.manifest.defaultLocale = 'en-US';
+        mockConfig.manifest.paths['locales/en-US.json'] = 'hash1234';
+        mockConfig.manifest.paths['locales/en.json'] = 'hash4321';
+        utils = new UtilClass(mockConfig);
+        const results = utils.getLocalePath('/locales', 'en-CA');
+        assume(results).equals('/locales/en-US.json');
+      }
+    );
+
     it('falls back to default locale if no localePath for locale', function () {
       mockConfig.manifest.defaultLocale = 'fake';
       mockConfig.manifest.paths['locales/fake.json'] = 'hash1234';


### PR DESCRIPTION
```
<locale> => <locale lang (if doesnt match default)> => <default locale> => <default lang> => null
```

Also added missing dependency for assume-sinon which is needed in the `returns localesProps with error for missing path` server test

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

The current strategy doesn't fallback properly when the default locale has the same language as a possible locale.
i.e. en-CA with a default locale of en-US doesn't look for en-US, it returns en. This change will ensure is goes from en-CA to en-US and then en.

## Changelog

- Adjust fallback strategy
- Added missing test dependency for assume-sinon

## Test Plan

Added  unit tests to cover the possible permutations with their expected outcomes.
