### PR TITLE
Fix glob paths after lib move

### DIFF
--- a/packages/create-gasket-app/lib/index.js
+++ b/packages/create-gasket-app/lib/index.js
@@ -7,7 +7,7 @@ const [, , ...args] = process.argv;
 
 function main() {
   return fork(
-    path.join(__dirname, 'node_modules', '.bin', 'gasket'),
+    path.join(__dirname, '..', 'node_modules', '.bin', 'gasket'),
     ['create', ...args],
     { stdio: 'inherit', stdin: 'inherit', stderr: 'inherit' }
   );

--- a/packages/gasket-plugin-express/lib/index.js
+++ b/packages/gasket-plugin-express/lib/index.js
@@ -15,12 +15,14 @@ module.exports = {
      * @public
      */
     create: async function create(gasket, context) {
+      const generatorDir = `${ __dirname }/../generator`;
+
       context.pkg.add('dependencies', {
         express: devDependencies.express
       });
 
       if (context.apiApp) {
-        context.files.add(`${ __dirname }/generator/**/*`);
+        context.files.add(`${ generatorDir }/**/*`);
 
         context.gasketConfig.add('express', {
           routes: './routes/*'

--- a/packages/gasket-plugin-jest/lib/index.js
+++ b/packages/gasket-plugin-jest/lib/index.js
@@ -9,7 +9,7 @@ module.exports = {
         before: ['@gasket/plugin-lint']
       },
       handler: async function create(gasket, { files, pkg }) {
-        const path = require('path');
+        const generatorDir = `${ __dirname }/../generator`;
         const isReactProject = pkg.has('dependencies', 'react');
 
         pkg.add('devDependencies', {
@@ -18,8 +18,8 @@ module.exports = {
 
         if (isReactProject) {
           files.add(
-            path.join(__dirname, '..', 'generator', '*'),
-            path.join(__dirname, '..', 'generator', '**', '*')
+            `${generatorDir}/*`,
+            `${generatorDir}/**/*`
           );
 
           pkg.add('devDependencies', {

--- a/packages/gasket-plugin-jest/test/index.test.js
+++ b/packages/gasket-plugin-jest/test/index.test.js
@@ -1,7 +1,6 @@
 const self = require('../package.json');
 const plugin = require('../lib/index.js');
 const config = require('../generator/jest.config.js');
-const path = require('path');
 
 describe('Plugin', function () {
   async function create() {
@@ -87,7 +86,8 @@ describe('Plugin', function () {
     it('includes a glob for the `generator/jest.config.js` contents for react projects', async function () {
       const { files } = await createReact();
 
-      expect(files[1]).toEqual(path.join(__dirname, '..', 'generator', '**', '*'));
+      expect(files[0]).toContain('/../generator/*');
+      expect(files[1]).toContain('/../generator/**/*');
     });
 
     describe('adds react specific dependencies', function () {

--- a/packages/gasket-plugin-mocha/lib/index.js
+++ b/packages/gasket-plugin-mocha/lib/index.js
@@ -10,7 +10,7 @@ module.exports = {
       },
       handler: async function create(gasket, { files, pkg, packageManager = 'npm' }) {
         const runCmd = packageManager === 'npm' ? `npm run` : packageManager;
-        const path = require('path');
+        const generatorDir = `${ __dirname }/../generator`;
         const isReactProject = pkg.has('dependencies', 'react');
         const isNextProject = pkg.has('dependencies', 'next');
 
@@ -33,8 +33,8 @@ module.exports = {
 
         if (isReactProject) {
           files.add(
-            path.join(__dirname, 'generator', '*'),
-            path.join(__dirname, 'generator', '**', '*')
+            `${generatorDir}/*`,
+            `${generatorDir}/**/*`
           );
 
           pkg.add('devDependencies', {

--- a/packages/gasket-plugin-mocha/test/index.test.js
+++ b/packages/gasket-plugin-mocha/test/index.test.js
@@ -8,14 +8,15 @@ const sinon = require('sinon');
 chai.use(spies);
 
 describe('Plugin', () => {
-  let spyFunc;
+  let spyFunc, filesAddStub;
 
   async function create() {
     const pkg = {};
+    filesAddStub = sinon.stub();
 
     await plugin.hooks.create.handler({}, {
       files: {
-        add: sinon.stub()
+        add: filesAddStub
       },
       pkg: {
         add: (key, value) => {
@@ -37,7 +38,7 @@ describe('Plugin', () => {
 
     await plugin.hooks.create.handler({}, {
       files: {
-        add: sinon.stub()
+        add: filesAddStub
       },
       pkg: {
         add: (key, value) => {
@@ -123,6 +124,14 @@ describe('Plugin', () => {
   });
 
   describe('dependencies - react', function () {
+    it('includes a glob for generator contents', async function () {
+      await createReact();
+
+      const [firstCall, secondCall] = filesAddStub.args[0];
+      expect(firstCall).includes('/../generator/*');
+      expect(secondCall).includes('/../generator/**/*');
+    });
+
     [
       'global-jsdom',
       '@testing-library/react',

--- a/packages/gasket-plugin-nextjs/lib/index.js
+++ b/packages/gasket-plugin-nextjs/lib/index.js
@@ -56,18 +56,19 @@ module.exports = {
        */
       handler: function create(gasket, context) {
         const { files, pkg, testPlugin } = context;
+        const generatorDir = `${ __dirname }/../generator`;
 
         files.add(
-          `${__dirname}/generator/app/.*`,
-          `${__dirname}/generator/app/*`,
-          `${__dirname}/generator/app/**/*`
+          `${ generatorDir }/app/.*`,
+          `${ generatorDir }/app/*`,
+          `${ generatorDir }/app/**/*`
         );
 
         ['jest', 'mocha'].forEach(tester => {
-          if (testPlugin && pluginIdentifier(testPlugin).longName === `@gasket/plugin-${tester}`) {
+          if (testPlugin && pluginIdentifier(testPlugin).longName === `@gasket/plugin-${ tester }`) {
             files.add(
-              `${__dirname}/generator/${tester}/*`,
-              `${__dirname}/generator/${tester}/**/*`
+              `${ generatorDir }/${ tester }/*`,
+              `${ generatorDir }/${ tester }/**/*`
             );
           }
         });
@@ -88,8 +89,8 @@ module.exports = {
           });
 
           files.add(
-            `${__dirname}/generator/redux/*`,
-            `${__dirname}/generator/redux/**/*`
+            `${ generatorDir }/redux/*`,
+            `${ generatorDir }/redux/**/*`
           );
         }
       }
@@ -154,11 +155,11 @@ module.exports = {
       return await builder(path.resolve('.'), await createConfig(gasket, true));
     },
     /**
-    * Workbox config partial to add next.js static assets to precache
-    *
-    * @param {Gasket} gasket The gasket API.
-    * @returns {Object} config
-    */
+     * Workbox config partial to add next.js static assets to precache
+     *
+     * @param {Gasket} gasket The gasket API.
+     * @returns {Object} config
+     */
     workbox: function (gasket) {
       const { nextConfig = {}, basePath: rootBasePath } = gasket.config;
       const assetPrefix = [nextConfig.assetPrefix, nextConfig.basePath, rootBasePath, ''].find(isDefined);

--- a/packages/gasket-plugin-nextjs/test/index.test.js
+++ b/packages/gasket-plugin-nextjs/test/index.test.js
@@ -205,9 +205,9 @@ describe('create hook', () => {
     await plugin.hooks.create.handler({}, mockContext);
 
     assume(mockContext.files.add).calledWith(
-      `${root}/generator/app/.*`,
-      `${root}/generator/app/*`,
-      `${root}/generator/app/**/*`
+      `${root}/../generator/app/.*`,
+      `${root}/../generator/app/*`,
+      `${root}/../generator/app/**/*`
     );
   });
 
@@ -216,8 +216,8 @@ describe('create hook', () => {
     await plugin.hooks.create.handler({}, mockContext);
 
     assume(mockContext.files.add).calledWith(
-      `${root}/generator/mocha/*`,
-      `${root}/generator/mocha/**/*`
+      `${root}/../generator/mocha/*`,
+      `${root}/../generator/mocha/**/*`
     );
   });
 
@@ -226,8 +226,8 @@ describe('create hook', () => {
     await plugin.hooks.create.handler({}, mockContext);
 
     assume(mockContext.files.add).calledWith(
-      `${root}/generator/jest/*`,
-      `${root}/generator/jest/**/*`
+      `${root}/../generator/jest/*`,
+      `${root}/../generator/jest/**/*`
     );
   });
 
@@ -249,8 +249,8 @@ describe('create hook', () => {
     await plugin.hooks.create.handler({}, mockContext);
 
     assume(mockContext.files.add).calledWith(
-      `${root}/generator/redux/*`,
-      `${root}/generator/redux/**/*`
+      `${root}/../generator/redux/*`,
+      `${root}/../generator/redux/**/*`
     );
   });
 

--- a/packages/gasket-plugin-redux/lib/index.js
+++ b/packages/gasket-plugin-redux/lib/index.js
@@ -19,6 +19,7 @@ module.exports = {
     prompt,
     async create(gasket, context) {
       const { pkg, files } = context;
+      const generatorDir = `${ __dirname }/../generator`;
 
       pkg.add('dependencies', {
         '@gasket/redux': devDependencies['@gasket/redux'],
@@ -27,8 +28,8 @@ module.exports = {
       });
 
       files.add(
-        `${ __dirname }/../generator/*`,
-        `${ __dirname }/../generator/**/*`
+        `${ generatorDir }/*`,
+        `${ generatorDir }/**/*`
       );
 
       context.hasGasketRedux = true;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Some expected files were not being generated during create. This is because the glob path need to be update after some code was aligned to exist under `./lib`.

## Changelog

**create-gasket-app**
- Update relative path from __dirname

**@gasket/plugin-express**
- Update glob path from __dirname

**@gasket/plugin-jest**
- Update glob path from __dirname

**@gasket/plugin-mocha**
- Update glob path from __dirname

**@gasket/plugin-nextjs**
- Update glob path from __dirname

**@gasket/plugin-redux**
- Align glob path pattern

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
- Updated unit tests
- Create gasket app with local plugin changes