### PR TITLE
Handle missing package export

### DIFF
--- a/packages/gasket-resolve/lib/resolver.js
+++ b/packages/gasket-resolve/lib/resolver.js
@@ -56,10 +56,11 @@ class Resolver {
       debug('try-resolve', moduleName);
       return this.resolve(moduleName);
     } catch (err) {
-      if (err.code === 'MODULE_NOT_FOUND'
-        && err.message.includes(moduleName)) return null;
-
       debug('try-resolve error', err.message);
+      if (err.code === 'MODULE_NOT_FOUND' && err.message.includes(moduleName) ||
+        err.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+      ) return null;
+
       throw err;
     }
   }
@@ -75,10 +76,11 @@ class Resolver {
       debug('try-require', moduleName);
       return this.require(moduleName);
     } catch (err) {
-      if (err.code === 'MODULE_NOT_FOUND'
-        && err.message.includes(moduleName)) return null;
-
       debug('try-require error', err.message);
+      if (err.code === 'MODULE_NOT_FOUND' && err.message.includes(moduleName) ||
+        err.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+      ) return null;
+
       throw err;
     }
   }

--- a/packages/gasket-resolve/test/loader.test.js
+++ b/packages/gasket-resolve/test/loader.test.js
@@ -143,6 +143,13 @@ describe('Loader', () => {
       expect(results).not.toHaveProperty('path');
       expect(results).not.toHaveProperty('version');
     });
+
+    it('ignores package info if package.json not exported', () => {
+      const results = loader.getModuleInfo(null, 'no-exported', { extra: true });
+      expect(results).not.toHaveProperty('package');
+      expect(results).not.toHaveProperty('path');
+      expect(results).not.toHaveProperty('version');
+    });
   });
 
   describe('.loadModule', () => {

--- a/packages/gasket-resolve/test/resolver.test.js
+++ b/packages/gasket-resolve/test/resolver.test.js
@@ -74,6 +74,11 @@ describe('Resolver', () => {
       expect(() => resolver.resolve('missing')).toThrow(/Cannot find module/);
     });
 
+    it('throws if package.json not exported', () => {
+      const resolver = new Resolver({ require: mockRequire });
+      expect(() => resolver.resolve('no-exported/package.json')).toThrow(/Package subpath '\.\/package.json' is not defined by "exports"/);
+    });
+
     it('uses resolver file require by default', () => {
       const resolver = new Resolver();
       expect(() => resolver.resolve('missing')).toThrow(/from 'lib\/resolver.js'/);
@@ -120,6 +125,11 @@ describe('Resolver', () => {
       expect(() => resolver.require('missing')).toThrow(/Cannot find module/);
     });
 
+    it('throws if package.json not exported', () => {
+      const resolver = new Resolver({ require: mockRequire });
+      expect(() => resolver.require('no-exported/package.json')).toThrow(/Package subpath '\.\/package.json' is not defined by "exports"/);
+    });
+
     it('throws if module malformed', () => {
       const resolver = new Resolver({ require: mockRequire });
       expect(() => resolver.require('broken')).toThrow();
@@ -144,6 +154,11 @@ describe('Resolver', () => {
       const resolver = new Resolver();
       expect(() => resolver.tryResolve('missing')).not.toThrow();
     });
+
+    it('does not throw if package.json not exported', () => {
+      const resolver = new Resolver({ require: mockRequire });
+      expect(() => resolver.tryResolve('no-exported/package.json')).not.toThrow();
+    });
   });
 
   describe('.tryRequire', () => {
@@ -163,6 +178,11 @@ describe('Resolver', () => {
     it('does not throw if module not found', () => {
       const resolver = new Resolver();
       expect(() => resolver.tryRequire('missing')).not.toThrow();
+    });
+
+    it('does not throw if package.json not exported', () => {
+      const resolver = new Resolver({ require: mockRequire });
+      expect(() => resolver.tryRequire('no-exported/package.json')).not.toThrow();
     });
 
     it('does throw if module has problems', () => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Some packages are beginning to use the exports field but leaving out the export path for `./package.json`. This would unnecessarily blow up the metadata plugin. Although ideally packages export this, it is not critical and shouldn't block builds.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/resolve**
- tryRequire and tryResolve ignore missing exports errors

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Added unit tests
- local canary-app testing