### PR TITLE
Wrap fetch for patches

### DIFF
--- a/packages/gasket-fetch/lib/browser.js
+++ b/packages/gasket-fetch/lib/browser.js
@@ -1,6 +1,10 @@
+// Wrapper to access window.fetch in case of polyfill or monkey patch
+function fetchWrapper(...args) {
+  return window.fetch(...args);
+}
 
-exports = window.fetch; // To import fetch from @gasket/fetch
-exports.default = window.fetch; // For TypeScript consumers without esModuleInterop.
+exports = fetchWrapper; // To import fetch from @gasket/fetch
+exports.default = fetchWrapper; // For TypeScript consumers without esModuleInterop.
 exports.Headers = window.Headers;
 exports.Request = window.Request;
 exports.Response = window.Response;

--- a/packages/gasket-fetch/test/browser.spec.js
+++ b/packages/gasket-fetch/test/browser.spec.js
@@ -1,4 +1,5 @@
 import { describe, it } from 'mocha';
+import assume from 'assume';
 
 import fetch from '../lib/browser';
 const { AbortController, Request, Headers, Response } = fetch;
@@ -9,4 +10,10 @@ describe('fetch is available in browsers', function () {
   it('can fetch resources', assertGet(fetch));
   it('fetch can POST to API', assertPost(fetch));
   it('can abort fetch', assertAbort(fetch, AbortController));
+  it('uses patched version', function () {
+    const original = window.fetch;
+    window.fetch = () => 'replaced window.fetch';
+    assume(fetch()).equals('replaced window.fetch');
+    window.fetch = original;
+  });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Use a wrapper to access `window.fetch` in case an app polyfills or otherwise patches the browser-native Fetch.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/fetch**
- Use wrapper to call through to `window.fetch` in browser

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
- Updated unit tests
- Tested in local app