### PR TITLE
Allow differing callbacks for execApply and execApplySync

### DIFF
--- a/packages/gasket-engine/lib/engine.js
+++ b/packages/gasket-engine/lib/engine.js
@@ -349,7 +349,6 @@ class PluginEngine {
    */
   execApply(event, applyFn) {
     return this._execWithCachedPlan({
-      cachePlan: false,
       event,
       type: 'execApply',
       prepare: (hookConfig, trace) => {

--- a/packages/gasket-engine/lib/engine.js
+++ b/packages/gasket-engine/lib/engine.js
@@ -349,6 +349,7 @@ class PluginEngine {
    */
   execApply(event, applyFn) {
     return this._execWithCachedPlan({
+      cachePlan: false,
       event,
       type: 'execApply',
       prepare: (hookConfig, trace) => {
@@ -387,6 +388,7 @@ class PluginEngine {
    */
   execApplySync(event, applyFn) {
     return this._execWithCachedPlan({
+      cachePlan: false,
       event,
       type: 'execApplySync',
       prepare: (hookConfig, trace) => {
@@ -413,7 +415,7 @@ class PluginEngine {
    * @param {Object} options options
    * @returns {*} result
    */
-  _execWithCachedPlan({ event, type, prepare, exec }) {
+  _execWithCachedPlan({ event, type, prepare, exec, cachePlan = true }) {
     debug(`${'  '.repeat(this._traceDepth++)}${type} ${event}`);
     const traceDepth = this._traceDepth;
     const trace = plugin => debug(`${'  '.repeat(traceDepth)}${plugin}:${event}`);
@@ -422,9 +424,8 @@ class PluginEngine {
     const plansByType = this._plans[event] || (
       this._plans[event] = {}
     );
-    const plan = plansByType[type] || (
-      plansByType[type] = prepare(hookConfig, trace)
-    );
+    const plan = (cachePlan && plansByType[type]) ||
+      (plansByType[type] = prepare(hookConfig, trace));
 
     const result = exec(plan);
     if (result.finally) {

--- a/packages/gasket-engine/test/exec-apply-sync.test.js
+++ b/packages/gasket-engine/test/exec-apply-sync.test.js
@@ -117,4 +117,15 @@ describe('The execApplySync method', () => {
     expect(result[1].plugin).toEqual(pluginB);
     expect(result[2].plugin).toEqual(pluginC);
   });
+
+  it('can be executed with differing callbacks', async () => {
+    const stub1 = jest.fn().mockImplementation((plugin, handler) => handler())
+    const stub2 = jest.fn().mockImplementation((plugin, handler) => handler())
+
+    engine.execApplySync('eventA', stub1);
+    engine.execApplySync('eventA', stub2);
+
+    expect(stub1).toHaveBeenCalledTimes(3);
+    expect(stub2).toHaveBeenCalledTimes(3);
+  });
 });

--- a/packages/gasket-engine/test/exec-apply.test.js
+++ b/packages/gasket-engine/test/exec-apply.test.js
@@ -117,4 +117,15 @@ describe('The execApply method', () => {
     expect(result[1].plugin).toEqual(pluginB);
     expect(result[2].plugin).toEqual(pluginC);
   });
+
+  it('can be executed with differing callbacks', async () => {
+    const stub1 = jest.fn().mockImplementation((plugin, handler) => handler())
+    const stub2 = jest.fn().mockImplementation((plugin, handler) => handler())
+
+    await engine.execApply('eventA', stub1);
+    await engine.execApply('eventA', stub2);
+
+    expect(stub1).toHaveBeenCalledTimes(3);
+    expect(stub2).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Repeated executions of the same lifecycle name, when using `execApply` and `execApplySync` resulted in only the first supplied callback being used in subsequent runs.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/engine**
- Allow differing callbacks for execApply and execApplySync

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Updated unit tests