### PR TITLE
Accept-language locale improvements

### DIFF
--- a/packages/gasket-plugin-intl/lib/middleware.js
+++ b/packages/gasket-plugin-intl/lib/middleware.js
@@ -16,13 +16,10 @@ module.exports = function middlewareHook(gasket) {
     let preferredLocale = defaultLocale;
     if (req.headers['accept-language']) {
       try {
-        // if we have a list of support locales, fallback to one.
-        preferredLocale = locales && locales.length ?
-          accept.language(req.headers['accept-language'], locales) :
-          // Otherwise just run with the first accept language.
-          req.headers['accept-language'].split(',')[0];
+        // Get highest or highest from locales if configured
+        preferredLocale = accept.language(req.headers['accept-language'], locales);
       } catch (error) {
-        gasket.logger.warning(`Unable to parse accept-language header: ${error.message}`);
+        gasket.logger.warning(`Unable to parse accept-language header: ${ error.message }`);
       }
     }
 

--- a/packages/gasket-plugin-intl/test/middleware.test.js
+++ b/packages/gasket-plugin-intl/test/middleware.test.js
@@ -69,6 +69,18 @@ describe('middleware', function () {
       assume(mockGasket.execWaterfall).calledWith('intlLocale', 'fr-CH', { req, res });
     });
 
+    it('formats accept-language to lower-UPPER', async function () {
+      req.headers['accept-language'] = 'fr-fr';
+      await layer(req, res, next);
+      assume(mockGasket.execWaterfall).calledWith('intlLocale', 'fr-FR', { req, res });
+    });
+
+    it('formats accept-language to lo-UP-Capitals', async function () {
+      req.headers['accept-language'] = 'az-az-latn';
+      await layer(req, res, next);
+      assume(mockGasket.execWaterfall).calledWith('intlLocale', 'az-AZ-Latn', { req, res });
+    });
+
     it('passes defaultLocale if no accept-language header', async function () {
       delete req.headers['accept-language'];
       await layer(req, res, next);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Use `@hapi/accept` even when supported `locales` are not configured, to provide consistency when handling malformed `accept-language` header errors. Also, ensure the locale casing is consistent.

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/plugin-intl**
- Handle malformed and inconsistent formatted accept-language header

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
Addiitonal unit test