### PR TITLE
Fix relative link transforms

### DIFF
--- a/packages/gasket-plugin-docs/lib/utils/transforms.js
+++ b/packages/gasket-plugin-docs/lib/utils/transforms.js
@@ -69,12 +69,13 @@ const txGasketUrlLinks = {
     const allModuleDocConfigs = modules.concat(plugins).concat(presets);
 
     const tx = makeLinkTransform(link => {
-      return link.replace(matchUrlLink, (match, p1, p2) => {
-        const moduleName = p1.replace('gasket-', '@gasket/');
+      return link.replace(matchUrlLink, (match, pkgMatch, fileMatch) => {
+        const moduleName = pkgMatch.replace('gasket-', '@gasket/');
         const tgtDocConfig = allModuleDocConfigs.find(m => m.name === moduleName);
         if (tgtDocConfig) {
-          const relRoot = path.relative(path.join(targetRoot, filename), tgtDocConfig.targetRoot);
-          return [relRoot, p2].join('');
+          const dirWithLinkRef = path.dirname(path.join(targetRoot, filename));
+          const filePathOfLink = path.join(tgtDocConfig.targetRoot, fileMatch);
+          return path.relative(dirWithLinkRef, filePathOfLink);
         }
         return match;
       });

--- a/packages/gasket-plugin-docs/test/utils/transforms.test.js
+++ b/packages/gasket-plugin-docs/test/utils/transforms.test.js
@@ -242,7 +242,7 @@ describe('Utils Transforms', () => {
         it('transforms gasket repo URLs to relative links', () => {
           const results = handler(mockInlineStyle, { filename, docsConfig, docsConfigSet });
           assume(results).not.includes('[6](https://github.com/godaddy/gasket/tree/canary/packages/gasket-fake/path/to/doc.md#with-hash)');
-          assume(results).includes('[6](../../../../modules/@gasket/fake/path/to/doc.md#with-hash)');
+          assume(results).includes('[6](../../../modules/@gasket/fake/path/to/doc.md#with-hash)');
         });
 
         it('transforms gasket repo URLs under any branch', () => {
@@ -252,16 +252,16 @@ describe('Utils Transforms', () => {
 [canary-1.7](https://github.com/godaddy/gasket/tree/canary-1.7/packages/gasket-fake/path/to/doc.md#with-hash)
 `;
           const results = handler(mockContent, { filename, docsConfig, docsConfigSet });
-          assume(results).includes('[main](../../../../modules/@gasket/fake/path/to/doc.md#with-hash)');
-          assume(results).includes('[BOGUS](../../../../modules/@gasket/fake/path/to/doc.md#with-hash)');
-          assume(results).includes('[canary-1.7](../../../../modules/@gasket/fake/path/to/doc.md#with-hash)');
+          assume(results).includes('[main](../../../modules/@gasket/fake/path/to/doc.md#with-hash)');
+          assume(results).includes('[BOGUS](../../../modules/@gasket/fake/path/to/doc.md#with-hash)');
+          assume(results).includes('[canary-1.7](../../../modules/@gasket/fake/path/to/doc.md#with-hash)');
         });
 
         it('does not transforms gasket repo URLs if module not collated', () => {
           const mockContent = `[missing](https://github.com/godaddy/gasket/tree/main/packages/gasket-missing/path/to/doc.md#with-hash)`;
           const results = handler(mockContent, { filename, docsConfig, docsConfigSet });
           assume(results).includes(mockContent);
-          assume(results).not.includes('[missing](../../../../modules/@gasket/missing/path/to/doc.md#with-hash)');
+          assume(results).not.includes('[missing](../../../modules/@gasket/missing/path/to/doc.md#with-hash)');
         });
 
         it('does not transform non gasket repo URLs', () => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Docs links to installed @gasket packages were being transformed with an extra up-dir throwing links off. @mmason2-godaddy and I paired on sorting this out.

## Changelog

**@gasket/plugin-docs**
- Fix relative path for `@gasket` package transforms

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Updated unit tests
- Debugged with plugin linked in local test app