### PR TITLE
Fix unhandled rejection warnings

### DIFF
--- a/packages/gasket-engine/CHANGELOG.md
+++ b/packages/gasket-engine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `@gasket/engine`
 
+### 6.3.1
+
+- Fix issue causing unhandled rejection warnings to surface
+
 ### 6.0.11
 
 - Add ability to do debug tracing for the plugin lifecycle ([#267])

--- a/packages/gasket-engine/CHANGELOG.md
+++ b/packages/gasket-engine/CHANGELOG.md
@@ -1,7 +1,5 @@
 # `@gasket/engine`
 
-### 6.3.1
-
 - Fix issue causing unhandled rejection warnings to surface
 
 ### 6.0.11

--- a/packages/gasket-engine/lib/engine.js
+++ b/packages/gasket-engine/lib/engine.js
@@ -427,11 +427,11 @@ class PluginEngine {
     );
 
     const result = exec(plan);
+    if (result.finally) {
+      return result.finally(() => this._traceDepth--);
+    }
 
-    result.finally
-      ? result.finally(() => this._traceDepth--)
-      : this._traceDepth--;
-
+    this._traceDepth--;
     return result;
   }
 

--- a/packages/gasket-engine/package.json
+++ b/packages/gasket-engine/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint lib test",
     "lint:fix": "npm run lint -- --fix",
-    "test": "jest",
+    "test": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "posttest": "npm run lint"
@@ -39,6 +39,7 @@
     "debug": "^4.3.1"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "eslint": "^7.17.0",
     "eslint-config-godaddy": "^4.0.1",
     "eslint-plugin-jest": "^24.1.3",

--- a/packages/gasket-engine/test/exec.test.js
+++ b/packages/gasket-engine/test/exec.test.js
@@ -70,4 +70,15 @@ describe('The exec method', () => {
 
     expect(result).toEqual([1, 2]);
   });
+
+  it('does not cause unhandled rejections on thrown errors', async () => {
+    engine.hook({
+      event: 'mock',
+      async handler() {
+        throw new Error('I am rejecting you');
+      }
+    });
+
+    await expect(engine.exec('mock')).rejects.toThrow(Error);
+  });
 });


### PR DESCRIPTION
## Summary

- (fix) Fix issue causing unhandled rejection warnings on failures

The issue is that when `.finally()` is called on Promise exec results, that creates a new Promise, but that new Promise is not being returned. The returned Promise has its rejections handled by the caller, but this inner Promise does not. Fix by not orphaning a new Promise object.

## Test Plan

Unit test added. I had to update the running of Jest so it crashes on unhandled rejections instead of just printing warnings.