### PR TITLE
Support for AbortController with runShellCommand

### DIFF
--- a/packages/gasket-utils/docs/api.md
+++ b/packages/gasket-utils/docs/api.md
@@ -154,7 +154,7 @@ can be passed to use AbortController, allowing processes to be killed when
 no longer needed.
 
 **Kind**: global function  
-**Returns**: `Promise` - A promise represents if npm succeeds or fails.  
+**Returns**: `Promise` - A promise represents if command succeeds or fails.  
 **Access**: public  
 
 | Param | Type | Description |

--- a/packages/gasket-utils/docs/api.md
+++ b/packages/gasket-utils/docs/api.md
@@ -149,6 +149,10 @@ Normalize the config by applying any environment or local overrides
 Promise friendly wrapper to running a shell command (eg: git, npm, ls)
 which passes back any { stdout, stderr } to the error thrown.
 
+Options can be passed to the underlying spawn. An additional `signal option
+can be passed to use AbortController, allowing processes to be killed when
+no longer needed.
+
 **Kind**: global function  
 **Returns**: `Promise` - A promise represents if npm succeeds or fails.  
 **Access**: public  
@@ -156,8 +160,9 @@ which passes back any { stdout, stderr } to the error thrown.
 | Param | Type | Description |
 | --- | --- | --- |
 | cmd | `string` | binary that is run |
-| argv | `array` | args passed to npm binary through spawn. |
-| options | `object` | options passed to npm binary through spawn |
+| argv | `array` | args passed to npm binary through spawn. |
+| options | `object` | options passed to npm binary through spawn |
+| \[options.signal\] | `object` | AbortControl signal allowing process to be canceled |
 | \[debug\] | `boolean` | When present pipes std{out,err} to process.* |
 
 **Example**  
@@ -166,6 +171,21 @@ const { runShellCommand } = require('@gasket/utils');
 
  async function helloWorld() {
   await runShellCommand('echo', ['hello world']);
+}
+```
+**Example**  
+```js
+// Enable timeout using AbortController
+
+const { runShellCommand } = require('@gasket/utils');
+const AbortController = require('abort-controller');
+
+ async function helloWorld() {
+  const controller = new AbortController();
+  // abort the process after 60 seconds
+  const id = setTimeout(() => controller.abort(), 60000);
+  await runShellCommand('long-process', ['something'], { signal: controller.signal });
+  clearTimeout(id);
 }
 ```
 

--- a/packages/gasket-utils/docs/api.md
+++ b/packages/gasket-utils/docs/api.md
@@ -149,7 +149,7 @@ Normalize the config by applying any environment or local overrides
 Promise friendly wrapper to running a shell command (eg: git, npm, ls)
 which passes back any { stdout, stderr } to the error thrown.
 
-Options can be passed to the underlying spawn. An additional `signal option
+Options can be passed to the underlying spawn. An additional `signal` option
 can be passed to use AbortController, allowing processes to be killed when
 no longer needed.
 
@@ -175,7 +175,7 @@ const { runShellCommand } = require('@gasket/utils');
 ```
 **Example**  
 ```js
-// Enable timeout using AbortController
+// With timeout using AbortController
 
 const { runShellCommand } = require('@gasket/utils');
 const AbortController = require('abort-controller');

--- a/packages/gasket-utils/lib/run-shell-command.js
+++ b/packages/gasket-utils/lib/run-shell-command.js
@@ -5,7 +5,7 @@ const spawn = require('cross-spawn');
  * Promise friendly wrapper to running a shell command (eg: git, npm, ls)
  * which passes back any { stdout, stderr } to the error thrown.
  *
- * Options can be passed to the underlying spawn. An additional `signal option
+ * Options can be passed to the underlying spawn. An additional `signal` option
  * can be passed to use AbortController, allowing processes to be killed when
  * no longer needed.
  *

--- a/packages/gasket-utils/lib/run-shell-command.js
+++ b/packages/gasket-utils/lib/run-shell-command.js
@@ -38,11 +38,11 @@ const spawn = require('cross-spawn');
  * @returns {Promise} A promise represents if npm succeeds or fails.
  * @public
  */
-function runShellCommand(cmd, argv, options, debug) {
+function runShellCommand(cmd, argv, options = {}, debug = false) {
   const { signal, ...opts } = options;
 
   if (signal && signal.aborted) {
-    return Promise.reject(new Error(`${ cmd } was aborted before spawn`, { argv, aborted: true }));
+    return Promise.reject(Object.assign(new Error(`${ cmd } was aborted before spawn`), { argv, aborted: true }));
   }
 
   return new Promise((resolve, reject) => {

--- a/packages/gasket-utils/lib/run-shell-command.js
+++ b/packages/gasket-utils/lib/run-shell-command.js
@@ -5,6 +5,10 @@ const spawn = require('cross-spawn');
  * Promise friendly wrapper to running a shell command (eg: git, npm, ls)
  * which passes back any { stdout, stderr } to the error thrown.
  *
+ * Options can be passed to the underlying spawn. An additional `signal option
+ * can be passed to use AbortController, allowing processes to be killed when
+ * no longer needed.
+ *
  * @example
  * const { runShellCommand } = require('@gasket/utils');
  *
@@ -12,16 +16,37 @@ const spawn = require('cross-spawn');
  *   await runShellCommand('echo', ['hello world']);
  * }
  *
+ * @example
+ * // With timeout using AbortController
+ *
+ * const { runShellCommand } = require('@gasket/utils');
+ * const AbortController = require('abort-controller');
+ *
+ *  async function helloWorld() {
+ *   const controller = new AbortController();
+ *   // abort the process after 60 seconds
+ *   const id = setTimeout(() => controller.abort(), 60000);
+ *   await runShellCommand('long-process', ['something'], { signal: controller.signal });
+ *   clearTimeout(id);
+ * }
+ *
  * @param {string} cmd binary that is run
- * @param {array} argv args passed to npm binary through spawn.
- * @param {object} options options passed to npm binary through spawn
+ * @param {array} argv args passed to npm binary through spawn.
+ * @param {object} options options passed to npm binary through spawn
+ * @param {object} [options.signal] AbortControl signal allowing process to be canceled
  * @param {boolean} [debug] When present pipes std{out,err} to process.*
  * @returns {Promise} A promise represents if npm succeeds or fails.
  * @public
  */
 function runShellCommand(cmd, argv, options, debug) {
+  const { signal, ...opts } = options;
+
+  if (signal && signal.aborted) {
+    return Promise.reject(new Error(`${ cmd } was aborted before spawn`, { argv, aborted: true }));
+  }
+
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, argv, options);
+    const child = spawn(cmd, argv, opts);
 
     let stderr;
     let stdout;
@@ -39,12 +64,22 @@ function runShellCommand(cmd, argv, options, debug) {
       child.stdout.pipe(process.stdout);
     }
 
+    let aborted = false;
+    if (signal) {
+      signal.addEventListener('abort', () => {
+        aborted = true;
+        child.kill();
+      });
+    }
+
     child.on('close', code => {
       if (code !== 0) {
-        return reject(Object.assign(new Error(`${cmd} exited with non-zero code`), {
+        return reject(Object.assign(new Error(`${ cmd } exited with non-zero code`), {
           argv,
           stdout,
-          stderr
+          stderr,
+          aborted,
+          code
         }));
       }
 

--- a/packages/gasket-utils/lib/run-shell-command.js
+++ b/packages/gasket-utils/lib/run-shell-command.js
@@ -35,7 +35,7 @@ const spawn = require('cross-spawn');
  * @param {object} options options passed to npm binary through spawn
  * @param {object} [options.signal] AbortControl signal allowing process to be canceled
  * @param {boolean} [debug] When present pipes std{out,err} to process.*
- * @returns {Promise} A promise represents if npm succeeds or fails.
+ * @returns {Promise} A promise represents if command succeeds or fails.
  * @public
  */
 function runShellCommand(cmd, argv, options = {}, debug = false) {

--- a/packages/gasket-utils/package.json
+++ b/packages/gasket-utils/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@godaddy/dmd": "^1.0.0",
+    "abort-controller": "^3.0.0",
     "assume": "^2.3.0",
     "assume-sinon": "^1.1.0",
     "eslint": "^8.7.0",

--- a/packages/gasket-utils/test/fixtures/test-script.js
+++ b/packages/gasket-utils/test/fixtures/test-script.js
@@ -1,0 +1,18 @@
+const pause = ms => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+async function main(argv) {
+  const [, , fail = 'false', timeout = 10] = argv;
+  console.log(`waiting for ${ timeout }ms...`);
+  console.log();
+  await pause(timeout);
+
+  if (fail === 'true') {
+    console.error('fail');
+    process.exit(1);
+  }
+  console.log('success');
+}
+
+main(process.argv);

--- a/packages/gasket-utils/test/run-shell-command.test.js
+++ b/packages/gasket-utils/test/run-shell-command.test.js
@@ -1,0 +1,112 @@
+const assume = require('assume');
+const AbortController = require('abort-controller');
+const runShellCommand = require('../lib/run-shell-command');
+
+const cwd = __dirname;
+const failMode = true;
+
+const pause = ms => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+describe('runShellCommand', function () {
+  it('returns a promise', async function () {
+    const promise = runShellCommand('node', ['./fixtures/test-script.js'], { cwd });
+    assume(promise).is.instanceof(Promise);
+  });
+
+  it('resolves object with stdout', async function () {
+    const results = await runShellCommand('node', ['./fixtures/test-script.js'], { cwd });
+    assume(results).is.instanceof(Object);
+    assume(results).property('stdout');
+    assume(results.stdout).includes('waiting');
+    assume(results.stdout).includes('success');
+  });
+
+  it('rejects for non-zero exits', async function () {
+    const promise = runShellCommand('node', ['./fixtures/test-script.js', failMode], { cwd });
+    await assume(promise).throwsAsync();
+  });
+
+  it('rejects with details object', async function () {
+    try {
+      await runShellCommand('node', ['./fixtures/test-script.js', failMode], { cwd });
+    } catch (err) {
+      assume(err).is.instanceof(Object);
+      assume(err).property('message');
+      assume(err.message).includes('exited with non-zero code');
+
+      assume(err).property('argv');
+      assume(err).property('stdout');
+      assume(err.stdout).includes('waiting');
+
+      assume(err).property('stderr');
+      assume(err.stderr).includes('fail');
+
+      assume(err).property('code', 1);
+      assume(err).property('aborted', false);
+    }
+  });
+
+  describe('with AbortController', function () {
+    let controller, signal;
+    beforeEach(function () {
+      controller = new AbortController();
+      signal = controller.signal;
+    });
+
+    it('returns a promise', async function () {
+      const promise = runShellCommand('node', ['./fixtures/test-script.js'], { cwd, signal });
+      await assume(promise).not.throwsAsync();
+    });
+
+    it('early abort rejects before run', async function () {
+      controller.abort();
+      const promise = runShellCommand('node', ['./fixtures/test-script.js'], { cwd, signal });
+      await assume(promise).throwsAsync();
+    });
+
+    it('early abort rejects with details object', async function () {
+      controller.abort();
+      try {
+        await runShellCommand('node', ['./fixtures/test-script.js'], { cwd, signal });
+      } catch (err) {
+        assume(err).is.instanceof(Object);
+        assume(err).property('message');
+        assume(err.message).includes('aborted');
+
+        assume(err).property('argv');
+        assume(err).not.property('stdout');
+        assume(err).not.property('stderr');
+        assume(err).property('aborted', true);
+      }
+    });
+
+    it('abort rejects after run', async function () {
+      const promise = runShellCommand('node', ['./fixtures/test-script.js', !failMode, 100], { cwd, signal });
+      await pause(10);
+      controller.abort();
+      await assume(promise).throwsAsync();
+    });
+
+    it('abort rejects with details object', async function () {
+      try {
+        const promise = runShellCommand('node', ['./fixtures/test-script.js', !failMode, 100], { cwd, signal });
+        await pause(10);
+        controller.abort();
+        await promise;
+      } catch (err) {
+        assume(err).is.instanceof(Object);
+        assume(err).property('message');
+        assume(err.message).includes('exited with non-zero code');
+
+        assume(err).property('argv');
+        assume(err).property('stdout');
+        assume(err).property('stderr');
+        assume(err).property('code');
+
+        assume(err).property('aborted', true);
+      }
+    }, 'early abort rejects with details object');
+  });
+});


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

For cases where you need to timeout or otherwise close processes started with the `runShellCommand` utility function, this allows an AbortController `signal` option.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/utils**
- Support for AbortController with runShellCommand 

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Tested locally in canary-app
- ~Unit/integration tests for `runShellCommand` are currently absent. I'll will add some before moving PR out of draft.~ Added unit tests