### PR TITLE
Use eslint from config, not react intl addon

### DIFF
--- a/packages/gasket-plugin-lint/lib/code-styles.js
+++ b/packages/gasket-plugin-lint/lib/code-styles.js
@@ -42,7 +42,6 @@ const godaddy = {
     pkg.add('eslintConfig', { extends: [configName] });
 
     if (hasReactIntl) {
-      pkg.add('devDependencies', (await gatherDevDeps('@godaddy/eslint-plugin-react-intl')));
       pkg.add('eslintConfig', {
         extends: ['plugin:@godaddy/react-intl/recommended'],
         settings: {

--- a/packages/gasket-plugin-lint/test/code-styles.test.js
+++ b/packages/gasket-plugin-lint/test/code-styles.test.js
@@ -89,9 +89,6 @@ describe('code styles', () => {
       pkgHas.callsFake((_, name) => ['react-intl'].includes(name));
       await codeStyle.create(context, utils);
 
-      assume(pkgAdd).calledWithMatch('devDependencies', {
-        '@godaddy/eslint-plugin-react-intl': sinon.match.string
-      });
       assume(pkgAdd).calledWithMatch('eslintConfig', {
         extends: ['plugin:@godaddy/react-intl/recommended'],
         settings: {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

We were unnecessarily setting the eslint version for GoDaddy configs from the `eslint-plugin-react-intl`. Now the preferred eslint version will always come from the main GoDaddy config.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/plugin-lint**
- For GoDaddy code style, always use eslint version from main config

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Updated unit tests