### PR TITLE
Support for --require flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18569,6 +18569,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/getopts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+      "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="
+    },
     "node_modules/getos": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
@@ -35172,6 +35177,7 @@
         "concat-stream": "^2.0.0",
         "cross-spawn": "^7.0.1",
         "deepmerge": "^4.2.2",
+        "getopts": "^2.3.0",
         "glob": "^7.1.6",
         "handlebars": "^4.7.6",
         "inquirer": "6.3.1",
@@ -35539,7 +35545,7 @@
     },
     "packages/gasket-plugin-docusaurus": {
       "name": "@gasket/plugin-docusaurus",
-      "version": "6.23.0",
+      "version": "6.23.1",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/core": "2.0.0-beta.20",
@@ -39420,6 +39426,7 @@
         "eslint-plugin-unicorn": "^40.1.0",
         "fancy-test": "^1.2.0",
         "fetch-mock": "^7.3.3",
+        "getopts": "*",
         "glob": "^7.1.6",
         "handlebars": "^4.7.6",
         "inquirer": "6.3.1",
@@ -51478,6 +51485,11 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "getopts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+      "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="
     },
     "getos": {
       "version": "3.2.1",

--- a/packages/gasket-cli/README.md
+++ b/packages/gasket-cli/README.md
@@ -98,6 +98,16 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
+### --require module
+
+Using this flag allows preloading modules when the CLI starts up. The `module`
+may be either a path to a file, or a node module name. Only CommonJS modules are
+supported. This can be useful for loading instrumentation modules.
+
+```bash
+gasket start --require ./setup.js --require elastic-apm-node/start
+```
+
 ## Lifecycles
 
 Lifecycles for apps are enabled by plugins, however the CLI has some built-in
@@ -187,7 +197,7 @@ module.exports = {
       });
 
       pkg.add('scripts', {
-        bake: `pizza-oven --size ${pizzaSize}`
+        bake: `pizza-oven --size ${ pizzaSize }`
       });
     }
   }
@@ -245,7 +255,6 @@ The hook is passed the following parameters:
 | `utils`           | Functions that aid in post create hooks                                                                |
 | `utils.runScript` | run an `npm` script at the root of the generated `npm` package                                         |
 
-
 # Tests
 
 Tests are written with `mocha`, `@oclif/test`, and `assume`. They can be run &
@@ -291,17 +300,27 @@ npm install --no-save @gasket/preset-nextjs @gasket/redux next react-dom
 <!-- LINKS -->
 
 [npm]:https://docs.npm.red
+
 [yarn]:https://yarnpkg.com
+
 [npm env vars]:https://docs.npmjs.com/misc/config#environment-variables
+
 [yarn env vars]:https://yarnpkg.com/en/docs/envvars#toc-npm-config
 
 [inquirer questions]:https://github.com/SBoudrias/Inquirer.js#question
+
 [execWaterfall]:/packages/gasket-engine/README.md#execwaterfallevent-value-args
+
 [exec]:/packages/gasket-engine/README.md#execevent-args
+
 [Configuration Guide]: docs/configuration.md
+
 [Plugins Guide]: docs/plugins.md
+
 [Presets Guide]: docs/presets.md
 
 [Jest plugin]:/packages/gasket-plugin-jest/README.md
+
 [Mocha plugin]:/packages/gasket-plugin-mocha/README.md
+
 [lint plugin]:/packages/gasket-plugin-lint/README.md

--- a/packages/gasket-cli/README.md
+++ b/packages/gasket-cli/README.md
@@ -300,27 +300,15 @@ npm install --no-save @gasket/preset-nextjs @gasket/redux next react-dom
 <!-- LINKS -->
 
 [npm]:https://docs.npm.red
-
 [yarn]:https://yarnpkg.com
-
 [npm env vars]:https://docs.npmjs.com/misc/config#environment-variables
-
 [yarn env vars]:https://yarnpkg.com/en/docs/envvars#toc-npm-config
-
 [inquirer questions]:https://github.com/SBoudrias/Inquirer.js#question
-
 [execWaterfall]:/packages/gasket-engine/README.md#execwaterfallevent-value-args
-
 [exec]:/packages/gasket-engine/README.md#execevent-args
-
 [Configuration Guide]: docs/configuration.md
-
 [Plugins Guide]: docs/plugins.md
-
 [Presets Guide]: docs/presets.md
-
 [Jest plugin]:/packages/gasket-plugin-jest/README.md
-
 [Mocha plugin]:/packages/gasket-plugin-mocha/README.md
-
 [lint plugin]:/packages/gasket-plugin-lint/README.md

--- a/packages/gasket-cli/bin/run
+++ b/packages/gasket-cli/bin/run
@@ -1,23 +1,5 @@
 #!/usr/bin/env node
-
-const { flags: Flags, parse } = require('@oclif/parser');
-
-const { flags } = parse(process.argv, {
-  flags: {
-    require: Flags.string({
-      multiple: true
-    })
-  },
-  strict: false
-});
-
-if (flags.require) {
-  const { Resolver } = require('@gasket/resolve')
-  const resolver = new Resolver({ resolveFrom: process.cwd() })
-  flags.require.forEach(module => {
-    resolver.require(module)
-  })
-}
+require('../src/utils/setup')();
 
 require('@oclif/command').run()
-  .catch(require('@oclif/errors/handle'))
+  .catch(require('@oclif/errors/handle'));

--- a/packages/gasket-cli/bin/run
+++ b/packages/gasket-cli/bin/run
@@ -1,4 +1,23 @@
 #!/usr/bin/env node
 
+const { flags: Flags, parse } = require('@oclif/parser');
+
+const { flags } = parse(process.argv, {
+  flags: {
+    require: Flags.string({
+      multiple: true
+    })
+  },
+  strict: false
+});
+
+if (flags.require) {
+  const { Resolver } = require('@gasket/resolve')
+  const resolver = new Resolver({ resolveFrom: process.cwd() })
+  flags.require.forEach(module => {
+    resolver.require(module)
+  })
+}
+
 require('@oclif/command').run()
   .catch(require('@oclif/errors/handle'))

--- a/packages/gasket-cli/package.json
+++ b/packages/gasket-cli/package.json
@@ -72,6 +72,7 @@
     "concat-stream": "^2.0.0",
     "cross-spawn": "^7.0.1",
     "deepmerge": "^4.2.2",
+    "getopts": "^2.3.0",
     "glob": "^7.1.6",
     "handlebars": "^4.7.6",
     "inquirer": "6.3.1",

--- a/packages/gasket-cli/src/commands/create.js
+++ b/packages/gasket-cli/src/commands/create.js
@@ -131,6 +131,7 @@ comma-separated values: --plugins=jest,zkconfig^1.0.0
   }),
   'require': flags.string({
     description: 'Require module(s) before Gasket is initialized',
+    char: 'r',
     multiple: true
   }),
   'bootstrap': flags.boolean({

--- a/packages/gasket-cli/src/commands/create.js
+++ b/packages/gasket-cli/src/commands/create.js
@@ -105,14 +105,14 @@ class CreateCommand extends Command {
  */
 const commasToArray = input => input.split(',').map(name => name.trim());
 
-CreateCommand.description = `Create a new gasket application`;
+CreateCommand.description = `Create a new Gasket application`;
 CreateCommand.flags = {
   'presets': flags.string({
     env: 'GASKET_PRESETS',
     char: 'p',
     multiple: true,
     parse: commasToArray,
-    description: `Initial gasket preset(s) to use.
+    description: `Initial Gasket preset(s) to use.
 Can be set as short name with version (e.g. --presets nextjs@^1.0.0)
 Or other (multiple) custom presets (e.g. --presets my-gasket-preset@1.0.0.beta-1,nextjs@^1.0.0)`
   }),
@@ -129,15 +129,19 @@ comma-separated values: --plugins=jest,zkconfig^1.0.0
     description: `Selects which package manager you would like to use during
  installation. (e.g. --package-manager yarn)`
   }),
+  'require': flags.string({
+    description: 'Require module(s) before Gasket is initialized',
+    multiple: true
+  }),
   'bootstrap': flags.boolean({
     default: true,
-    description: '(INTERNAL) If provided, skip the bootstrap phase of gasket create',
+    description: '(INTERNAL) If provided, skip the bootstrap phase',
     allowNo: true,
     hidden: true
   }),
   'generate': flags.boolean({
     default: true,
-    description: '(INTERNAL) If provided, skip the generate phase of gasket create',
+    description: '(INTERNAL) If provided, skip the generate phase',
     allowNo: true,
     hidden: true
   }),
@@ -171,7 +175,7 @@ CreateCommand.args = [
   {
     name: 'appname',
     required: true,
-    description: 'Name of the gasket application to create'
+    description: 'Name of the Gasket application to create'
   }
 ];
 

--- a/packages/gasket-cli/src/utils/setup.js
+++ b/packages/gasket-cli/src/utils/setup.js
@@ -1,0 +1,21 @@
+/**
+ * Step which runs before oclif any everything else is required.
+ * Handles the `--require` flags to allow for early importing of instrumentation
+ * modules and the like.
+ *
+ * @param {string[]} [argv] - CLI arguments - defaults to process.argv
+ */
+module.exports = function setup(argv = process.argv) {
+  // Using to parse args before mounting all of oclif
+  const getopts = require('getopts');
+  const opts = getopts(argv);
+
+  if (opts.require) {
+    const required = Array.isArray(opts.require) ? opts.require : [opts.require];
+    required.forEach(module => {
+      require(
+        require.resolve(module, { paths: [process.cwd()] })
+      );
+    });
+  }
+};

--- a/packages/gasket-cli/src/utils/setup.js
+++ b/packages/gasket-cli/src/utils/setup.js
@@ -8,7 +8,11 @@
 module.exports = function setup(argv = process.argv) {
   // Using to parse args before mounting all of oclif
   const getopts = require('getopts');
-  const opts = getopts(argv);
+  const opts = getopts(argv, {
+    alias: {
+      require: ['r']
+    }
+  });
 
   if (opts.require) {
     const required = Array.isArray(opts.require) ? opts.require : [opts.require];

--- a/packages/gasket-cli/test/fixtures/example-setup.js
+++ b/packages/gasket-cli/test/fixtures/example-setup.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/gasket-cli/test/unit/utils/setup.test.js
+++ b/packages/gasket-cli/test/unit/utils/setup.test.js
@@ -1,0 +1,45 @@
+const sinon = require('sinon');
+const assume = require('assume');
+const setup = require('../../../src/utils/setup');
+require('../../fixtures/example-setup');
+
+const resolvedFile = require.resolve('../../fixtures/example-setup.js', { paths: [__dirname] });
+const resolvedPkg = require.resolve('mocha', { paths: [__dirname] });
+delete require.cache[resolvedFile];
+delete require.cache[resolvedPkg];
+
+describe('cli setup', function () {
+  beforeEach(function () {
+    sinon.stub(process, 'cwd').callsFake(() => __dirname);
+  });
+
+  afterEach(function () {
+    sinon.restore();
+    delete require.cache[resolvedFile];
+    delete require.cache[resolvedPkg];
+  });
+
+  it('requires correctly resolved file', function () {
+    assume(require.cache).not.property(resolvedFile);
+    setup(['/path/to/node', '/path/to/cli/bin', 'command', '--require', '../../fixtures/example-setup.js']);
+    assume(require.cache).property(resolvedFile);
+  });
+
+  it('requires correctly resolved package', function () {
+    assume(require.cache).not.property(resolvedPkg);
+    setup(['/path/to/node', '/path/to/cli/bin', 'command', '--require', 'mocha']);
+    assume(require.cache).property(resolvedPkg);
+  });
+
+  it('supports multiple flags', function () {
+    assume(require.cache).not.property(resolvedFile);
+    assume(require.cache).not.property(resolvedPkg);
+    setup([
+      '/path/to/node', '/path/to/cli/bin', 'command',
+      '--require', '../../fixtures/example-setup.js',
+      '--require', 'mocha'
+    ]);
+    assume(require.cache).property(resolvedFile);
+    assume(require.cache).property(resolvedPkg);
+  });
+});

--- a/packages/gasket-cli/test/unit/utils/setup.test.js
+++ b/packages/gasket-cli/test/unit/utils/setup.test.js
@@ -42,4 +42,16 @@ describe('cli setup', function () {
     assume(require.cache).property(resolvedFile);
     assume(require.cache).property(resolvedPkg);
   });
+
+  it('allows short -r flags', function () {
+    assume(require.cache).not.property(resolvedFile);
+    assume(require.cache).not.property(resolvedPkg);
+    setup([
+      '/path/to/node', '/path/to/cli/bin', 'command',
+      '-r', '../../fixtures/example-setup.js',
+      '-r', 'mocha'
+    ]);
+    assume(require.cache).property(resolvedFile);
+    assume(require.cache).property(resolvedPkg);
+  });
 });

--- a/packages/gasket-plugin-command/lib/command.js
+++ b/packages/gasket-plugin-command/lib/command.js
@@ -108,7 +108,6 @@ GasketCommand.flags = {
   root: flags.string({
     env: 'GASKET_ROOT',
     default: process.env.FAUX_ROOT || process.cwd(), // eslint-disable-line no-process-env
-    char: 'r',
     description: 'Top-level app directory'
   }),
   env: flags.string({
@@ -117,6 +116,7 @@ GasketCommand.flags = {
   }),
   require: flags.string({
     description: 'Require module before Gasket is initialized',
+    char: 'r',
     multiple: true
   })
 };

--- a/packages/gasket-plugin-command/lib/command.js
+++ b/packages/gasket-plugin-command/lib/command.js
@@ -103,7 +103,7 @@ GasketCommand.flags = {
     env: 'GASKET_CONFIG',
     default: 'gasket.config',
     char: 'c',
-    description: 'Fully qualified gasket config to load'
+    description: 'Fully qualified Gasket config to load'
   }),
   root: flags.string({
     env: 'GASKET_ROOT',
@@ -114,6 +114,10 @@ GasketCommand.flags = {
   env: flags.string({
     env: 'NODE_ENV',
     description: 'Target runtime environment'
+  }),
+  require: flags.string({
+    description: 'Require module before Gasket is initialized',
+    multiple: true
   })
 };
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Adding  support for a `--require` (or `-r`) to allow apps to preload modules before the CLI fully initializes. This pattern is in line with other familiar CLIs such as [node](https://nodejs.org/api/cli.html#-r---require-module) or [mocha](https://mochajs.org/#-require-module-r-module).

We are using [getopts](https://github.com/jorgebucaran/getopts) as an intermediate args parser for this step. It is a very thin zero-dependency parser that avoids bringing in several dependencies which developers may desire bootstrapping.

### Background 

Exploring options for loading instrumentation tool for various Gasket commands. In particular, using [@gasket/plugin-elastic-apm](https://github.com/godaddy/gasket/tree/main/packages/gasket-plugin-elastic-apm) to load [apm-agent-nodejs](https://github.com/elastic/apm-agent-nodejs) is too late in the process. While it fires in the `preboot` lifecycle, this happens after certain modules have already been required and so miss being bootstrapped.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/cli**
- Support for `--require` flag to load modules before Gasket initializes

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- [x] updated unit test
- [x] locally with `create` command and `start` command in an app