### PR TITLE
@gasket/plugin-config_error_handling

### DIFF
--- a/packages/gasket-plugin-config/lib/middleware.js
+++ b/packages/gasket-plugin-config/lib/middleware.js
@@ -16,6 +16,14 @@ function handler(gasket) {
         req,
         res);
 
+      // Error handling
+      // Better error description for the appRequestConfig & appEnvConfig lifecycles
+      // In the event a config object isn't returned from the hook(s)
+      // it will result in a error in the destructuring of req.config
+      if (!req.config) {
+        throw new Error('req.config is undefined - Ensure that all plugins hooking into the appRequestConfig and appEnvConfig lifecycle return a config object.')
+      }
+
       const { gasketData = {} } = res.locals;
       const { public: config = {} } = req.config;
 

--- a/packages/gasket-plugin-config/lib/middleware.js
+++ b/packages/gasket-plugin-config/lib/middleware.js
@@ -21,7 +21,10 @@ function handler(gasket) {
       // In the event a config object isn't returned from the hook(s)
       // it will result in a error in the destructuring of req.config
       if (!req.config) {
-        throw new Error('req.config is undefined - Ensure that all plugins hooking into the appRequestConfig and appEnvConfig lifecycle return a config object.')
+        throw new Error(
+          // eslint-disable-next-line max-len
+          'req.config is undefined - Ensure that all plugins hooking into the appRequestConfig and appEnvConfig lifecycle return a config object.'
+        );
       }
 
       const { gasketData = {} } = res.locals;

--- a/packages/gasket-plugin-config/lib/middleware.js
+++ b/packages/gasket-plugin-config/lib/middleware.js
@@ -17,13 +17,12 @@ function handler(gasket) {
         res);
 
       // Error handling
-      // Better error description for the appRequestConfig & appEnvConfig lifecycles
+      // Better error description for the appRequestConfig lifecycles
       // In the event a config object isn't returned from the hook(s)
       // it will result in a error in the destructuring of req.config
       if (!req.config) {
         throw new Error(
-          // eslint-disable-next-line max-len
-          'req.config is undefined - Ensure that all plugins hooking into the appRequestConfig and appEnvConfig lifecycle return a config object.'
+          'An appRequestConfig lifecycle hook did not return a config object.'
         );
       }
 

--- a/packages/gasket-plugin-config/lib/plugin.js
+++ b/packages/gasket-plugin-config/lib/plugin.js
@@ -13,6 +13,13 @@ module.exports = {
         'appEnvConfig',
         mergeRootConfig(gasket, mergeConfigFiles(gasket))
       );
+
+      // Better error description for the appRequestConfig lifecycles
+      if (!gasket[ENV_CONFIG]) {
+        throw new Error(
+          'An appEnvConfig lifecycle hook did not return a config object.'
+        );
+      }
     },
     middleware,
     initReduxState(gasket, state, req) {

--- a/packages/gasket-plugin-config/test/middleware.test.js
+++ b/packages/gasket-plugin-config/test/middleware.test.js
@@ -57,12 +57,14 @@ describe('middleware', function () {
   });
 
   it('descriptive error when config is not present in `appRequestConfig` hooks', async () => {
+    // eslint-disable-next-line no-undefined
     gasket[ENV_CONFIG] = undefined;
     gasket.execWaterfall.mockImplementation((event, config, req, res) => {
       expect(event).toEqual('appRequestConfig');
       expect(req).toEqual(mockReq);
       expect(res).toEqual(mockRes);
 
+      // eslint-disable-next-line no-undefined
       return undefined;
     });
 

--- a/packages/gasket-plugin-config/test/middleware.test.js
+++ b/packages/gasket-plugin-config/test/middleware.test.js
@@ -63,9 +63,6 @@ describe('middleware', function () {
       expect(event).toEqual('appRequestConfig');
       expect(req).toEqual(mockReq);
       expect(res).toEqual(mockRes);
-
-      // eslint-disable-next-line no-undefined
-      return undefined;
     });
 
     const middlewareMock = promisify(middleware.handler(gasket));

--- a/packages/gasket-plugin-config/test/middleware.test.js
+++ b/packages/gasket-plugin-config/test/middleware.test.js
@@ -56,6 +56,23 @@ describe('middleware', function () {
     });
   });
 
+  it('descriptive error when config is not present in `appRequestConfig` hooks', async () => {
+    gasket[ENV_CONFIG] = undefined;
+    gasket.execWaterfall.mockImplementation((event, config, req, res) => {
+      expect(event).toEqual('appRequestConfig');
+      expect(req).toEqual(mockReq);
+      expect(res).toEqual(mockRes);
+
+      return undefined;
+    });
+
+    const middlewareMock = promisify(middleware.handler(gasket));
+
+    await expect(middlewareMock(mockReq, mockRes)).rejects.toThrowError(
+      'req.config is undefined - Ensure that all plugins hooking into the appRequestConfig and appEnvConfig lifecycle return a config object.'
+    );
+  });
+
   it('does not swallow errors from `appRequestConfig` hooks', async () => {
     gasket[ENV_CONFIG] = { some: 'config' };
     gasket.execWaterfall.mockImplementation(() => {
@@ -77,7 +94,7 @@ describe('middleware', function () {
   });
 
   it('adds nothing to locals response if public config not set', async () => {
-    const mockConfig = { };
+    const mockConfig = {};
     gasket[ENV_CONFIG] = mockConfig;
     const middlewareMock = promisify(middleware.handler(gasket));
 

--- a/packages/gasket-plugin-config/test/middleware.test.js
+++ b/packages/gasket-plugin-config/test/middleware.test.js
@@ -69,7 +69,7 @@ describe('middleware', function () {
     const middlewareMock = promisify(middleware.handler(gasket));
 
     await expect(middlewareMock(mockReq, mockRes)).rejects.toThrowError(
-      'req.config is undefined - Ensure that all plugins hooking into the appRequestConfig and appEnvConfig lifecycle return a config object.'
+      'An appRequestConfig lifecycle hook did not return a config object.'
     );
   });
 

--- a/packages/gasket-plugin-config/test/plugin.test.js
+++ b/packages/gasket-plugin-config/test/plugin.test.js
@@ -158,11 +158,12 @@ describe('Plugin', () => {
     it('descriptive error when config is not present in `appEnvConfig` hooks', async () => {
       Object.assign(gasket.config, {
         root: path.join(__dirname, './fixtures', 'templated'),
-        env: 'test',
+        env: 'test'
       });
 
-      gasket.execWaterfall.mockImplementation((event, config) => {
+      gasket.execWaterfall.mockImplementation((event) => {
         expect(event).toEqual('appEnvConfig');
+        // eslint-disable-next-line no-undefined
         return undefined;
       });
 

--- a/packages/gasket-plugin-config/test/plugin.test.js
+++ b/packages/gasket-plugin-config/test/plugin.test.js
@@ -155,6 +155,22 @@ describe('Plugin', () => {
       });
     });
 
+    it('descriptive error when config is not present in `appEnvConfig` hooks', async () => {
+      Object.assign(gasket.config, {
+        root: path.join(__dirname, './fixtures', 'templated'),
+        env: 'test',
+      });
+
+      gasket.execWaterfall.mockImplementation((event, config) => {
+        expect(event).toEqual('appEnvConfig');
+        return undefined;
+      });
+
+      const { preboot } = plugin.hooks;
+
+      await expect(preboot(gasket)).rejects.toThrowError('An appEnvConfig lifecycle hook did not return a config object.');
+    });
+
     it('does not swallow errors in buggy config files', () => {
       return verify({
         withRootDir: 'invalid-config',

--- a/packages/gasket-plugin-config/test/plugin.test.js
+++ b/packages/gasket-plugin-config/test/plugin.test.js
@@ -163,8 +163,6 @@ describe('Plugin', () => {
 
       gasket.execWaterfall.mockImplementation((event) => {
         expect(event).toEqual('appEnvConfig');
-        // eslint-disable-next-line no-undefined
-        return undefined;
       });
 
       const { preboot } = plugin.hooks;


### PR DESCRIPTION
## Summary
Descriptive error handling when hooking into the `appRequestConfig` lifecycles. Currently if a config object is not returned from the handlers it results in an error [here](https://github.com/godaddy/gasket/blob/main/packages/gasket-plugin-config/lib/middleware.js#L20).

Added descriptive error handling for `appEnvConfig` lifecycle [here](https://github.com/godaddy/gasket/blob/main/packages/gasket-plugin-config/lib/plugin.js#L12-L15)

## Changelog
Unclear if this change should be added to the change log.

## Test Plan
`appRequestConfig` - `middleware.test.js` - Added test case to ensure that an error is thrown and has a matching description.
`appEnvConfig` - `plugin.test.js` - Added test case to ensure that an error is thrown and has a matching description.