### PR TITLE
Fix missing dev dep

### DIFF
--- a/packages/gasket-plugin-lint/lib/code-styles.js
+++ b/packages/gasket-plugin-lint/lib/code-styles.js
@@ -42,6 +42,12 @@ const godaddy = {
     pkg.add('eslintConfig', { extends: [configName] });
 
     if (hasReactIntl) {
+      const pluginName = '@godaddy/eslint-plugin-react-intl';
+      const deps = await gatherDevDeps(pluginName);
+      // only add the plugin to avoid stomping config version
+      pkg.add('devDependencies', {
+        [pluginName]: deps[pluginName]
+      });
       pkg.add('eslintConfig', {
         extends: ['plugin:@godaddy/react-intl/recommended'],
         settings: {

--- a/packages/gasket-plugin-lint/test/code-styles.test.js
+++ b/packages/gasket-plugin-lint/test/code-styles.test.js
@@ -89,6 +89,9 @@ describe('code styles', () => {
       pkgHas.callsFake((_, name) => ['react-intl'].includes(name));
       await codeStyle.create(context, utils);
 
+      assume(pkgAdd).calledWithMatch('devDependencies', {
+        '@godaddy/eslint-plugin-react-intl': sinon.match.string
+      });
       assume(pkgAdd).calledWithMatch('eslintConfig', {
         extends: ['plugin:@godaddy/react-intl/recommended'],
         settings: {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

I overlooked in https://github.com/godaddy/gasket/pull/341 that we still need to call `gatherDevDeps` to get the current plugin version. This restores that but avoids stomping over config version.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/plugin-lint**
- Fix to include `eslint-plugin-react-intl` as devDependency

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Update unit test
- Local testing