### PR TITLE
Lazy require init dependencies

### DIFF
--- a/packages/gasket-plugin-webpack/index.js
+++ b/packages/gasket-plugin-webpack/index.js
@@ -1,7 +1,3 @@
-const webpack = require('webpack');
-const WebpackChain = require('webpack-chain');
-const webpackMerge = require('webpack-merge');
-const WebpackMetricsPlugin = require('./webpack-metrics-plugin');
 const { name, devDependencies } = require('./package');
 
 /**
@@ -12,6 +8,11 @@ const { name, devDependencies } = require('./package');
 * @returns {Object}           Final webpack config
 */
 function initWebpack(gasket, initConfig, context) {
+  const webpack = require('webpack');
+  const WebpackChain = require('webpack-chain');
+  const webpackMerge = require('webpack-merge');
+  const WebpackMetricsPlugin = require('./webpack-metrics-plugin');
+
   const { execSync, execWaterfallSync, config } = gasket;
 
   const standardPlugins = { plugins: [new WebpackMetricsPlugin({ gasket })] };


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Lazying require `webpack` fixes the error with creating new apps with more recent versions of Next.js

```shell
> gasket create basic-next-app -p @gasket/preset-nextjs
Error: Cannot find module 'webpack'
```

This PR also defers other requires for init-related dependencies.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/plugin-webpack**
- Lazy require webpack dependencies

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Locally tested with **create** command
```shell
gasket create <APP_NAME> -p @gasket/preset-nextjs --plugins @gasket/plugin-webpack@file:/<PATH_TO>/godaddy/gasket/packages/gasket-plugin-webpack
```