### PR TITLE
Opt out of Next.js Intl Routing

### DIFF
--- a/packages/gasket-plugin-intl/README.md
+++ b/packages/gasket-plugin-intl/README.md
@@ -187,7 +187,7 @@ associate known locales to share a translations with another locale using
 
 ### Next.js Routing
 
-If your Gasket app us using the [@gasket/plugin-nextjs] for Next.js support,
+If your Gasket app is using the [@gasket/plugin-nextjs] for Next.js support,
 when setting `locales` and `defaultLocale`, these will automatically be used to
 configure [Next.js Internationalized Routing].
 

--- a/packages/gasket-plugin-intl/README.md
+++ b/packages/gasket-plugin-intl/README.md
@@ -49,12 +49,17 @@ required. However, these options exist to customize an app's setup.
   (default: `./public/locales`)
 - `manifestFilename` - (string) Change the name of the manifest file (default:
   `locales-manifest.json`)
-- `serveStatic` - (boolean|string) Enables ability to serve static locale files. If set to `true`, the app will use the `defaultPath` as the static endpoint path. This option can also be set to a string, to be used as the static endpoint path.
+- `serveStatic` - (boolean|string) Enables ability to serve static locale files.
+  If set to `true`, the app will use the `defaultPath` as the static endpoint
+  path. This option can also be set to a string, to be used as the static
+  endpoint path.
 - `modules` - (boolean|object) Enable locale files collation from node modules.
   Disabled by default, enable by setting to an object with options below, or set
   to `true` to use the default options. See [Module Locales] section.
   - `localesDir` - (string) Lookup dir for module files (default: `locales`)
   - `excludes` - (string[]) List of modules to ignore
+- `nextRouting` - (boolean) Enable [Next.js Routing] when used with
+  [@gasket/plugin-nextjs]. (default: true)
 
 #### Example config
 
@@ -179,6 +184,25 @@ customers, but this serves as a safety mechanism to make sure your app remains
 somewhat readable for unexpected locales. Also note, however, that you can
 associate known locales to share a translations with another locale using
 `localesMap`.
+
+### Next.js Routing
+
+If your Gasket app us using the [@gasket/plugin-nextjs] for Next.js support,
+when setting `locales` and `defaultLocale`, these will automatically be used to
+configure [Next.js Internationalized Routing].
+
+You can opt-out of this behavior by setting `nextRouting` to false.
+
+```js
+// gasket.config.js
+module.exports = {
+  intl: {
+    defaultLocale: 'fr-FR',
+    locales: ['fr-FR', 'en-US', 'zh-TW', 'zh-CN', 'zh-HK', 'zh-SG'],
+    nextRouting: false
+  }
+}
+```
 
 ### Locales Map
 
@@ -363,10 +387,13 @@ entry.
 [module locales]:#locales-manifest
 [Gasket data]:#gasket-data
 [intlLocale lifecycle]:#intllocale
+[Next.js Routing]:#nextjs-routing
 
 [@gasket/react-intl]: /packages/gasket-react-intl/README.md
+[@gasket/plugin-nextjs]: /packages/gasket-plugin-nextjs/README.md
 [@gasket/react-intl/next]: /packages/gasket-react-intl/README.md#nextjs
 [GasketData script tag]: /packages/gasket-data/README.md
+[Next.js Internationalized Routing]: https://nextjs.org/docs/advanced-features/i18n-routing
 
 [global window object]:https://developer.mozilla.org/en-US/docs/Glossary/Global_object
 

--- a/packages/gasket-plugin-nextjs/config.js
+++ b/packages/gasket-plugin-nextjs/config.js
@@ -11,6 +11,10 @@ function forwardIntlConfig(gasket, config) {
   const { logger } = gasket;
   const { intl: intlConfig = {} } = gasket.config;
 
+  if (intlConfig.nextRouting === false) {
+    return;
+  }
+
   // make a copy of i18n for mutating
   const i18n = { ...(config.i18n || {}) };
 

--- a/packages/gasket-plugin-nextjs/test/config.test.js
+++ b/packages/gasket-plugin-nextjs/test/config.test.js
@@ -80,6 +80,16 @@ describe('createConfig', () => {
     assume(result.i18n).not.exist();
   });
 
+  it('intl config not forwarded if `intl.nextRouting` disabled', async () => {
+    gasket.config.intl = {
+      defaultLocale: 'fr-FR',
+      locales: ['fr-FR', 'en-US'],
+      nextRouting: false
+    };
+    result = await createConfig(gasket);
+    assume(result.i18n).not.exist();
+  });
+
   it('intl config options merge with existing', async () => {
     gasket.config.intl = {
       defaultLocale: 'fr-FR',


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Next.js-based Gasket apps using the intl plugin with `locales` and `defaultLocale` configured, sometimes do not need or desire to utilize Next.js Intl Routing. This provides a way to opt out.

## Changelog

**@gasket/plugin-nextjs**
- Ability to disable Next.js Intl Routing when configuring supported locales

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
- Updated unit tests
- Locally tested against canary app
