### PR TITLE
Deprecating webpack-merge smart approaches

### DIFF
--- a/packages/gasket-plugin-webpack/README.md
+++ b/packages/gasket-plugin-webpack/README.md
@@ -30,7 +30,7 @@ module.exports = {
 
 ## Configuration
 
-The webpack plugin is configured using the `gasket.config.js` file.
+The Webpack plugin is configured using the `gasket.config.js` file.
 
 First, add it to the `plugins` section of your `gasket.config.js`:
 
@@ -42,33 +42,18 @@ module.exports = {
 }
 ```
 
-You can optionally define a specific user webpack config using the `webpack`
-property. This configuration will be [smartly merged] into the application's
-current `webpack` configuration.
-
-```js
-module.exports = {
-  plugins: {
-    add: ['@gasket/plugin-webpack']
-  },
-  webpack: {
-    performance: {
-      maxAssetSize: 20000
-    }
-  }
-};
-```
-
-This config can be further modified by interacting with the [`webpackConfig`](#webpackConfig)
-lifecycle.
+If your app was previously using the `webpack` property in the
+`gasket.config.js`, then you should take steps [migrating to webpackConfig]
+lifecycle.  
 
 ## API
 
-`webpack` exposes an init function called `initWebpack`.
+The package exposes an init function called `initWebpack` which can be used by
+plugins that need to gather Webpack configuration.
 
 ### initWebpack
 
-Use this to initialize the webpack lifecycles in a consuming plugin.
+Use this to initialize the Webpack lifecycles in a consuming plugin.
 
 ```js
 const { initWebpack } = require('@gasket/plugin-webpack');
@@ -85,66 +70,33 @@ const config = initWebpack(gasket, webpackConfig, data);
 
 ## Lifecycles
 
-### webpackChain
-
-DEPRECATED - we suggest using the [`webpackConfig`](#webpackConfig) lifecycle instead; this may be removed in a future version.
-
-Executed before the `webpack` lifecycle, allows you to easily create the initial
-webpack configuration using a chaining syntax that is provided by the
-`webpack-chain` library. The resulting configuration is then merged with:
-
-- WebPack configuration that is specified in the `gasket.config.js` as `webpack`
-  object.
-
-The result of this will be passed into the `webpack` hook as base configuration.
-
-### webpack
-
-DEPRECATED - we suggest using the [`webpackConfig`](#webpackConfig) lifecycle instead; this may be removed in a future version.
-
-Executed after `webpack-chain` lifecycle. It receives the full webpack config as
-first argument. It can be used to add additional configurations to webpack.
-
-```js
-const { DefinePlugin } = require('webpack');
-
-/**
- * @param {Gasket} gasket The gasket API
- * @param {Object} config webpack configuration
- * @return {Object} webpack config partial
- */
-function webpackHook(gasket, config) {
-  return {
-    plugins: [
-      new DefinePlugin({
-        MEANING_OF_LIFE: 42
-      })
-    ]
-  };
-}
-```
-
 ### webpackConfig
 
-Executed after `webpack-chain` and `webpack`, it receives four parameters:
+Executed with initial, it receives three parameters:
 
 1. The gasket API
 2. A webpack config object
 3. A context object with the following properties:
    * `webpack` - The webpack API.
-   * `webpackMerge` - The [`webpack-merge`](https://github.com/survivejs/webpack-merge/tree/v4.2.2) API, version 4.
+   * `webpackMerge` - _DEPRECATED - Use `require('webpack-merge')`._
+     Getter returns [webpack-merge v4] API.
    * `...additionalContext` - Additional context may be exposed. For example, in next.js apps, the [next.js webpack config options](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config) are included.
-   
 
-A hook should return a new webpack config object derived from the original. The usage of the `webpack-merge` API is recommended when doing so since properly handling the overloaded types within webpack config properties can be tricky. We recommend avoiding `webpack-merge` methods that have been deprecated in version 5 since a future version of this plugin may update to a new breaking version of `webpack-merge`.
+A hook should return a new Webpack config object derived from the original. The
+usage of [webpack-merge] is recommended when doing so since it can properly
+handle the overloaded types within Webpack config properties, which can be
+tricky.
 
+We recommend requiring [webpack-merge] as a dependency in your lifecycles,
+instead of using the instance on context which will be removed in a future
+version.
 
 ```js
-function webpackConfigHook(
-  gasket,
-  config,
-  { isServer, webpack, webpackMerge }
-) {
+const webpackMerge = require('webpack-merge');
+
+function webpackConfigHook( gasket, config, context) {
+  const { isServer, webpack } = context;
+  
   return isServer
     ? config
     : webpackMerge.merge(config, {
@@ -157,10 +109,88 @@ function webpackConfigHook(
 }
 ```
 
+### webpackChain
+
+_DEPRECATED - Use [`webpackConfig`](#webpackConfig) lifecycle instead._
+
+Executed before the `webpack` lifecycle, allows you to easily create the initial
+Webpack configuration using a chaining syntax that is provided by the
+`webpack-chain` library. The resulting configuration is then merged with:
+
+- WebPack configuration that is specified in the `gasket.config.js` as `webpack`
+  object.
+
+The result of this will be passed into the `webpack` hook as base configuration.
+
+### webpack
+
+_DEPRECATED - Use [`webpackConfig`](#webpackConfig) lifecycle instead._
+
+Executed after `webpack-chain` lifecycle. It receives the full Webpack config as
+first argument. It can be used to add additional configurations to Webpack.
+
+## Migrating to webpackConfig
+
+### From Gasket config
+
+If your app previously added Webpack configuration in the `gasket.config.js`,
+this feature is deprecated and you should migrate to using
+the [`webpackConfig`](#webpackConfig) lifecycle.
+
+For background, the `webpack` config is merged using an old deprecated "smart"
+method from [webpack-merge]. It is now recommended for apps and plugins to
+handle any merge strategies themselves in the `webpackConfig` lifecycle.
+
+So move from this setting `webpack` in the `gasket.config`:
+
+```diff
+// gasket.config.js
+module.exports = {
+  plugins: {
+    add: ['@gasket/plugin-webpack']
+  },
+-  webpack: {
+-    performance: {
+-      maxAssetSize: 20000
+-    }
+-  }
+};
+```
+
+to using the webpackConfig lifecycle to merge any custom Webpack config:
+
+```javascript
+// lifecycles/webpack-config.js
+const webpackMerge = require('webpack-merge');
+
+module.exports = function (gasket, webpackConfig, context) {
+  return webpackMerge.merge(webpackConfig, {
+    performance: {
+      maxAssetSize: 20000
+    }
+  })
+}
+```
+
+This gives apps the freedom to use whatever [merge strategies] makes sense
+for the custom webpack they want to configure.
+
+### From other lifecycles
+
+If you have plugins that were using either [webpackChain](#webpackchain)
+or [webpack](#webpack) lifecycles, these are now deprecated and will be removed
+in the next major release. Both of these lifecycles depended on the same
+deprecated "smart" method from [webpack-merge].
+
+Instead, handle any merging in the [webpackConfig](#webpackconfig), using
+whatever [merge strategies] are useful for the particular config being added.
+
 ## License
 
 [MIT](./LICENSE.md)
 
 <!-- LINKS -->
 
-[smartly merged]: https://github.com/survivejs/webpack-merge#smart-merging
+[webpack-merge v4]:https://github.com/survivejs/webpack-merge/tree/v4.2.2
+[webpack-merge]: https://github.com/survivejs/webpack-merge
+[merge strategies]: https://github.com/survivejs/webpack-merge#customizearray-and-customizeobject

--- a/packages/gasket-plugin-webpack/lib/deprecated-merges.js
+++ b/packages/gasket-plugin-webpack/lib/deprecated-merges.js
@@ -1,0 +1,42 @@
+/**
+ * Deprecated merging behavior
+ * TODO: Remove in next major release
+ *
+ * @param {Gasket} gasket - The Gasket API
+ * @param {object} initConfig - Initial webpack config
+ * @param {object} context - Additional context-specific information
+ * @returns {object} mergedConfig
+ */
+module.exports = function deprecatedMerges(gasket, initConfig, context) {
+  const { logger, execApplySync, config } = gasket;
+  const WebpackChain = require('webpack-chain');
+  const { smart: deprecatedSmartMerge } = require('webpack-merge');
+
+  if ('webpack' in config) {
+    logger.warning(`DEPRECATED \`webpack\` in Gasket config - Prefer \`webpackConfig\` lifecycle. See _http://x.co/2wbpckCnfg`);
+  }
+
+  const chain = new WebpackChain();
+  execApplySync('webpackChain', (plugin, handler) => {
+    const name = plugin ? plugin.name || 'unnamed plugin' : 'app lifecycles';
+    logger.warning(`DEPRECATED \`webpackChain\` lifecycle in ${ name } - Use \`webpackConfig\`. See _http://x.co/2wbpckCnfg`);
+    return handler(chain, context);
+  });
+
+  const baseConfig = deprecatedSmartMerge(
+    initConfig,
+    chain.toConfig(),         // From webpackChain (partial)
+    config.webpack || {}      // From gasket config file (partial)
+  );
+
+  const configPartials = execApplySync('webpack', (plugin, handler) => {
+    const name = plugin ? plugin.name || 'unnamed plugin' : 'app lifecycles';
+    logger.warning(`DEPRECATED \`webpack\` lifecycle in ${ name } - Use \`webpackConfig\`. See _http://x.co/2wbpckCnfg`);
+    return handler(baseConfig, context);
+  });
+
+  return deprecatedSmartMerge(
+    baseConfig,
+    ...configPartials
+  );
+};

--- a/packages/gasket-plugin-webpack/lib/index.d.ts
+++ b/packages/gasket-plugin-webpack/lib/index.d.ts
@@ -3,12 +3,13 @@ import type WebpackApi from 'webpack';
 
 export interface WebpackContext {
   webpack: typeof WebpackApi,
+  /** @deprecated use require('webpack-merge') */
   webpackMerge: any
 }
 
 declare module '@gasket/engine' {
   export interface GasketConfig {
-    webpack?: any  // TODO: Use types when upgrading to next version of `webpack-merge`
+    webpack?: any
   }
 
   export interface HookExecTypes {

--- a/packages/gasket-plugin-webpack/lib/index.js
+++ b/packages/gasket-plugin-webpack/lib/index.js
@@ -1,44 +1,5 @@
 const { name, devDependencies } = require('../package');
-
-/**
-* Creates the webpack config
-* @param  {Gasket} gasket     The Gasket API
-* @param {Object} initConfig  Initial webpack config
-* @param {Object} context     Additional context-specific information
-* @returns {Object}           Final webpack config
-*/
-function initWebpack(gasket, initConfig, context) {
-  const webpack = require('webpack');
-  const WebpackChain = require('webpack-chain');
-  const webpackMerge = require('webpack-merge');
-  const WebpackMetricsPlugin = require('./webpack-metrics-plugin');
-
-  const { execSync, execWaterfallSync, config } = gasket;
-
-  const standardPlugins = { plugins: [new WebpackMetricsPlugin({ gasket })] };
-
-  const chain = new WebpackChain();
-  execSync('webpackChain', chain, context);
-
-  const baseConfig = webpackMerge.smart(
-    initConfig,
-    standardPlugins,
-    chain.toConfig(),         // From webpackChain (partial)
-    config.webpack || {}      // From gasket config file (partial)
-  );
-
-  const configPartials = execSync('webpack', baseConfig, context).filter(Boolean);
-  const mergedConfig = webpackMerge.smart(
-    baseConfig,
-    ...configPartials
-  );
-
-  return execWaterfallSync(
-    'webpackConfig',
-    mergedConfig,
-    { ...context, webpack, webpackMerge }
-  );
-}
+const initWebpack = require('./init-webpack');
 
 module.exports = {
   name,
@@ -58,13 +19,13 @@ module.exports = {
           link: 'docs/webpack.md'
         }],
         lifecycles: [{
-          name: 'webpackChain',
+          name: 'webpackChain (deprecated)',
           method: 'execSync',
           description: 'Setup webpack config by chaining',
           link: 'README.md#webpackChain',
           parent: 'initWebpack'
         }, {
-          name: 'webpack',
+          name: 'webpack (deprecated)',
           method: 'execSync',
           description: 'Modify webpack config with partials or by mutating',
           link: 'README.md#webpack',

--- a/packages/gasket-plugin-webpack/lib/init-webpack.js
+++ b/packages/gasket-plugin-webpack/lib/init-webpack.js
@@ -1,0 +1,51 @@
+/**
+ * Sets up a context object with special getters
+ *
+ * @param {Gasket} gasket - The Gasket API
+ * @param {object} context - Additional context-specific information
+ * @param {string} name - Plugin name
+ * @returns {object} context
+ */
+function setupContext(gasket, context, name) {
+  return {
+    ...context,
+    // TODO: Remove in next major version
+    get webpackMerge() {
+      gasket.logger.warning(`DEPRECATED \`context.webpackMerge\` of webpackConfig hook in ${ name } - Use \`require('webpack-merge')\``);
+      return require('webpack-merge');
+    },
+    get webpack() {
+      return require('webpack');
+    }
+  };
+}
+
+/**
+ * Creates the webpack config
+ * @param {Gasket} gasket - The Gasket API
+ * @param {object} initConfig - Initial webpack config
+ * @param {object} context - Additional context-specific information
+ * @returns {object} Final webpack config
+ */
+module.exports = function initWebpack(gasket, initConfig, context) {
+  const WebpackMetricsPlugin = require('./webpack-metrics-plugin');
+
+  const baseConfig = {
+    ...initConfig,
+    plugins: [
+      ...(initConfig.plugins ? initConfig.plugins : []),
+      new WebpackMetricsPlugin({ gasket })
+    ].filter(Boolean)
+  };
+
+  // TODO: Remove in next major version
+  let mergedConfig = require('./deprecated-merges')(gasket, baseConfig, context);
+
+  // eslint-disable-next-line no-sync
+  gasket.execApplySync('webpackConfig', (plugin, handler) => {
+    const name = plugin ? plugin.name || 'unnamed plugin' : 'app lifecycle';
+    mergedConfig = handler(mergedConfig, setupContext(gasket, context, name));
+  });
+
+  return mergedConfig;
+};

--- a/packages/gasket-plugin-webpack/package.json
+++ b/packages/gasket-plugin-webpack/package.json
@@ -14,6 +14,7 @@
     "test": "npm run test:runner",
     "test:runner": "mocha --require ./test/setup.js \"test/**/*.test.js\"",
     "test:coverage": "nyc --reporter=text --reporter=json-summary npm run test:runner",
+    "test:watch": "npm run test:runner -- --watch",
     "posttest": "npm run lint",
     "report": "nyc report --reporter=lcov"
   },
@@ -54,6 +55,7 @@
     "mocha": "^9.1.4",
     "mock-require": "^3.0.3",
     "nyc": "^15.1.0",
+    "proxyquire": "^2.1.3",
     "sinon": "^12.0.1",
     "webpack": "^5.21.2"
   },

--- a/packages/gasket-plugin-webpack/test/deprecated-merges.test.js
+++ b/packages/gasket-plugin-webpack/test/deprecated-merges.test.js
@@ -1,0 +1,123 @@
+const assume = require('assume');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+const deprecatedSmartMerge = require('webpack-merge').smart;
+
+describe('deprecatedMerges', function () {
+  let deprecatedMerges, smartStub, mockGasket, mockContext, mockConfig;
+  let mockChain, webpackChainCb, webpackCb;
+
+  beforeEach(function () {
+    mockChain = {
+      toConfig: sinon.stub().returns({})
+    };
+    mockGasket = {
+      execApplySync: sinon.stub().callsFake((name, callback) => {
+        if (name === 'webpackChain') {
+          webpackChainCb = callback;
+          return mockChain;
+        } else if (name === 'webpack') {
+          webpackCb = callback;
+          return [{}];
+        }
+      }),
+      logger: {
+        warning: sinon.stub()
+      },
+      config: {}
+    };
+    mockContext = {};
+    mockConfig = {};
+
+    smartStub = sinon.stub().callsFake(deprecatedSmartMerge);
+    deprecatedMerges = proxyquire('../lib/deprecated-merges', {
+      'webpack-merge': {
+        smart: smartStub
+      }
+    });
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('returns webpack config object', function () {
+    const results = deprecatedMerges(mockGasket, mockConfig, mockContext);
+    assume(results).is.an('object');
+  });
+
+  it('smart merges', function () {
+    deprecatedMerges(mockGasket, mockConfig, mockContext);
+    assume(smartStub).called();
+  });
+
+  describe('gasket.config.webpack', function () {
+
+    it('logs deprecated warning if set', function () {
+      mockGasket.config.webpack = {};
+      deprecatedMerges(mockGasket, mockConfig, mockContext);
+      assume(mockGasket.logger.warning).calledWithMatch(/DEPRECATED `webpack` in Gasket config/);
+    });
+
+    it('does not log warning if not set', function () {
+      deprecatedMerges(mockGasket, mockConfig, mockContext);
+      assume(mockGasket.logger.warning).not.called();
+    });
+  });
+
+  describe('webpackChain', function () {
+
+    beforeEach(function () {
+      deprecatedMerges(mockGasket, mockConfig, mockContext);
+    });
+
+    it('logs deprecated warning', function () {
+      webpackChainCb({ name: 'mock-plugin' }, sinon.stub());
+      assume(mockGasket.logger.warning).calledWithMatch(/DEPRECATED `webpackChain` lifecycle/);
+    });
+
+    it('logs plugin name', function () {
+      webpackChainCb({ name: 'mock-plugin' }, sinon.stub());
+      assume(mockGasket.logger.warning).calledWithMatch(/mock-plugin/);
+    });
+
+    it('logs unnamed plugin', function () {
+      webpackChainCb({}, sinon.stub());
+      assume(mockGasket.logger.warning).calledWithMatch(/unnamed plugin/);
+    });
+
+    it('logs app lifecycle', function () {
+      // eslint-disable-next-line no-undefined
+      webpackChainCb(undefined, sinon.stub());
+      assume(mockGasket.logger.warning).calledWithMatch(/app lifecycle/);
+    });
+  });
+
+  describe('webpack', function () {
+
+    beforeEach(function () {
+      deprecatedMerges(mockGasket, mockConfig, mockContext);
+    });
+
+    it('logs deprecated warning', function () {
+      webpackCb({ name: 'mock-plugin' }, sinon.stub());
+      assume(mockGasket.logger.warning).calledWithMatch(/DEPRECATED `webpack` lifecycle/);
+    });
+
+    it('logs plugin name', function () {
+      webpackCb({ name: 'mock-plugin' }, sinon.stub());
+      assume(mockGasket.logger.warning).calledWithMatch(/mock-plugin/);
+    });
+
+    it('logs unnamed plugin', function () {
+      webpackCb({}, sinon.stub());
+      assume(mockGasket.logger.warning).calledWithMatch(/unnamed plugin/);
+    });
+
+    it('logs app lifecycle', function () {
+      // eslint-disable-next-line no-undefined
+      webpackCb(undefined, sinon.stub());
+      assume(mockGasket.logger.warning).calledWithMatch(/app lifecycle/);
+    });
+  });
+});

--- a/packages/gasket-plugin-webpack/test/init-webpack.test.js
+++ b/packages/gasket-plugin-webpack/test/init-webpack.test.js
@@ -1,0 +1,115 @@
+/* eslint-disable no-sync */
+const assume = require('assume');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+const WebpackMetricsPlugin = require('../lib/webpack-metrics-plugin');
+
+
+describe('deprecated merges', function () {
+  let initWebpack, mockGasket, mockContext, mockConfig;
+
+  beforeEach(function () {
+    mockGasket = {
+      execApplySync: sinon.stub(),
+      logger: {
+        warning: sinon.stub()
+      }
+    };
+    mockContext = {};
+    mockConfig = {};
+
+    initWebpack = proxyquire('../lib/init-webpack', {
+      './deprecated-merges': sinon.stub().callsFake((_, config) => config)
+    });
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('returns webpack config object', function () {
+    const results = initWebpack(mockGasket, mockConfig, mockContext);
+    assume(results).is.an('object');
+  });
+
+  it('configures webpack metrics plugin', function () {
+    const results = initWebpack(mockGasket, mockConfig, mockContext);
+    assume(results).property('plugins');
+    assume(results.plugins[0]).instanceof(WebpackMetricsPlugin);
+  });
+
+  it('executes webpackConfig lifecycle', function () {
+    initWebpack(mockGasket, mockConfig, mockContext);
+    assume(mockGasket.execApplySync).calledWith('webpackConfig');
+  });
+
+  describe('webpackConfig lifecycle callback', function () {
+    let applyFn, mockPlugin, handlerStub, baseConfig;
+
+    beforeEach(function () {
+      mockPlugin = { name: 'mock-plugin' };
+      handlerStub = sinon.stub();
+
+      baseConfig = initWebpack(mockGasket, {}, mockContext);
+      applyFn = mockGasket.execApplySync.getCall(0).args[1];
+    });
+
+    it('called with baseConfig', function () {
+      applyFn(mockPlugin, handlerStub);
+      assume(handlerStub).calledWith(baseConfig);
+    });
+
+    it('called with context', function () {
+      applyFn(mockPlugin, handlerStub);
+      const context = handlerStub.getCall(0).args[1];
+      assume(context).is.an('object');
+    });
+
+    // TODO: remove in next major version
+    describe('context.webpackMerge', function () {
+      it('getter logs deprecated warning', function () {
+        applyFn(mockPlugin, handlerStub);
+        const context = handlerStub.getCall(0).args[1];
+        assume(mockGasket.logger.warning).not.called();
+        context.webpackMerge;
+        assume(mockGasket.logger.warning).calledWithMatch(/DEPRECATED/);
+      });
+
+      it('logs plugin name', function () {
+        applyFn(mockPlugin, handlerStub);
+        const context = handlerStub.getCall(0).args[1];
+        context.webpackMerge;
+        assume(mockGasket.logger.warning).calledWithMatch(/mock-plugin/);
+      });
+
+      it('logs recommendation', function () {
+        applyFn(mockPlugin, handlerStub);
+        const context = handlerStub.getCall(0).args[1];
+        context.webpackMerge;
+        assume(mockGasket.logger.warning).calledWithMatch(/Use `require\('webpack-merge'\)`/);
+      });
+
+      it('logs `unnamed plugin` if plugin name not set', function () {
+        applyFn({}, handlerStub);
+        const context = handlerStub.getCall(0).args[1];
+        context.webpackMerge;
+        assume(mockGasket.logger.warning).calledWithMatch(/unnamed plugin/);
+      });
+
+      it('logs app lifecycle', function () {
+        // eslint-disable-next-line no-undefined
+        applyFn(undefined, handlerStub);
+        const context = handlerStub.getCall(0).args[1];
+        context.webpackMerge;
+        assume(mockGasket.logger.warning).calledWithMatch(/app lifecycle/);
+      });
+    });
+
+    it('context.webpack returns webpack', function () {
+      applyFn(mockPlugin, handlerStub);
+      const context = handlerStub.getCall(0).args[1];
+      assume(context.webpack).equals(require('webpack'));
+    });
+
+  });
+});

--- a/packages/gasket-plugin-webpack/test/plugin.test.js
+++ b/packages/gasket-plugin-webpack/test/plugin.test.js
@@ -1,24 +1,7 @@
-/* eslint-disable no-sync */
-
 const { stub } = require('sinon');
 const assume = require('assume');
-const webpack = require('webpack');
-const webpackMerge = require('webpack-merge');
 const plugin = require('../lib/index');
 const { devDependencies } = require('../package');
-
-const baseWebpackConfig = {
-  plugins: [],
-  module: {
-    rules: []
-  },
-  optimization: {
-    splitChunks: {
-      cacheGroups: {}
-    },
-    minimize: false
-  }
-};
 
 describe('Plugin', () => {
 
@@ -64,77 +47,3 @@ describe('create hook', () => {
     });
   });
 });
-
-describe('initWebpack hook', () => {
-  let gasket, context;
-
-  beforeEach(() => {
-    context = {
-      defaultLoaders: {}
-    };
-    gasket = mockGasketApi();
-  });
-
-  it('executes the `webpackChain` and `webpack` lifecycles', function () {
-    const webpackConfig = { ...baseWebpackConfig };
-    plugin.initWebpack(gasket, webpackConfig, context);
-
-    assume(gasket.execSync.firstCall).has.been.calledWith('webpackChain');
-    assume(gasket.execSync.secondCall).has.been.calledWith('webpack');
-  });
-
-  it('returns webpack config object', function () {
-    const webpackConfig = { ...baseWebpackConfig };
-    const result = plugin.initWebpack(gasket, webpackConfig, context);
-
-    assume(result).is.an('object');
-    assume(result).has.property('plugins');
-    assume(result).has.property('module');
-    assume(result).has.property('optimization');
-  });
-
-  it('returns webpack config object with configs merged', function () {
-    const mockConfigs = [{ newConfig1: 'newConfig1Value' }, { newConfig2: 'newConfig2Value' }];
-    gasket.execSync.withArgs('webpack').returns(mockConfigs);
-    const webpackConfig = { ...baseWebpackConfig };
-    const result = plugin.initWebpack(gasket, webpackConfig, context);
-
-    assume(result).is.an('object');
-    assume(result).has.property('plugins');
-    assume(result).has.property('module');
-    assume(result).has.property('optimization');
-    assume(result).has.property('newConfig1');
-    assume(result).has.property('newConfig2');
-  });
-
-  it('does custom merging through a webpackConfig lifecycle', function () {
-    const smartMerge = stub(webpackMerge, 'smart');
-    try {
-      const originalConfig = { ...baseWebpackConfig };
-      const smartMergedConfig = { mock: 'smartMerge' };
-      const updatedConfig = { mock: 'config' };
-      webpackMerge.smart.returns(smartMergedConfig);
-      gasket.execWaterfallSync.withArgs('webpackConfig').returns(updatedConfig);
-
-      const config = plugin.initWebpack(gasket, originalConfig, context);
-
-      assume(gasket.execWaterfallSync).has.been.calledWith(
-        'webpackConfig',
-        smartMergedConfig,
-        { ...context, webpackMerge, webpack });
-      assume(config).equals(updatedConfig);
-    } finally {
-      smartMerge.restore();
-    }
-  });
-});
-
-function mockGasketApi() {
-  return {
-    execSync: stub().returns([]),
-    execWaterfallSync: stub().returnsArg(1),
-    config: {
-      webpack: {}  // user specified webpack config
-    }
-  };
-}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

We were relying on the "smart merge" method from [webpack-merge] which was deprecated in v4 and has been removed in v5 ([see changelog]). Further, we had several approaches for configuring custom Webpack which was sometimes confusing.

This PR sets things up to remove Webpack merging from being handled by the Gasket Webpack plugin. This will put control in apps and plugins to merge and open up more recent version of [webpack-merge].

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/plugin-webpack**
- Log deprecated warnings and add docs pointing to use `webpackConfig` lifecycle

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Local testing
- Updated unit tests

<!-- LINKS -->
[webpack-merge]: https://github.com/survivejs/webpack-merge
[see changelog]: https://github.com/survivejs/webpack-merge/blob/master/CHANGELOG.md#503--2020-07-06