### PR TITLE
Use fs.createReadStream for node<16 support

### DIFF
--- a/packages/gasket-cli/src/scaffold/fetcher.js
+++ b/packages/gasket-cli/src/scaffold/fetcher.js
@@ -1,5 +1,6 @@
 const path = require('path');
-const { rename, unlink, open } = require('fs').promises;
+const fs = require('fs');
+const { rename, unlink } = fs.promises;
 const tar = require('tar-fs');
 const zlib = require('zlib');
 const pump = require('pump');
@@ -170,9 +171,7 @@ module.exports = class PackageFetcher {
     return {
       then: async (fulfill, reject) => {
         const logOpts = { tarball, dir };
-        const fd = await open(tarball);
-        console.log(fd);
-        const readableStream = fd.createReadStream(tarball).once('error', this._logError(`fs.createReadStream`, logOpts));
+        const readableStream = fs.createReadStream(tarball).once('error', this._logError(`fs.createReadStream`, logOpts));
         const unzip = zlib.createUnzip().once('error', this._logError(`zlib.createUnzip`, logOpts));
         const extract = tar.extract(dir).once('error', this._logError(`tar.extract`, logOpts));
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Fixes bug encountered with `gasket create` on node 14, introduced in https://github.com/godaddy/gasket/pull/319.

```
⠸ Load presetsFileHandle {
  close: [Function: close],
  [Symbol(kHandle)]: FileHandle {},
  [Symbol(kFd)]: 23,
  [Symbol(kRefs)]: 1,
  [Symbol(kClosePromise)]: null
}
```
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/cli**
- Use fs.createReadStream for node<16 support

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

Tested locally with
`/path/to/godaddy/gasket/packages/gasket-cli/bin/run create test-app --presets @gasket/preset-nextjs`