### PR TITLE
Solving reference binding of module imports bug and stubs during testing

### DIFF
--- a/packages/gasket-nextjs/package.json
+++ b/packages/gasket-nextjs/package.json
@@ -13,7 +13,7 @@
     "test:watch": "npm run test:runner -- --watch",
     "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",
     "posttest": "npm run lint",
-    "build": "babel src -d lib",
+    "build": "rimraf lib && babel src -d lib",
     "prepublishOnly": "npm run build"
   },
   "repository": {
@@ -65,7 +65,8 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "setup-env": "^1.2.2",
-    "sinon": "^9.2.3"
+    "sinon": "^9.2.3",
+    "rimraf": "^3.0.2"
   },
   "peerDependencies": {
     "next": "^10.2.0"

--- a/packages/gasket-nextjs/src/index.js
+++ b/packages/gasket-nextjs/src/index.js
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Main, NextScript } from 'next/document';
 import htmlescape from 'htmlescape';
+import { useGasketData as _useGasketData } from './use-gasket-data';
+import { withGasketDataProvider as _withGasketDataProvider } from './with-gasket-data-provider';
+
 
 /**
  * Renders a script tag with JSON gasketData
@@ -95,5 +98,6 @@ export function withGasketData(options = {}) {
   };
 }
 
-export * from './use-gasket-data';
-export * from './with-gasket-data-provider';
+
+export const useGasketData = _useGasketData;
+export const withGasketDataProvider = _withGasketDataProvider;


### PR DESCRIPTION
## Summary

Babel converts exports * imports to getters to correctly implement reference binding of module imports. This causes issues when needing to stub out one of the exports during testing. If a consuming app tries to stub out one of the exports, the stub dosent work.

This PR solves that issue by reworking how the components are exported. This change allows the stubs to function properly.

## Changelog

Changed the index.js so it dosent export * import, but instead exports consts


## Test Plan

no change needed
