### PR TITLE
Fix to not polyfill intl for node >= 14

### DIFF
--- a/packages/gasket-plugin-intl/lib/init.js
+++ b/packages/gasket-plugin-intl/lib/init.js
@@ -1,9 +1,15 @@
 /**
- * For SSR, the node we need to polyfill Intl to make sure all locale data is available.
- * For the browser, this should be polyfilled matching app requirements.
- *
+ * For SSR with Node < 14, we must polyfill Intl to make sure all locale data is
+ * available. For the browser, this may need polyfilled matching app requirements.
  * @see: https://techoverflow.net/2018/09/19/fixing-nodejs-intl-datetimeformat-not-formatting-properly-for-locales/
+ *
+ * For Node >= 14, full-icu is supported, so we avoid the polyfill
+ * @see: https://formatjs.io/docs/guides/runtime-requirements/#nodejs
  */
 module.exports = function initHook() {
-  global.Intl = require('intl');
+  const semver = require('semver');
+  const current = semver.coerce(process.version).version;
+  if (!semver.satisfies(current, '>=14')) {
+    global.Intl = require('intl');
+  }
 };

--- a/packages/gasket-plugin-intl/package.json
+++ b/packages/gasket-plugin-intl/package.json
@@ -41,6 +41,7 @@
     "intl": "^1.2.5",
     "loader-utils": "^1.1.0",
     "lodash.merge": "^4.6.0",
+    "semver": "^7.3.4",
     "serve-static": "^1.14.1",
     "url-join": "^4.0.0"
   },

--- a/packages/gasket-plugin-intl/test/init.test.js
+++ b/packages/gasket-plugin-intl/test/init.test.js
@@ -1,18 +1,54 @@
 const assume = require('assume');
+const sinon = require('sinon');
 const init = require('../lib/init');
 
 const intlPolyfill = require('intl');
 const intlDefault = global.Intl;
 
 describe('init', function () {
+  let versionStub;
+
+  beforeEach(function () {
+    versionStub = sinon.stub(process, 'version');
+  });
 
   afterEach(function () {
     global.Intl = intlDefault;
+    sinon.restore();
   });
 
-  it('polyfills Intl', function () {
+  it('polyfills Intl for Node@10', function () {
     assume(global.Intl).equals(intlDefault);
+    versionStub.get(() => 'v10.0.0');
     init();
     assume(global.Intl).equals(intlPolyfill);
+  });
+
+  it('polyfills Intl for Node@12', function () {
+    assume(global.Intl).equals(intlDefault);
+    versionStub.get(() => 'v12.0.0');
+    init();
+    assume(global.Intl).equals(intlPolyfill);
+  });
+
+  it('does NOT polyfill Intl for Node@14', function () {
+    assume(global.Intl).equals(intlDefault);
+    versionStub.get(() => 'v14.0.0');
+    init();
+    assume(global.Intl).equals(intlDefault);
+  });
+
+  it('does NOT polyfill Intl for Node@16', function () {
+    assume(global.Intl).equals(intlDefault);
+    versionStub.get(() => 'v16.0.0');
+    init();
+    assume(global.Intl).equals(intlDefault);
+  });
+
+  it('does NOT polyfill Intl for Node@18', function () {
+    assume(global.Intl).equals(intlDefault);
+    versionStub.get(() => 'v18.0.0');
+    init();
+    assume(global.Intl).equals(intlDefault);
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

For Node >= 14, full-icu is supported, so we should avoid polyfilling `Intl` on these versions which can cause issues in some situations. https://formatjs.io/docs/guides/runtime-requirements/#nodejs

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/plugin-intl**
- Fix to not polyfill intl for node >= 14

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Added unit tests
- local canary-app testing