### PR TITLE
Add Fastify support to Intl plugin

### DIFF
--- a/packages/gasket-plugin-intl/lib/fastify.js
+++ b/packages/gasket-plugin-intl/lib/fastify.js
@@ -1,0 +1,25 @@
+const { getIntlConfig } = require('./configure');
+const serveStaticMw = require('serve-static');
+
+/**
+ * Express lifecycle to set up route for serving locales
+ *
+ * @param {Gasket} gasket - Gasket
+ * @param {Object} app - Fastify app
+ */
+module.exports = function fastify(gasket, app) {
+  const { localesDir, serveStatic, defaultPath } = getIntlConfig(gasket);
+
+  if (serveStatic) {
+    const staticPath = serveStatic === true ? defaultPath : serveStatic;
+
+    app.use(
+      staticPath,
+      serveStaticMw(localesDir, {
+        index: false,
+        maxAge: '1y',
+        immutable: true
+      })
+    );
+  }
+};

--- a/packages/gasket-plugin-intl/lib/index.js
+++ b/packages/gasket-plugin-intl/lib/index.js
@@ -4,6 +4,7 @@ const configure = require('./configure');
 const init = require('./init');
 const middleware = require('./middleware');
 const express = require('./express');
+const fastify = require('./fastify');
 const serviceWorkerCacheKey = require('./service-worker-cache-key');
 const workbox = require('./workbox');
 const buildManifest = require('./build-manifest');
@@ -21,10 +22,7 @@ module.exports = {
       const rootDir = path.join(__dirname, '..');
       const isReactProject = pkg.has('dependencies', 'react');
 
-      files.add(
-        `${rootDir}/generator/*`,
-        `${rootDir}/generator/**/*`
-      );
+      files.add(`${rootDir}/generator/*`, `${rootDir}/generator/**/*`);
 
       if (isReactProject) {
         pkg.add('dependencies', {
@@ -60,6 +58,7 @@ module.exports = {
       };
     },
     express,
+    fastify,
     middleware,
     workbox,
     serviceWorkerCacheKey,
@@ -67,18 +66,22 @@ module.exports = {
       const { localesDir } = getIntlConfig(gasket);
       return {
         ...meta,
-        lifecycles: [{
-          name: 'intlLocale',
-          method: 'execWaterfall',
-          description: 'Set the language for which locale files to load',
-          link: 'README.md#intlLocale',
-          parent: 'middleware'
-        }],
-        structures: [{
-          name: localesDir + '/',
-          description: 'Locale JSON files with translation strings',
-          link: 'README.md#Options'
-        }]
+        lifecycles: [
+          {
+            name: 'intlLocale',
+            method: 'execWaterfall',
+            description: 'Set the language for which locale files to load',
+            link: 'README.md#intlLocale',
+            parent: 'middleware'
+          }
+        ],
+        structures: [
+          {
+            name: localesDir + '/',
+            description: 'Locale JSON files with translation strings',
+            link: 'README.md#Options'
+          }
+        ]
       };
     }
   }

--- a/packages/gasket-plugin-intl/test/fastify.test.js
+++ b/packages/gasket-plugin-intl/test/fastify.test.js
@@ -1,0 +1,70 @@
+const assume = require('assume');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+describe('fastify', function () {
+  let mockGasket, mockApp, fastifyHook, serveStaticStub;
+
+  beforeEach(() => {
+    mockApp = {
+      use: sinon.stub(),
+      get: sinon.stub()
+    };
+
+    mockGasket = {
+      config: {
+        root: process.cwd(),
+        intl: {
+          defaultLocale: 'en',
+          defaultPath: '/locales',
+          localesMap: {},
+          localesDir: './public/locales',
+          manifestFilename: 'mock-manifest.json'
+        }
+      }
+    };
+
+    serveStaticStub = sinon.stub();
+
+    fastifyHook = proxyquire('../lib/fastify', {
+      'serve-static': serveStaticStub
+    });
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('should not call app.use() without serveStatic set', function () {
+    fastifyHook(mockGasket, mockApp);
+    assume(mockApp.use).not.called();
+  });
+
+  it('should set staticPath to defaultPath', function () {
+    mockGasket.config.intl.serveStatic = true;
+    fastifyHook(mockGasket, mockApp);
+    assume(mockApp.use.args[0][0]).eqls(mockGasket.config.intl.defaultPath);
+  });
+
+  it('should set staticPath to custom path', function () {
+    mockGasket.config.intl.serveStatic = '/custom-path';
+    fastifyHook(mockGasket, mockApp);
+    assume(mockApp.use.args[0][0]).eqls(mockGasket.config.intl.serveStatic);
+  });
+
+  it('static serves from configured localesDir', function () {
+    mockGasket.config.intl.serveStatic = true;
+    fastifyHook(mockGasket, mockApp);
+    assume(serveStaticStub.args[0][0]).eqls(mockGasket.config.intl.localesDir);
+  });
+
+  it('uses expected static serve settings', function () {
+    mockGasket.config.intl.serveStatic = true;
+    fastifyHook(mockGasket, mockApp);
+    assume(serveStaticStub.args[0][1]).eqls({
+      index: false,
+      maxAge: '1y',
+      immutable: true
+    });
+  });
+});

--- a/packages/gasket-plugin-intl/test/index.test.js
+++ b/packages/gasket-plugin-intl/test/index.test.js
@@ -2,7 +2,6 @@ const assume = require('assume');
 const plugin = require('../lib');
 
 describe('Plugin', function () {
-
   it('is an object', function () {
     assume(plugin).instanceOf(Object);
   });
@@ -19,6 +18,7 @@ describe('Plugin', function () {
       'build',
       'webpackConfig',
       'express',
+      'fastify',
       'middleware',
       'workbox',
       'serviceWorkerCacheKey',

--- a/packages/gasket-plugin-service-worker/lib/configure-endpoint.js
+++ b/packages/gasket-plugin-service-worker/lib/configure-endpoint.js
@@ -1,0 +1,32 @@
+const LRU = require('lru-cache');
+const { getCacheKeys, getComposedContent, getSWConfig } = require('./utils');
+
+/**
+ * Configures the endpoint with the gasket config
+ *
+ * @param {Gasket} gasket - Gasket
+ * @returns {Function} endpoint
+ */
+module.exports = async function configureEndpoint(gasket) {
+  const { logger } = gasket;
+  const { cache: cacheConfig = {} } = getSWConfig(gasket);
+
+  const cache = new LRU(cacheConfig);
+  const cacheKeys = await getCacheKeys(gasket);
+
+  return async function sw(req, res) {
+    const cacheKey = cacheKeys.reduce((acc, fn) => acc + fn(req, res), '_');
+
+    let composedContent = cache.get(cacheKey);
+    if (!composedContent) {
+      logger.info(`Composing service worker for key: ${cacheKey}`);
+
+      composedContent = await getComposedContent(gasket, { req, res });
+
+      cache.set(cacheKey, composedContent);
+    }
+
+    res.set('Content-Type', 'application/javascript');
+    res.send(composedContent);
+  };
+};

--- a/packages/gasket-plugin-service-worker/lib/express.js
+++ b/packages/gasket-plugin-service-worker/lib/express.js
@@ -1,36 +1,5 @@
-const LRU = require('lru-cache');
-const { getCacheKeys, getComposedContent, getSWConfig } = require('./utils');
-
-/**
- * Configures the endpoint with the gasket config
- *
- * @param {Gasket} gasket - Gasket
- * @returns {Function} endpoint
- */
-async function configureEndpoint(gasket) {
-  const { logger } = gasket;
-  const { cache: cacheConfig = {} } = getSWConfig(gasket);
-
-  const cache = new LRU(cacheConfig);
-  const cacheKeys = await getCacheKeys(gasket);
-
-  return async function sw(req, res) {
-    const cacheKey = cacheKeys.reduce((acc, fn) => acc + fn(req, res), '_');
-
-    let composedContent = cache.get(cacheKey);
-    if (!composedContent) {
-      logger.info(`Composing service worker for key: ${cacheKey}`);
-
-      composedContent = await getComposedContent(gasket, { req, res });
-
-      cache.set(cacheKey, composedContent);
-    }
-
-    res.set('Content-Type', 'application/javascript');
-    res.send(composedContent);
-  };
-}
-
+const { getSWConfig } = require('./utils');
+const configureEndpoint = require('./configure-endpoint');
 /**
  * Express lifecycle to add an endpoint to serve service worker script
  *

--- a/packages/gasket-plugin-service-worker/lib/fastify.js
+++ b/packages/gasket-plugin-service-worker/lib/fastify.js
@@ -1,35 +1,5 @@
-const LRU = require('lru-cache');
-const { getCacheKeys, getComposedContent, getSWConfig } = require('./utils');
-
-/**
- * Configures the endpoint with the gasket config
- *
- * @param {Gasket} gasket - Gasket
- * @returns {Function} endpoint
- */
-async function configureEndpoint(gasket) {
-  const { logger } = gasket;
-  const { cache: cacheConfig = {} } = getSWConfig(gasket);
-
-  const cache = new LRU(cacheConfig);
-  const cacheKeys = await getCacheKeys(gasket);
-
-  return async function sw(req, res) {
-    const cacheKey = cacheKeys.reduce((acc, fn) => acc + fn(req, res), '_');
-
-    let composedContent = cache.get(cacheKey);
-    if (!composedContent) {
-      logger.info(`Composing service worker for key: ${cacheKey}`);
-
-      composedContent = await getComposedContent(gasket, { req, res });
-
-      cache.set(cacheKey, composedContent);
-    }
-
-    res.set('Content-Type', 'application/javascript');
-    res.send(composedContent);
-  };
-}
+const { getSWConfig } = require('./utils');
+const configureEndpoint = require('./configure-endpoint');
 
 /**
  * Express lifecycle to add an endpoint to serve service worker script

--- a/packages/gasket-plugin-service-worker/lib/fastify.js
+++ b/packages/gasket-plugin-service-worker/lib/fastify.js
@@ -2,7 +2,7 @@ const { getSWConfig } = require('./utils');
 const configureEndpoint = require('./configure-endpoint');
 
 /**
- * Express lifecycle to add an endpoint to serve service worker script
+ * Fastify lifecycle to add an endpoint to serve service worker script
  *
  * @param {Gasket} gasket - Gasket
  * @param {Fastify} app - App

--- a/packages/gasket-plugin-service-worker/lib/fastify.js
+++ b/packages/gasket-plugin-service-worker/lib/fastify.js
@@ -1,0 +1,44 @@
+const LRU = require('lru-cache');
+const { getCacheKeys, getComposedContent, getSWConfig } = require('./utils');
+
+/**
+ * Configures the endpoint with the gasket config
+ *
+ * @param {Gasket} gasket - Gasket
+ * @returns {Function} endpoint
+ */
+async function configureEndpoint(gasket) {
+  const { logger } = gasket;
+  const { cache: cacheConfig = {} } = getSWConfig(gasket);
+
+  const cache = new LRU(cacheConfig);
+  const cacheKeys = await getCacheKeys(gasket);
+
+  return async function sw(req, res) {
+    const cacheKey = cacheKeys.reduce((acc, fn) => acc + fn(req, res), '_');
+
+    let composedContent = cache.get(cacheKey);
+    if (!composedContent) {
+      logger.info(`Composing service worker for key: ${cacheKey}`);
+
+      composedContent = await getComposedContent(gasket, { req, res });
+
+      cache.set(cacheKey, composedContent);
+    }
+
+    res.set('Content-Type', 'application/javascript');
+    res.send(composedContent);
+  };
+}
+
+/**
+ * Express lifecycle to add an endpoint to serve service worker script
+ *
+ * @param {Gasket} gasket - Gasket
+ * @param {Fastify} app - App
+ */
+module.exports = async function fastify(gasket, app) {
+  const { staticOutput, url } = getSWConfig(gasket);
+  if (staticOutput) return;
+  app.get(url, await configureEndpoint(gasket));
+};

--- a/packages/gasket-plugin-service-worker/lib/index.js
+++ b/packages/gasket-plugin-service-worker/lib/index.js
@@ -3,7 +3,7 @@ const build = require('./build');
 const middleware = require('./middleware');
 const express = require('./express');
 const webpackConfig = require('./webpack-config');
-const fasitfy = require('./fastify');
+const fastify = require('./fastify');
 
 module.exports = {
   name: require('../package').name,
@@ -12,7 +12,7 @@ module.exports = {
     build,
     middleware,
     express,
-    fasitfy,
+    fastify,
     webpackConfig,
     metadata(gasket, meta) {
       return {

--- a/packages/gasket-plugin-service-worker/lib/index.js
+++ b/packages/gasket-plugin-service-worker/lib/index.js
@@ -3,6 +3,7 @@ const build = require('./build');
 const middleware = require('./middleware');
 const express = require('./express');
 const webpackConfig = require('./webpack-config');
+const fasitfy = require('./fastify');
 
 module.exports = {
   name: require('../package').name,
@@ -11,23 +12,27 @@ module.exports = {
     build,
     middleware,
     express,
+    fasitfy,
     webpackConfig,
     metadata(gasket, meta) {
       return {
         ...meta,
-        lifecycles: [{
-          name: 'composeServiceWorker',
-          method: 'execWaterfall',
-          description: 'Update the service worker script',
-          link: 'README.md#composeServiceWorker',
-          parent: 'express'
-        }, {
-          name: 'serviceWorkerCacheKey',
-          method: 'exec',
-          description: 'Get cache keys for request based service workers',
-          link: 'README.md#serviceWorkerCacheKey',
-          parent: 'express'
-        }]
+        lifecycles: [
+          {
+            name: 'composeServiceWorker',
+            method: 'execWaterfall',
+            description: 'Update the service worker script',
+            link: 'README.md#composeServiceWorker',
+            parent: 'express'
+          },
+          {
+            name: 'serviceWorkerCacheKey',
+            method: 'exec',
+            description: 'Get cache keys for request based service workers',
+            link: 'README.md#serviceWorkerCacheKey',
+            parent: 'express'
+          }
+        ]
       };
     }
   }

--- a/packages/gasket-plugin-service-worker/lib/utils.js
+++ b/packages/gasket-plugin-service-worker/lib/utils.js
@@ -25,12 +25,14 @@ async function getCacheKeys(gasket) {
 
   const pluginCacheKeys = await exec('serviceWorkerCacheKey');
 
-  return [...userCacheKeys, ...pluginCacheKeys]
-    .filter(k => typeof k === 'function');
+  return [...userCacheKeys, ...pluginCacheKeys].filter((k) => typeof k === 'function');
 }
 
 async function getComposedContent(gasket, context) {
-  const { execWaterfall, config: { env } } = gasket;
+  const {
+    execWaterfall,
+    config: { env }
+  } = gasket;
   const swConfig = getSWConfig(gasket);
   const { content, minify = {} } = swConfig;
   const composed = await execWaterfall('composeServiceWorker', content, context);

--- a/packages/gasket-plugin-service-worker/test/fastify.spec.js
+++ b/packages/gasket-plugin-service-worker/test/fastify.spec.js
@@ -1,0 +1,127 @@
+const mockCache = require('lru-cache');
+const mockMinify = require('uglify-js');
+const fastify = require('../lib/fastify');
+
+describe('fastify', () => {
+  let mockGasket, mockApp, mockConfig, mockReq, mockRes, mockCacheKeys;
+  let cacheKeyA, cacheKeyB;
+
+  beforeEach(() => {
+    mockCacheKeys = [];
+
+    mockConfig = {
+      url: '/sw.js',
+      scope: '/',
+      content: '',
+      cacheKeys: [],
+      cache: {}
+    };
+    mockGasket = {
+      config: {
+        serviceWorker: mockConfig
+      },
+      exec: jest.fn().mockReturnValue(Promise.resolve(mockCacheKeys)),
+      execWaterfall: jest.fn(),
+      logger: {
+        info: jest.fn()
+      }
+    };
+    mockApp = {
+      get: jest.fn()
+    };
+    mockReq = {};
+    mockRes = {
+      set: jest.fn(),
+      send: jest.fn()
+    };
+    mockCache.mockClear();
+    mockMinify.mockClear();
+
+    cacheKeyA = jest.fn(() => 'A');
+    cacheKeyB = jest.fn(() => 'B');
+  });
+
+  async function getEndpoint() {
+    await fastify(mockGasket, mockApp);
+    return mockApp.get.mock.calls[0][1];
+  }
+
+  it('sets app get endpoint', async () => {
+    await fastify(mockGasket, mockApp);
+    expect(mockApp.get).toHaveBeenCalledWith('/sw.js', expect.any(Function));
+  });
+
+  it('does not setup endpoint if staticOutput is configured', async () => {
+    mockConfig.staticOutput = './public/sw.js';
+    await fastify(mockGasket, mockApp);
+    expect(mockApp.get).not.toHaveBeenCalled();
+  });
+
+  it('configures cache', async () => {
+    await fastify(mockGasket, mockApp);
+    expect(mockCache).toHaveBeenCalledWith(mockConfig.cache);
+  });
+
+  describe('endpoint', () => {
+    it('executes execWaterfall for composeServiceWorker', async () => {
+      mockConfig.content = 'This is preconfigured content';
+      const endpoint = await getEndpoint();
+      await endpoint(mockReq, mockRes);
+      expect(mockGasket.execWaterfall).toHaveBeenCalledWith(
+        'composeServiceWorker',
+        mockConfig.content,
+        expect.objectContaining({ req: mockReq, res: mockRes })
+      );
+    });
+
+    it('sets response header content-type', async () => {
+      const endpoint = await getEndpoint();
+      await endpoint(mockReq, mockRes);
+      expect(mockRes.set).toHaveBeenCalledWith('Content-Type', 'application/javascript');
+    });
+
+    it('sends the compose service worker response', async () => {
+      const endpoint = await getEndpoint();
+      await endpoint(mockReq, mockRes);
+      expect(mockRes.send).toHaveBeenCalled();
+    });
+
+    it('executes cache key functions', async () => {
+      mockCacheKeys.push(cacheKeyA, cacheKeyB);
+      const endpoint = await getEndpoint();
+      await endpoint(mockReq, mockRes);
+      expect(cacheKeyA).toHaveBeenCalledWith(mockReq, mockRes);
+      expect(cacheKeyB).toHaveBeenCalledWith(mockReq, mockRes);
+    });
+
+    it('looks up existing cached content with generated key', async () => {
+      mockCacheKeys.push(cacheKeyA, cacheKeyB);
+      const endpoint = await getEndpoint();
+      await endpoint(mockReq, mockRes);
+      expect(mockCache.getStub).toHaveBeenCalledWith('_AB');
+    });
+
+    it('set new cached content with generated key', async () => {
+      mockCacheKeys.push(cacheKeyA, cacheKeyB);
+      const endpoint = await getEndpoint();
+      await endpoint(mockReq, mockRes);
+      expect(mockCache.setStub).toHaveBeenCalledWith(
+        '_AB',
+        expect.stringContaining('use strict')
+      );
+    });
+
+    it('executes composeServiceWorker if no cached content', async () => {
+      const endpoint = await getEndpoint();
+      await endpoint(mockReq, mockRes);
+      expect(mockGasket.execWaterfall).toHaveBeenCalled();
+    });
+
+    it('does not execute composeServiceWorker for cached content', async () => {
+      mockCache.getStub.mockReturnValue('bogus content');
+      const endpoint = await getEndpoint();
+      await endpoint(mockReq, mockRes);
+      expect(mockGasket.execWaterfall).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/gasket-plugin-service-worker/test/index.spec.js
+++ b/packages/gasket-plugin-service-worker/test/index.spec.js
@@ -1,7 +1,6 @@
 const plugin = require('../lib');
 
 describe('Plugin', () => {
-
   it('is an object', () => {
     expect(plugin).toBeInstanceOf(Object);
   });
@@ -16,6 +15,7 @@ describe('Plugin', () => {
       'build',
       'middleware',
       'express',
+      'fastify',
       'webpackConfig',
       'metadata'
     ];
@@ -30,9 +30,11 @@ describe('Plugin', () => {
   describe('meta', function () {
     it('returns lifecycle metadata', function () {
       const results = plugin.hooks.metadata({}, {});
-      expect(results).toEqual(expect.objectContaining({
-        lifecycles: expect.any(Array)
-      }));
+      expect(results).toEqual(
+        expect.objectContaining({
+          lifecycles: expect.any(Array)
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Add support for fastify where express is already available in the intl plugin

## Changelog

- Add fastify lifecycle to set up route for serving locales 

## Test Plan

- created `fastify.test.js` test file 
<img width="699" alt="Screen Shot 2022-06-02 at 1 39 16 PM" src="https://user-images.githubusercontent.com/104379885/171734053-d143a0fa-5661-4d8f-85c9-41cde6de4a76.png">

