### PR TITLE
Convert to `fs.promises` and Align `mkdirp`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
       - name: Build
         run: npm run build
       - name: Run Tests & Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
       - name: Build
         run: npm run build
       - name: Run Tests & Lint

--- a/packages/gasket-assets/package.json
+++ b/packages/gasket-assets/package.json
@@ -45,7 +45,7 @@
     "eslint-plugin-json": "^2.1.2",
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-unicorn": "^39.0.0",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.4",
     "react": "^17.0.1",
     "recursive-readdir": "^2.2.2",
     "rimraf": "^3.0.2"

--- a/packages/gasket-assets/scripts/svg-to-react.js
+++ b/packages/gasket-assets/scripts/svg-to-react.js
@@ -2,14 +2,10 @@
 
 import svgr from '@svgr/core';
 import { transform } from '@babel/core';
-import fs from 'fs';
-import { promisify } from 'util';
+import { writeFile, readFile } from 'fs/promises';
 import path from 'path';
 import recursive from 'recursive-readdir';
-
-const mkdirp = promisify(require('mkdirp'));
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
+import mkdirp from 'mkdirp';
 
 const rootDir = path.join(__dirname, '..');
 const srcDir = path.join(rootDir, 'svgs');

--- a/packages/gasket-assets/scripts/svg-to-react.js
+++ b/packages/gasket-assets/scripts/svg-to-react.js
@@ -2,7 +2,7 @@
 
 import svgr from '@svgr/core';
 import { transform } from '@babel/core';
-import { writeFile, readFile } from 'fs/promises';
+import { promises as fs } from 'fs';
 import path from 'path';
 import recursive from 'recursive-readdir';
 import mkdirp from 'mkdirp';
@@ -32,7 +32,7 @@ async function process(file) {
   const outFile = file.replace(srcDir, outputDir).replace('.svg', '.js');
 
   try {
-    const data = await readFile(file);
+    const data = await fs.readFile(file);
 
     //
     // Convert to React
@@ -48,7 +48,7 @@ async function process(file) {
     // Output the results to file
     //
     await mkdirp(path.dirname(outFile));
-    await writeFile(outFile, banner + results.code, 'utf8');
+    await fs.writeFile(outFile, banner + results.code, 'utf8');
     console.log('wrote', path.relative(rootDir, outFile));
     return Promise.resolve();
   } catch (e) {

--- a/packages/gasket-cli/package.json
+++ b/packages/gasket-cli/package.json
@@ -76,7 +76,7 @@
     "json5": "^2.1.0",
     "lodash.defaultsdeep": "^4.6.1",
     "map-stream": "^0.1.0",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.4",
     "ora": "^3.4.0",
     "pump": "^3.0.0",
     "semver": "^7.3.4",

--- a/packages/gasket-cli/src/config/utils.js
+++ b/packages/gasket-cli/src/config/utils.js
@@ -1,12 +1,11 @@
-const { promisify } = require('util');
 const path = require('path');
-const fs = require('fs');
+const { statSync } = require('fs');
+const { readdir } = require('fs/promises');
 const defaultsDeep = require('lodash.defaultsdeep');
 const { pluginIdentifier } = require('@gasket/resolve');
 const defaultPlugins = require('./default-plugins');
 const { flattenPresets } = require('../scaffold/utils');
 
-const readDir = promisify(fs.readdir);
 const jsExtension = /\.js$/i;
 
 /**
@@ -37,7 +36,7 @@ function loadConfigFile(flags) {
   const configFileName = configFilePath.endsWith('.js') ? configFilePath : configFilePath + '.js';
   // require the file if config file exist, else return null
   try {
-    fs.statSync(configFileName); // eslint-disable-line no-sync
+    statSync(configFileName); // eslint-disable-line no-sync
   } catch (err) {
     return null;
   }
@@ -78,7 +77,7 @@ function addDefaultPlugins(gasketConfig) {
 async function addUserPlugins(gasketConfig) {
   try {
     const pluginsDir = path.join(gasketConfig.root, 'plugins');
-    const files = await readDir(pluginsDir);
+    const files = await readdir(pluginsDir);
     const moduleNames = files
       .filter(fileName => jsExtension.test(fileName))
       .map(fileName => {

--- a/packages/gasket-cli/src/config/utils.js
+++ b/packages/gasket-cli/src/config/utils.js
@@ -1,6 +1,6 @@
 const path = require('path');
-const { statSync } = require('fs');
-const { readdir } = require('fs/promises');
+const { statSync, promises } = require('fs');
+const { readdir } = promises;
 const defaultsDeep = require('lodash.defaultsdeep');
 const { pluginIdentifier } = require('@gasket/resolve');
 const defaultPlugins = require('./default-plugins');

--- a/packages/gasket-cli/src/scaffold/actions/generate-files.js
+++ b/packages/gasket-cli/src/scaffold/actions/generate-files.js
@@ -1,5 +1,6 @@
 const { promisify } = require('util');
 const Handlebars = require('handlebars');
+// TODO: See if we can move away from pump to a async solution
 const pump = promisify(require('pump'));
 const map = require('map-stream');
 const path = require('path');

--- a/packages/gasket-cli/src/scaffold/actions/load-pkg-for-debug.js
+++ b/packages/gasket-cli/src/scaffold/actions/load-pkg-for-debug.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { readFile } = require('fs/promises');
+const fs = require('fs').promises;
 const action = require('../action-wrapper');
 const ConfigBuilder = require('../config-builder');
 
@@ -14,7 +14,7 @@ async function loadPkForDebug(context) {
 
   const filePath = path.join(dest, 'package.json');
 
-  const contents = await readFile(filePath, 'utf8');
+  const contents = await fs.readFile(filePath, 'utf8');
   const fields = JSON.parse(contents);
   const pkg = ConfigBuilder.createPackageJson(fields, { warnings });
 

--- a/packages/gasket-cli/src/scaffold/actions/load-pkg-for-debug.js
+++ b/packages/gasket-cli/src/scaffold/actions/load-pkg-for-debug.js
@@ -1,7 +1,5 @@
 const path = require('path');
-const { promisify } = require('util');
-const fs = require('fs');
-const readFile = promisify(fs.readFile);
+const { readFile } = require('fs/promises');
 const action = require('../action-wrapper');
 const ConfigBuilder = require('../config-builder');
 

--- a/packages/gasket-cli/src/scaffold/actions/mkdir.js
+++ b/packages/gasket-cli/src/scaffold/actions/mkdir.js
@@ -1,4 +1,4 @@
-const { mkdir } = require('fs/promises');
+const { mkdir } = require('fs').promises;
 const action = require('../action-wrapper');
 
 /**

--- a/packages/gasket-cli/src/scaffold/actions/mkdir.js
+++ b/packages/gasket-cli/src/scaffold/actions/mkdir.js
@@ -1,7 +1,5 @@
-const { promisify } = require('util');
-const fs = require('fs');
+const { mkdir } = require('fs/promises');
 const action = require('../action-wrapper');
-const mkdir = promisify(fs.mkdir);
 
 /**
  * Validates this instance can execute without common blockers:

--- a/packages/gasket-cli/src/scaffold/actions/write-gasket-config.js
+++ b/packages/gasket-cli/src/scaffold/actions/write-gasket-config.js
@@ -1,9 +1,7 @@
 const JSON5 = require('json5');
 const path = require('path');
-const { promisify } = require('util');
-const fs = require('fs');
+const { writeFile } = require('fs/promises');
 const action = require('../action-wrapper');
-const writeFile = promisify(fs.writeFile);
 
 /**
  * Writes the contents of `pkg` to the app's package.json.

--- a/packages/gasket-cli/src/scaffold/actions/write-gasket-config.js
+++ b/packages/gasket-cli/src/scaffold/actions/write-gasket-config.js
@@ -1,6 +1,6 @@
 const JSON5 = require('json5');
 const path = require('path');
-const { writeFile } = require('fs/promises');
+const { writeFile } = require('fs').promises;
 const action = require('../action-wrapper');
 
 /**

--- a/packages/gasket-cli/src/scaffold/actions/write-pkg.js
+++ b/packages/gasket-cli/src/scaffold/actions/write-pkg.js
@@ -1,8 +1,6 @@
 const path = require('path');
-const { promisify } = require('util');
-const fs = require('fs');
+const { writeFile } = require('fs/promises');
 const action = require('../action-wrapper');
-const writeFile = promisify(fs.writeFile);
 
 /**
  * Writes the contents of `pkg` to the app's package.json.

--- a/packages/gasket-cli/src/scaffold/actions/write-pkg.js
+++ b/packages/gasket-cli/src/scaffold/actions/write-pkg.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { writeFile } = require('fs/promises');
+const { writeFile } = require('fs').promises;
 const action = require('../action-wrapper');
 
 /**

--- a/packages/gasket-cli/src/scaffold/dump-error-context.js
+++ b/packages/gasket-cli/src/scaffold/dump-error-context.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { writeFile } = require('fs/promises');
+const fs = require('fs').promises;
 
 /**
  * If an error occurs during create, dump the context for debugging.
@@ -17,7 +17,7 @@ module.exports = async function dumpErrorContext(context, error) {
     const fileName = 'gasket-create-error.log';
 
     const filePath = path.join(cwd, fileName);
-    await writeFile(filePath, JSON.stringify(report, null, 2), 'utf8');
+    await fs.writeFile(filePath, JSON.stringify(report, null, 2), 'utf8');
     console.log(`Error log dumped to: ${filePath}`);
   } catch (err) {
     //

--- a/packages/gasket-cli/src/scaffold/dump-error-context.js
+++ b/packages/gasket-cli/src/scaffold/dump-error-context.js
@@ -1,7 +1,5 @@
 const path = require('path');
-const { promisify } = require('util');
-const fs = require('fs');
-const writeFile = promisify(fs.writeFile);
+const { writeFile } = require('fs/promises');
 
 /**
  * If an error occurs during create, dump the context for debugging.

--- a/packages/gasket-cli/src/scaffold/fetcher.js
+++ b/packages/gasket-cli/src/scaffold/fetcher.js
@@ -168,9 +168,10 @@ module.exports = class PackageFetcher {
    */
   async unpack(tarball, dir) {
     return {
-      then: (fulfill, reject) => {
+      then: async (fulfill, reject) => {
         const logOpts = { tarball, dir };
-        const fd = open(tarball);
+        const fd = await open(tarball);
+        console.log(fd);
         const readableStream = fd.createReadStream(tarball).once('error', this._logError(`fs.createReadStream`, logOpts));
         const unzip = zlib.createUnzip().once('error', this._logError(`zlib.createUnzip`, logOpts));
         const extract = tar.extract(dir).once('error', this._logError(`tar.extract`, logOpts));

--- a/packages/gasket-cli/src/scaffold/fetcher.js
+++ b/packages/gasket-cli/src/scaffold/fetcher.js
@@ -1,10 +1,9 @@
-const { promisify } = require('util');
 const path = require('path');
-const fs = require('fs');
+const { rename, unlink, open } = require('fs/promises');
 const tar = require('tar-fs');
 const zlib = require('zlib');
 const pump = require('pump');
-const mkdirp = promisify(require('mkdirp'));
+const mkdirp = require('mkdirp');
 const debug = require('diagnostics')('gasket:cli:fetcher');
 const { PackageManager } = require('@gasket/utils');
 
@@ -27,7 +26,6 @@ const Fetcher = class Fetcher {
    * @returns {Promise} result
    */
   async vacuum(sourceDir) {
-    const rename = promisify(fs.rename);
     const spawn = require('cross-spawn');
     const basename = path.basename(sourceDir);
     const rootDir = path.join(__dirname, '..', '..');
@@ -113,8 +111,6 @@ module.exports = class PackageFetcher {
    * @public
    */
   async clone() {
-    const unlink = promisify(fs.unlink);
-
     await mkdirp(this.tmp.dir);
 
     const tarballFile = await this.fetch(this.packageName, this.tmp.dir);
@@ -174,7 +170,8 @@ module.exports = class PackageFetcher {
     return {
       then: (fulfill, reject) => {
         const logOpts = { tarball, dir };
-        const readableStream = fs.createReadStream(tarball).once('error', this._logError(`fs.createReadStream`, logOpts));
+        const fd = open(tarball);
+        const readableStream = fd.createReadStream(tarball).once('error', this._logError(`fs.createReadStream`, logOpts));
         const unzip = zlib.createUnzip().once('error', this._logError(`zlib.createUnzip`, logOpts));
         const extract = tar.extract(dir).once('error', this._logError(`tar.extract`, logOpts));
 

--- a/packages/gasket-cli/src/scaffold/fetcher.js
+++ b/packages/gasket-cli/src/scaffold/fetcher.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { rename, unlink, open } = require('fs/promises');
+const { rename, unlink, open } = require('fs').promises;
 const tar = require('tar-fs');
 const zlib = require('zlib');
 const pump = require('pump');

--- a/packages/gasket-cli/test/unit/config/utils.test.js
+++ b/packages/gasket-cli/test/unit/config/utils.test.js
@@ -14,10 +14,10 @@ const statStub = sinon.stub().callsFake(mod => {
 
 const utils = proxyquire('../../../src/config/utils', {
   'fs': {
-    statSync: statStub
-  },
-  'fs/promises': {
-    readdir: readDirStub
+    statSync: statStub,
+    promises: {
+      readdir: readDirStub
+    }
   },
   '/path/to/gasket.config': { mockConfig: true },
   '/path/to/app/gasket.config': { mockConfig: true },

--- a/packages/gasket-cli/test/unit/config/utils.test.js
+++ b/packages/gasket-cli/test/unit/config/utils.test.js
@@ -13,10 +13,11 @@ const statStub = sinon.stub().callsFake(mod => {
 });
 
 const utils = proxyquire('../../../src/config/utils', {
-  'util': { promisify: f => f },
   'fs': {
-    readdir: readDirStub,
     statSync: statStub
+  },
+  'fs/promises': {
+    readdir: readDirStub
   },
   '/path/to/gasket.config': { mockConfig: true },
   '/path/to/app/gasket.config': { mockConfig: true },

--- a/packages/gasket-cli/test/unit/scaffold/actions/load-pkg-for-debug.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/load-pkg-for-debug.test.js
@@ -22,7 +22,9 @@ describe('load-pkg-for-debug', () => {
     readFileStub = sandbox.stub().resolves(JSON.stringify(mockPkg));
 
     mockImports = {
-      'util': { promisify: () => readFileStub },
+      'fs/promises': {
+        readFile: readFileStub
+      },
       '../action-wrapper': require('../../../helpers').mockActionWrapper
     };
 

--- a/packages/gasket-cli/test/unit/scaffold/actions/load-pkg-for-debug.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/load-pkg-for-debug.test.js
@@ -22,8 +22,10 @@ describe('load-pkg-for-debug', () => {
     readFileStub = sandbox.stub().resolves(JSON.stringify(mockPkg));
 
     mockImports = {
-      'fs/promises': {
-        readFile: readFileStub
+      'fs': {
+        promises: {
+          readFile: readFileStub
+        }
       },
       '../action-wrapper': require('../../../helpers').mockActionWrapper
     };

--- a/packages/gasket-cli/test/unit/scaffold/actions/mkdir.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/mkdir.test.js
@@ -21,8 +21,10 @@ describe('mkdir', () => {
     mkdirStub = sandbox.stub();
 
     mkDir = proxyquire('../../../../src/scaffold/actions/mkdir', {
-      'fs/promises': {
-        mkdir: mkdirStub
+      'fs': {
+        promises: {
+          mkdir: mkdirStub
+        }
       },
       '../action-wrapper': require('../../../helpers').mockActionWrapper
     });

--- a/packages/gasket-cli/test/unit/scaffold/actions/mkdir.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/mkdir.test.js
@@ -21,7 +21,9 @@ describe('mkdir', () => {
     mkdirStub = sandbox.stub();
 
     mkDir = proxyquire('../../../../src/scaffold/actions/mkdir', {
-      'util': { promisify: () => mkdirStub },
+      'fs/promises': {
+        mkdir: mkdirStub
+      },
       '../action-wrapper': require('../../../helpers').mockActionWrapper
     });
   });

--- a/packages/gasket-cli/test/unit/scaffold/actions/write-gasket-config.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/write-gasket-config.test.js
@@ -26,8 +26,10 @@ describe('write-gasket-config', () => {
     writeStub = sandbox.stub();
 
     writeGasketConfig = proxyquire('../../../../src/scaffold/actions/write-gasket-config', {
-      'fs/promises': {
-        writeFile: writeStub
+      'fs': {
+        promises: {
+          writeFile: writeStub
+        }
       },
       '../action-wrapper': require('../../../helpers').mockActionWrapper
     });

--- a/packages/gasket-cli/test/unit/scaffold/actions/write-gasket-config.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/write-gasket-config.test.js
@@ -26,7 +26,9 @@ describe('write-gasket-config', () => {
     writeStub = sandbox.stub();
 
     writeGasketConfig = proxyquire('../../../../src/scaffold/actions/write-gasket-config', {
-      'util': { promisify: () => writeStub },
+      'fs/promises': {
+        writeFile: writeStub
+      },
       '../action-wrapper': require('../../../helpers').mockActionWrapper
     });
   });

--- a/packages/gasket-cli/test/unit/scaffold/actions/write-pkg.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/write-pkg.test.js
@@ -24,7 +24,9 @@ describe('write-pkg', () => {
     writeStub = sandbox.stub();
 
     writePkg = proxyquire('../../../../src/scaffold/actions/write-pkg', {
-      'util': { promisify: () => writeStub },
+      'fs/promises': {
+        writeFile: writeStub
+      },
       '../action-wrapper': require('../../../helpers').mockActionWrapper
     });
   });

--- a/packages/gasket-cli/test/unit/scaffold/actions/write-pkg.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/write-pkg.test.js
@@ -24,8 +24,10 @@ describe('write-pkg', () => {
     writeStub = sandbox.stub();
 
     writePkg = proxyquire('../../../../src/scaffold/actions/write-pkg', {
-      'fs/promises': {
-        writeFile: writeStub
+      'fs': {
+        promises: {
+          writeFile: writeStub
+        }
       },
       '../action-wrapper': require('../../../helpers').mockActionWrapper
     });

--- a/packages/gasket-cli/test/unit/scaffold/dump-error-context.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/dump-error-context.test.js
@@ -23,8 +23,10 @@ describe('dumpErrorContext', () => {
     errorStub = sandbox.stub(console, 'error');
 
     dumpErrorContext = proxyquire('../../../src/scaffold/dump-error-context', {
-      'fs/promises': {
-        writeFile: writeStub
+      fs: {
+        promises: {
+          writeFile: writeStub
+        }
       }
     });
   });

--- a/packages/gasket-cli/test/unit/scaffold/dump-error-context.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/dump-error-context.test.js
@@ -23,7 +23,9 @@ describe('dumpErrorContext', () => {
     errorStub = sandbox.stub(console, 'error');
 
     dumpErrorContext = proxyquire('../../../src/scaffold/dump-error-context', {
-      util: { promisify: () => writeStub }
+      'fs/promises': {
+        writeFile: writeStub
+      }
     });
   });
 

--- a/packages/gasket-plugin-docs-graphs/plugin.js
+++ b/packages/gasket-plugin-docs-graphs/plugin.js
@@ -1,7 +1,7 @@
 /* eslint no-sync: 0 */
 const path = require('path');
 const fs = require('fs');
-const write = require('util').promisify(fs.writeFile);
+const write = fs.promises.writeFile;
 
 module.exports = {
   name: require('./package.json').name,

--- a/packages/gasket-plugin-docs-graphs/test/plugin.test.js
+++ b/packages/gasket-plugin-docs-graphs/test/plugin.test.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { readFile: read } = require('fs/promises');
+const { readFile: read } = require('fs').promises;
 const plugin = require('../');
 const hook = plugin.hooks.docsGenerate;
 const assume = require('assume');

--- a/packages/gasket-plugin-docs-graphs/test/plugin.test.js
+++ b/packages/gasket-plugin-docs-graphs/test/plugin.test.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const read = require('util').promisify(require('fs').readFile);
+const { readFile: read } = require('fs/promises');
 const plugin = require('../');
 const hook = plugin.hooks.docsGenerate;
 const assume = require('assume');

--- a/packages/gasket-plugin-docs/README.md
+++ b/packages/gasket-plugin-docs/README.md
@@ -170,7 +170,7 @@ Allows a plugin to add documentation that has to be programmatically generated.
 #### An example graph
 
 ```js
-const writeFile = require('util').promisify(require('fs').writeFile);
+const { writeFile } = require('fs/promises');;
 
 module.exports = {
   name: 'questions',

--- a/packages/gasket-plugin-docs/README.md
+++ b/packages/gasket-plugin-docs/README.md
@@ -170,7 +170,7 @@ Allows a plugin to add documentation that has to be programmatically generated.
 #### An example graph
 
 ```js
-const { writeFile } = require('fs/promises');;
+const { writeFile } = require('fs').promises;;
 
 module.exports = {
   name: 'questions',

--- a/packages/gasket-plugin-docs/lib/utils/collate-files.js
+++ b/packages/gasket-plugin-docs/lib/utils/collate-files.js
@@ -1,4 +1,4 @@
-const { readFile, writeFile, copyFile } = require('fs/promises');
+const { readFile, writeFile, copyFile } = require('fs').promises;
 const path = require('path');
 const { promisify } = require('util');
 const mkdirp = require('mkdirp');

--- a/packages/gasket-plugin-docs/lib/utils/collate-files.js
+++ b/packages/gasket-plugin-docs/lib/utils/collate-files.js
@@ -1,11 +1,8 @@
-const fs = require('fs');
+const { readFile, writeFile, copyFile } = require('fs/promises');
 const path = require('path');
 const { promisify } = require('util');
-
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
-const copyFile = promisify(fs.copyFile);
-const mkdirp = promisify(require('mkdirp'));
+const mkdirp = require('mkdirp');
+// TODO: rimraf currently does not have native promise support https://github.com/isaacs/rimraf/pull/229
 const rimraf = promisify(require('rimraf'));
 
 /**

--- a/packages/gasket-plugin-docs/lib/utils/config-set-builder.js
+++ b/packages/gasket-plugin-docs/lib/utils/config-set-builder.js
@@ -4,6 +4,7 @@ const defaultsDeep = require('lodash.defaultsdeep');
 const { promisify } = require('util');
 const { sortModules, sortStructures, sortCommands, sortLifecycles, sortGuides } = require('./sorts');
 
+// TODO: Need to review for native promise usage
 const glob = promisify(require('glob'));
 
 const isAppPlugin = /^\/.+\/plugins\//;

--- a/packages/gasket-plugin-docs/lib/utils/generate-index.js
+++ b/packages/gasket-plugin-docs/lib/utils/generate-index.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-statements */
 
-const { writeFile } = require('fs/promises');
+const { writeFile } = require('fs').promises;
 const path = require('path');
 const mdTable = require('markdown-table');
 

--- a/packages/gasket-plugin-docs/lib/utils/generate-index.js
+++ b/packages/gasket-plugin-docs/lib/utils/generate-index.js
@@ -1,11 +1,8 @@
 /* eslint-disable max-statements */
 
-const fs = require('fs');
+const { writeFile } = require('fs/promises');
 const path = require('path');
-const { promisify } = require('util');
 const mdTable = require('markdown-table');
-
-const writeFile = promisify(fs.writeFile);
 
 const isUrl = /^(https?:)?\/\//;
 
@@ -90,4 +87,3 @@ async function generateIndex(docsConfigSet) {
 generateIndex.generateContent = generateContent;
 
 module.exports = generateIndex;
-

--- a/packages/gasket-plugin-docs/package-lock.json
+++ b/packages/gasket-plugin-docs/package-lock.json
@@ -1,0 +1,23 @@
+{
+	"name": "@gasket/plugin-docs",
+	"version": "6.10.1",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"mkdirp": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"requires": {
+				"minimist": "^1.2.5"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+				}
+			}
+		}
+	}
+}

--- a/packages/gasket-plugin-docs/package.json
+++ b/packages/gasket-plugin-docs/package.json
@@ -40,7 +40,7 @@
     "glob": "^7.1.6",
     "lodash.defaultsdeep": "^4.6.1",
     "markdown-table": "^1.1.3",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.4",
     "rimraf": "^3.0.2"
   },
   "devDependencies": {

--- a/packages/gasket-plugin-docs/test/utils/collate-files.test.js
+++ b/packages/gasket-plugin-docs/test/utils/collate-files.test.js
@@ -10,14 +10,14 @@ const copyFileStub = sinon.stub();
 const mkdirpStub = sinon.stub();
 const rimrafStub = sinon.stub();
 const collateFiles = proxyquire('../../lib/utils/collate-files', {
-  fs: {
+  'fs/promises': {
     readFile: readFileStub,
     writeFile: writeFileStub,
     copyFile: copyFileStub
   },
-  mkdirp: mkdirpStub,
-  rimraf: rimrafStub,
-  util: {
+  'mkdirp': mkdirpStub,
+  'rimraf': rimrafStub,
+  'util': {
     promisify: f => f
   }
 });

--- a/packages/gasket-plugin-docs/test/utils/collate-files.test.js
+++ b/packages/gasket-plugin-docs/test/utils/collate-files.test.js
@@ -10,14 +10,16 @@ const copyFileStub = sinon.stub();
 const mkdirpStub = sinon.stub();
 const rimrafStub = sinon.stub();
 const collateFiles = proxyquire('../../lib/utils/collate-files', {
-  'fs/promises': {
-    readFile: readFileStub,
-    writeFile: writeFileStub,
-    copyFile: copyFileStub
+  fs: {
+    promises: {
+      readFile: readFileStub,
+      writeFile: writeFileStub,
+      copyFile: copyFileStub
+    }
   },
-  'mkdirp': mkdirpStub,
-  'rimraf': rimrafStub,
-  'util': {
+  mkdirp: mkdirpStub,
+  rimraf: rimrafStub,
+  util: {
     promisify: f => f
   }
 });

--- a/packages/gasket-plugin-docs/test/utils/generate-index.test.js
+++ b/packages/gasket-plugin-docs/test/utils/generate-index.test.js
@@ -75,8 +75,10 @@ const fullDocsConfigSet = {
 
 const writeFileStub = sinon.stub();
 const generateIndex = proxyquire('../../lib/utils/generate-index', {
-  'fs/promises': {
-    writeFile: writeFileStub
+  fs: {
+    promises: {
+      writeFile: writeFileStub
+    }
   }
 });
 const { generateContent } = generateIndex;

--- a/packages/gasket-plugin-docs/test/utils/generate-index.test.js
+++ b/packages/gasket-plugin-docs/test/utils/generate-index.test.js
@@ -75,8 +75,8 @@ const fullDocsConfigSet = {
 
 const writeFileStub = sinon.stub();
 const generateIndex = proxyquire('../../lib/utils/generate-index', {
-  util: {
-    promisify: () => writeFileStub
+  'fs/promises': {
+    writeFile: writeFileStub
   }
 });
 const { generateContent } = generateIndex;

--- a/packages/gasket-plugin-docsify/lib/generate-content.js
+++ b/packages/gasket-plugin-docsify/lib/generate-content.js
@@ -1,5 +1,5 @@
 const defaultsDeep = require('lodash.defaultsdeep');
-const { readFile, writeFile, copyFile } = require('fs/promises');
+const { readFile, writeFile, copyFile } = require('fs').promises;
 const path = require('path');
 const { promisify } = require('util');
 const mkdirp = require('mkdirp');

--- a/packages/gasket-plugin-docsify/lib/generate-content.js
+++ b/packages/gasket-plugin-docsify/lib/generate-content.js
@@ -1,11 +1,9 @@
 const defaultsDeep = require('lodash.defaultsdeep');
-const fs = require('fs');
+const { readFile, writeFile, copyFile } = require('fs/promises');
 const path = require('path');
 const { promisify } = require('util');
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
-const copyFile = promisify(fs.copyFile);
-const mkdirp = promisify(require('mkdirp'));
+const mkdirp = require('mkdirp');
+// TODO: Need to review for native promise usage
 const glob = promisify(require('glob'));
 
 const isCssFile = /.css$/;
@@ -20,6 +18,7 @@ const srcIndex = path.join(srcDir, 'index.html');
  * @param {DocsConfigSet} docsConfigSet -
  * @returns {Promise<string>} output file
  */
+// eslint-disable-next-line max-statements
 async function generateContent(docsifyConfig, docsConfigSet) {
   const { theme = 'styles/gasket.css', config = {} } = docsifyConfig;
   const { docsRoot } = docsConfigSet;

--- a/packages/gasket-plugin-docsify/package-lock.json
+++ b/packages/gasket-plugin-docsify/package-lock.json
@@ -1,0 +1,23 @@
+{
+	"name": "@gasket/plugin-docsify",
+	"version": "6.10.1",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"mkdirp": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"requires": {
+				"minimist": "^1.2.5"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+				}
+			}
+		}
+	}
+}

--- a/packages/gasket-plugin-docsify/package.json
+++ b/packages/gasket-plugin-docsify/package.json
@@ -42,7 +42,7 @@
     "glob": "^7.1.6",
     "handlebars": "^4.7.6",
     "lodash.defaultsdeep": "^4.6.1",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^1.0.4"
   },
   "devDependencies": {
     "@gasket/engine": "^6.10.1",

--- a/packages/gasket-plugin-docsify/test/generate-content.test.js
+++ b/packages/gasket-plugin-docsify/test/generate-content.test.js
@@ -2,7 +2,7 @@
 const assume = require('assume');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
-const { readFile } = require('fs/promises');
+const { readFile } = require('fs').promises;
 const path = require('path');
 
 const template = readFile(path.join(__dirname, '..', 'generator', 'index.html'), 'utf8');
@@ -24,14 +24,16 @@ const writeFileStub = sinon.stub();
 const copyFileStub = sinon.stub();
 const mkdirpStub = sinon.stub().resolves('/path/to/app');
 const generateContent = proxyquire('../lib/generate-content', {
-  'fs/promises': {
-    readFile: readFileStub.resolves(template),
-    writeFile: writeFileStub,
-    copyFile: copyFileStub
+  fs: {
+    promises: {
+      readFile: readFileStub.resolves(template),
+      writeFile: writeFileStub,
+      copyFile: copyFileStub
+    }
   },
-  'mkdirp': mkdirpStub,
-  'glob': globStub,
-  'util': {
+  mkdirp: mkdirpStub,
+  glob: globStub,
+  util: {
     promisify: f => f
   }
 });

--- a/packages/gasket-plugin-docsify/test/generate-content.test.js
+++ b/packages/gasket-plugin-docsify/test/generate-content.test.js
@@ -2,10 +2,8 @@
 const assume = require('assume');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
-const fs = require('fs');
+const { readFile } = require('fs/promises');
 const path = require('path');
-const { promisify } = require('util');
-const readFile = promisify(fs.readFile);
 
 const template = readFile(path.join(__dirname, '..', 'generator', 'index.html'), 'utf8');
 
@@ -24,14 +22,16 @@ const readFileStub = sinon.stub().resolves('mock-content');
 const globStub = sinon.stub().resolves(['favicon.ico']);
 const writeFileStub = sinon.stub();
 const copyFileStub = sinon.stub();
+const mkdirpStub = sinon.stub().resolves('/path/to/app');
 const generateContent = proxyquire('../lib/generate-content', {
-  fs: {
+  'fs/promises': {
     readFile: readFileStub.resolves(template),
     writeFile: writeFileStub,
     copyFile: copyFileStub
   },
-  glob: globStub,
-  util: {
+  'mkdirp': mkdirpStub,
+  'glob': globStub,
+  'util': {
     promisify: f => f
   }
 });

--- a/packages/gasket-plugin-intl/lib/build-manifest.js
+++ b/packages/gasket-plugin-intl/lib/build-manifest.js
@@ -1,12 +1,11 @@
 const path = require('path');
-const fs = require('fs');
+const { readFile, writeFile } = require('fs/promises');
 const { promisify } = require('util');
 const loaderUtils = require('loader-utils');
 const { getIntlConfig } = require('./configure');
 
+// TODO: Need to review for native promise usage
 const glob = promisify(require('glob'));
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
 
 /**
  * Constructs a manifest of locale file paths and settings which can be

--- a/packages/gasket-plugin-intl/lib/build-manifest.js
+++ b/packages/gasket-plugin-intl/lib/build-manifest.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { readFile, writeFile } = require('fs/promises');
+const fs = require('fs').promises;
 const { promisify } = require('util');
 const loaderUtils = require('loader-utils');
 const { getIntlConfig } = require('./configure');
@@ -32,7 +32,7 @@ module.exports = async function buildManifest(gasket) {
   // generate a content hash for each file
   const paths = (
     await Promise.all(files.map(async file => {
-      const buffer = await readFile(path.join(localesDir, file));
+      const buffer = await fs.readFile(path.join(localesDir, file));
       const hash = loaderUtils.getHashDigest(buffer, 'md5', 'hex', 7);
       return { [path.basename(localesDir) + '/' + file]: hash };
     })))
@@ -58,7 +58,7 @@ module.exports = async function buildManifest(gasket) {
   };
 
   try {
-    await writeFile(tgtFile, JSON.stringify(manifest), 'utf-8');
+    await fs.writeFile(tgtFile, JSON.stringify(manifest), 'utf-8');
     logger.log('build:locales: Wrote locales manifest.');
   } catch (err) {
     logger.error('build:locales: Unable to write locales manifest.');

--- a/packages/gasket-plugin-intl/test/build-manifest.test.js
+++ b/packages/gasket-plugin-intl/test/build-manifest.test.js
@@ -2,6 +2,7 @@ const assume = require('assume');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const path = require('path');
+const { readFile } = require('fs').promises;
 
 describe('buildManifest', function () {
   let mockGasket, buildManifest, writeFileStub;
@@ -33,8 +34,11 @@ describe('buildManifest', function () {
     });
 
     buildManifest = proxyquire('../lib/build-manifest', {
-      'fs/promises': {
-        writeFile: writeFileStub
+      fs: {
+        promises: {
+          writeFile: writeFileStub,
+          readFile
+        }
       }
     });
   });

--- a/packages/gasket-plugin-intl/test/build-manifest.test.js
+++ b/packages/gasket-plugin-intl/test/build-manifest.test.js
@@ -28,12 +28,12 @@ describe('buildManifest', function () {
       }
     };
 
-    writeFileStub = sinon.stub().callsFake((...args) => {
+    writeFileStub = sinon.stub().resolves((...args) => {
       args[args.length - 1](null, true);
     });
 
     buildManifest = proxyquire('../lib/build-manifest', {
-      fs: {
+      'fs/promises': {
         writeFile: writeFileStub
       }
     });

--- a/packages/gasket-plugin-lifecycle/index.js
+++ b/packages/gasket-plugin-lifecycle/index.js
@@ -1,10 +1,7 @@
 const debug = require('diagnostics')('gasket:lifecycle');
 const path = require('path');
-const fs = require('fs');
-const { promisify } = require('util');
+const { readdir } = require('fs/promises');
 const camelCase = require('lodash.camelcase');
-
-const readDir = promisify(fs.readdir);
 
 /**
  * Resolves a given directory to valid `lifecycle` plugins.
@@ -19,7 +16,7 @@ async function resolve(root, name) {
 
   let files = [];
   try {
-    files = await readDir(dir);
+    files = await readdir(dir);
   } catch (err) {
     if (err.code !== 'ENOENT') {
       throw err;

--- a/packages/gasket-plugin-lifecycle/index.js
+++ b/packages/gasket-plugin-lifecycle/index.js
@@ -1,6 +1,6 @@
 const debug = require('diagnostics')('gasket:lifecycle');
 const path = require('path');
-const { readdir } = require('fs/promises');
+const { readdir } = require('fs').promises;
 const camelCase = require('lodash.camelcase');
 
 /**

--- a/packages/gasket-plugin-manifest/lib/build.js
+++ b/packages/gasket-plugin-manifest/lib/build.js
@@ -1,10 +1,7 @@
 const path = require('path');
-const { promisify } = require('util');
-const fs = require('fs');
+const { writeFile } = require('fs/promises');
 const mkdirp = require('mkdirp');
 const { gatherManifestData } = require('./utils');
-
-const writeFile = promisify(fs.writeFile);
 
 /**
  * Write a static web manifest file

--- a/packages/gasket-plugin-manifest/lib/build.js
+++ b/packages/gasket-plugin-manifest/lib/build.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { writeFile } = require('fs/promises');
+const { writeFile } = require('fs').promises;
 const mkdirp = require('mkdirp');
 const { gatherManifestData } = require('./utils');
 

--- a/packages/gasket-plugin-manifest/test/build.test.js
+++ b/packages/gasket-plugin-manifest/test/build.test.js
@@ -7,11 +7,13 @@ describe('build', function () {
   const mkdirpStub = sinon.stub();
 
   const build = proxyquire('../lib/build', {
-    'fs/promises': {
-      writeFile: writeFileStub
+    fs: {
+      promises: {
+        writeFile: writeFileStub
+      }
     },
-    'mkdirp': mkdirpStub,
-    'replace': sinon.stub()
+    mkdirp: mkdirpStub,
+    replace: sinon.stub()
   });
 
   let gasket;

--- a/packages/gasket-plugin-manifest/test/build.test.js
+++ b/packages/gasket-plugin-manifest/test/build.test.js
@@ -7,14 +7,11 @@ describe('build', function () {
   const mkdirpStub = sinon.stub();
 
   const build = proxyquire('../lib/build', {
-    fs: {
+    'fs/promises': {
       writeFile: writeFileStub
     },
-    mkdirp: mkdirpStub,
-    util: {
-      promisify: f => f
-    },
-    replace: sinon.stub()
+    'mkdirp': mkdirpStub,
+    'replace': sinon.stub()
   });
 
   let gasket;

--- a/packages/gasket-plugin-service-worker/README.md
+++ b/packages/gasket-plugin-service-worker/README.md
@@ -120,7 +120,7 @@ In this example, we use the market id from the request to read in a partial
 service worker and add it to the content.
 
 ```js
-const { readFile } = require('fs/promises');
+const { readFile } = require('fs').promises;
 
 module.exports = {
   hooks: {

--- a/packages/gasket-plugin-service-worker/README.md
+++ b/packages/gasket-plugin-service-worker/README.md
@@ -120,9 +120,7 @@ In this example, we use the market id from the request to read in a partial
 service worker and add it to the content.
 
 ```js
-const util = require('util');
-const fs = require('fs');
-const readFile = util.promisify(fs.readFile);
+const { readFile } = require('fs/promises');
 
 module.exports = {
   hooks: {
@@ -253,4 +251,3 @@ environment, which can be easily done using [service-worker-mock].
 [service workers]:https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API
 [@gasket/plugin-webpack]:/packages/gasket-plugin-webpack/README.md
 [@gasket/plugin-nextjs]:/packages/gasket-plugin-nextjs/README.md
-

--- a/packages/gasket-plugin-service-worker/lib/build.js
+++ b/packages/gasket-plugin-service-worker/lib/build.js
@@ -1,10 +1,7 @@
 const path = require('path');
-const util = require('util');
-const fs = require('fs');
+const { writeFile } = require('fs/promises');
 const mkdirp = require('mkdirp');
 const { getComposedContent, getSWConfig } = require('./utils');
-
-const writeFile = util.promisify(fs.writeFile);
 
 /**
  * Write a static service worker file

--- a/packages/gasket-plugin-service-worker/lib/build.js
+++ b/packages/gasket-plugin-service-worker/lib/build.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { writeFile } = require('fs/promises');
+const { writeFile } = require('fs').promises;
 const mkdirp = require('mkdirp');
 const { getComposedContent, getSWConfig } = require('./utils');
 

--- a/packages/gasket-plugin-service-worker/lib/utils.js
+++ b/packages/gasket-plugin-service-worker/lib/utils.js
@@ -56,13 +56,12 @@ let __script;
  */
 async function loadRegisterScript(config) {
   if (!__script) {
-    const { readFile } = require('fs/promises');
-
+    const fs = require('fs').promises;
     const { url, scope } = config;
     const template = require.resolve('./sw-register.template.js');
 
     // eslint-disable-next-line require-atomic-updates
-    __script = (await readFile(template, 'utf8'))
+    __script = (await fs.readFile(template, 'utf8'))
       .replace('{URL}', url)
       .replace('{SCOPE}', scope);
   }

--- a/packages/gasket-plugin-service-worker/lib/utils.js
+++ b/packages/gasket-plugin-service-worker/lib/utils.js
@@ -56,9 +56,7 @@ let __script;
  */
 async function loadRegisterScript(config) {
   if (!__script) {
-    const util = require('util');
-    const fs = require('fs');
-    const readFile = util.promisify(fs.readFile);
+    const { readFile } = require('fs/promises');
 
     const { url, scope } = config;
     const template = require.resolve('./sw-register.template.js');

--- a/packages/gasket-plugin-service-worker/package.json
+++ b/packages/gasket-plugin-service-worker/package.json
@@ -38,7 +38,7 @@
     "@types/uglify-js": "^3.13.1",
     "deepmerge": "^4.2.2",
     "lru-cache": "^5.1.1",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.4",
     "uglify-js": "^3.5.3",
     "webpack-inject-plugin": "^1.5.4"
   },

--- a/packages/gasket-plugin-service-worker/test/build.spec.js
+++ b/packages/gasket-plugin-service-worker/test/build.spec.js
@@ -1,13 +1,22 @@
 const mkdirp = require('mkdirp');
 const build = require('../lib/build');
-const fsPromises = require('fs/promises');
-jest.mock('fs/promises', () => jest.createMockFromModule('fs/promises'));
+const fs = require('fs');
+
+jest.mock('fs', () => {
+  const originalModule = jest.requireActual('fs');
+
+  return {
+    ...originalModule,
+    promises: {
+      writeFile: jest.fn(() =>  Promise.resolve(null))
+    }
+  };
+});
 
 describe('build', () => {
   let mockConfig, mockGasket;
 
   beforeEach(() => {
-    fsPromises.writeFile.mockImplementation(() => Promise.resolve(null));
 
     mockConfig = {
       url: '/sw.js',
@@ -61,7 +70,7 @@ describe('build', () => {
   it('writes file out', async () => {
     mockConfig.content = 'This is preconfigured content';
     await build.handler(mockGasket);
-    expect(fsPromises.writeFile).toHaveBeenCalledWith(
+    expect(fs.promises.writeFile).toHaveBeenCalledWith(
       '/some-root/public/sw.js',
       expect.stringContaining('strict'),
       'utf-8'

--- a/packages/gasket-plugin-service-worker/test/build.spec.js
+++ b/packages/gasket-plugin-service-worker/test/build.spec.js
@@ -1,13 +1,13 @@
 const mkdirp = require('mkdirp');
 const build = require('../lib/build');
-const fs = require('fs');
-jest.mock('fs');
+const fsPromises = require('fs/promises');
+jest.mock('fs/promises', () => jest.createMockFromModule('fs/promises'));
 
 describe('build', () => {
   let mockConfig, mockGasket;
 
   beforeEach(() => {
-    fs.writeFile.mockImplementation((path, content, options, callback) => callback(null, true));
+    fsPromises.writeFile.mockImplementation(() => Promise.resolve(null));
 
     mockConfig = {
       url: '/sw.js',
@@ -61,11 +61,10 @@ describe('build', () => {
   it('writes file out', async () => {
     mockConfig.content = 'This is preconfigured content';
     await build.handler(mockGasket);
-    expect(fs.writeFile).toHaveBeenCalledWith(
+    expect(fsPromises.writeFile).toHaveBeenCalledWith(
       '/some-root/public/sw.js',
       expect.stringContaining('strict'),
-      'utf-8',
-      expect.any(Function)
+      'utf-8'
     );
   });
 });

--- a/packages/gasket-plugin-service-worker/test/utils.spec.js
+++ b/packages/gasket-plugin-service-worker/test/utils.spec.js
@@ -137,8 +137,8 @@ describe('utils', () => {
 
     beforeEach(() => {
       jest.isolateModules(() => {
-        fs = require('fs');
-        fs.readFile = jest.fn((path, options, callback) => callback(null, 'mock {URL} and {SCOPE}'));
+        fs = require('fs/promises');
+        fs.readFile = jest.fn(() => Promise.resolve('mock {URL} and {SCOPE}'));
       });
     });
 

--- a/packages/gasket-plugin-service-worker/test/utils.spec.js
+++ b/packages/gasket-plugin-service-worker/test/utils.spec.js
@@ -137,7 +137,7 @@ describe('utils', () => {
 
     beforeEach(() => {
       jest.isolateModules(() => {
-        fs = require('fs/promises');
+        fs = require('fs').promises;
         fs.readFile = jest.fn(() => Promise.resolve('mock {URL} and {SCOPE}'));
       });
     });

--- a/packages/gasket-plugin-swagger/index.js
+++ b/packages/gasket-plugin-swagger/index.js
@@ -1,12 +1,8 @@
 const path = require('path');
 const fs = require('fs');
-const { promisify } = require('util');
+const { readFile, writeFile, access } = require('fs/promises');
 const swaggerUi = require('swagger-ui-express');
 const swaggerJSDoc = require('swagger-jsdoc');
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
-const accessFile = promisify(fs.access);
-
 const isYaml = /\.ya?ml$/;
 
 let __swaggerSpec;
@@ -23,7 +19,7 @@ async function loadSwaggerSpec(root, definitionFile, logger) {
   if (!__swaggerSpec) {
     const target = path.join(root, definitionFile);
 
-    await accessFile(target, fs.constants.F_OK)
+    await access(target, fs.constants.F_OK)
       .then(async () => {
         if (isYaml.test(definitionFile)) {
           const content = await readFile(target, 'utf8');

--- a/packages/gasket-plugin-swagger/index.js
+++ b/packages/gasket-plugin-swagger/index.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-const { readFile, writeFile, access } = require('fs/promises');
+const { readFile, writeFile, access } = require('fs').promises;
 const swaggerUi = require('swagger-ui-express');
 const swaggerJSDoc = require('swagger-jsdoc');
 const isYaml = /\.ya?ml$/;

--- a/packages/gasket-plugin-swagger/test/index.test.js
+++ b/packages/gasket-plugin-swagger/test/index.test.js
@@ -20,11 +20,13 @@ describe('Swagger Plugin', function () {
 
     plugin = proxyquire('../index', {
       'fs': {
-        readFile: readFileStub,
-        writeFile: writeFileStub,
         constants: {
           F_OK: oKStub
-        },
+        }
+      },
+      'fs/promises': {
+        readFile: readFileStub,
+        writeFile: writeFileStub,
         access: accessStub
       },
       'swagger-jsdoc': swaggerJSDocStub,

--- a/packages/gasket-plugin-swagger/test/index.test.js
+++ b/packages/gasket-plugin-swagger/test/index.test.js
@@ -22,12 +22,12 @@ describe('Swagger Plugin', function () {
       'fs': {
         constants: {
           F_OK: oKStub
+        },
+        promises: {
+          readFile: readFileStub,
+          writeFile: writeFileStub,
+          access: accessStub
         }
-      },
-      'fs/promises': {
-        readFile: readFileStub,
-        writeFile: writeFileStub,
-        access: accessStub
       },
       'swagger-jsdoc': swaggerJSDocStub,
       'js-yaml': {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

This PR solves #314. I've aligned `mkdirp` in all packages (which this version has native promise support). Along w/ moving to `fs.promises` vs `promisify` for all things `fs` related
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

- minor: convert to `require('fs').promises` and align `mdirp` accross packages
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

Updated all tests related to the `require('fs').promises` test suite passes locally

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
