### PR TITLE
Add --exit flag to build command

### DIFF
--- a/packages/gasket-plugin-start/README.md
+++ b/packages/gasket-plugin-start/README.md
@@ -13,8 +13,9 @@ This is a default plugin in the Gasket CLI and is always available for use.
 Executes the `build` lifecycle. Use this to prepare your app for running, such
 as bundling files, minifying code, processing assets, etc.
 
-If you need to force the process to exit once build lifecycle completes, you can
-pass the `--exit` flag. This should be used sparingly.
+If you need to force the process to exit once the build lifecycle completes,
+you can pass the `--exit` flag. This should be used sparingly. Prefer to find
+and fix lingering open handle issues which may be keeping the process running.
 
 ### start command
 

--- a/packages/gasket-plugin-start/README.md
+++ b/packages/gasket-plugin-start/README.md
@@ -13,6 +13,9 @@ This is a default plugin in the Gasket CLI and is always available for use.
 Executes the `build` lifecycle. Use this to prepare your app for running, such
 as bundling files, minifying code, processing assets, etc.
 
+If you need to force the process to exit once build lifecycle completes, you can
+pass the `--exit` flag. This should be used sparingly.
+
 ### start command
 
 Executes the `preboot` and `start` lifecycles. Upon building your app, use this

--- a/packages/gasket-plugin-start/lib/get-commands.js
+++ b/packages/gasket-plugin-start/lib/get-commands.js
@@ -11,10 +11,22 @@ module.exports = function getCommands(gasket, { GasketCommand, flags }) {
   class BuildCommand extends GasketCommand {
     async gasketRun() {
       await this.gasket.exec('build');
+
+      if (this.gasket.command.flags.exit) {
+        this.gasket.logger.debug('force exit');
+        // eslint-disable-next-line no-process-exit
+        process.exit(0);
+      }
     }
   }
   BuildCommand.id = 'build';
   BuildCommand.description = 'Prepare your app';
+  BuildCommand.flags = {
+    exit: flags.boolean({
+      default: false,
+      description: 'Exit process immediately after command completes'
+    })
+  };
 
 
   class StartCommand extends GasketCommand {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Sometimes, the Next.js 12 process hangs. The current recommendation from their team is to force `process.exit`. This adds a flag to the Gasket build command to enable force exiting until the Next.js issues are addressed.

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/plugin-start**
- Add `--exit` flag to build command

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Updated unit tests
- Local testing in canary-app