### PR TITLE
Expose gasket class/constructor

### DIFF
--- a/packages/gasket-engine/CHANGELOG.md
+++ b/packages/gasket-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/engine`
 
+- Expose the Gasket engine class so TypeScript code can construct engine instances
+
 ### 6.19.0
 
 - Allow differing callbacks for `execApply` and `execApplySync` ([#345])

--- a/packages/gasket-engine/lib/engine.d.ts
+++ b/packages/gasket-engine/lib/engine.d.ts
@@ -92,4 +92,8 @@ declare module '@gasket/engine' {
 
     environments?: Record<string, PartialRecursive<GasketConfig>>
   }
+
+  export default class GasketEngine implements Gasket {
+    constructor(config: GasketConfig, context?: { resolveFrom?: string }): Gasket;
+  };
 }

--- a/packages/gasket-engine/lib/engine.d.ts
+++ b/packages/gasket-engine/lib/engine.d.ts
@@ -94,6 +94,31 @@ declare module '@gasket/engine' {
   }
 
   export default class GasketEngine implements Gasket {
-    constructor(config: GasketConfig, context?: { resolveFrom?: string }): Gasket;
-  };
+    constructor(config: GasketConfigFile, context?: { resolveFrom?: string });
+    config: GasketConfig;
+    exec<Id extends HookId>(
+      hook: Id,
+      ...args: Parameters<HookExecTypes[Id]>
+    ): Promise<ResolvedType<ReturnType<HookExecTypes[Id]>>[]>;
+    execSync<Id extends HookId>(
+      hook: Id,
+      ...args: Parameters<HookExecTypes[Id]>
+    ): Promise<ResolvedType<ReturnType<HookExecTypes[Id]>>[]>;
+    execWaterfall<Id extends HookId>(
+      hook: Id,
+      ...args: Parameters<HookExecTypes[Id]>
+    ): ReturnType<HookExecTypes[Id]>;
+    execWaterfallSync<Id extends HookId>(
+      hook: Id,
+      ...args: Parameters<HookExecTypes[Id]>
+    ): ReturnType<HookExecTypes[Id]>;
+    execApply<Id extends HookId, Return = void>(
+      hook: Id,
+      callback: (plugin: Plugin, handler: HookHandler<Id>) => Promise<Return>
+    ): Promise<Return[]>;
+    execApplySync<Id extends HookId, Return = void>(
+      hook: Id,
+      callback: (plugin: Plugin, handler: HookHandler<Id>) => Return
+    ): Return[];
+  }
 }

--- a/packages/gasket-typescript-tests/test/engine.spec.ts
+++ b/packages/gasket-typescript-tests/test/engine.spec.ts
@@ -1,0 +1,10 @@
+import Gasket from '@gasket/engine';
+
+describe('@gasket/engine', () => {
+  it('exposes the constructor interface', () => {
+    new Gasket(
+      { root: __dirname, env: 'test', command: { id: 'start' } },
+      { resolveFrom: __dirname }
+    );
+  });
+});

--- a/packages/gasket-typescript-tests/test/engine.spec.ts
+++ b/packages/gasket-typescript-tests/test/engine.spec.ts
@@ -2,7 +2,7 @@ import Gasket from '@gasket/engine';
 
 describe('@gasket/engine', () => {
   it('exposes the constructor interface', () => {
-    // eslint-disable no-new
+    // eslint-disable-next-line no-new
     new Gasket(
       { root: __dirname, env: 'test' },
       { resolveFrom: __dirname }

--- a/packages/gasket-typescript-tests/test/engine.spec.ts
+++ b/packages/gasket-typescript-tests/test/engine.spec.ts
@@ -2,8 +2,9 @@ import Gasket from '@gasket/engine';
 
 describe('@gasket/engine', () => {
   it('exposes the constructor interface', () => {
+    // eslint-disable no-new
     new Gasket(
-      { root: __dirname, env: 'test', command: { id: 'start' } },
+      { root: __dirname, env: 'test' },
       { resolveFrom: __dirname }
     );
   });


### PR DESCRIPTION
## Summary

So that TypeScript code can create Gasket engine instances, we need to expose the class so they can be constructed.

## Changelog

- Allow TypeScript code to import and construct a gasket instance

## Test Plan

Created type checking test for invoking the constructor.