### PR TITLE
fix:(@gasket/plugin-docs) fix for the defaults to be passed to plugin-level docsSetup hooks

### DIFF
--- a/packages/gasket-plugin-docs/lib/utils/build-config-set.js
+++ b/packages/gasket-plugin-docs/lib/utils/build-config-set.js
@@ -56,6 +56,7 @@ async function buildDocsConfigSet(gasket) {
   const builder = new DocsConfigSetBuilder(gasket);
 
   await gasket.execApply('docsSetup', async (plugin, handler) => {
+    // console.log(plugin);
     //
     // If this is a lifecycle file, use it to modify the app-level docConfig
     //
@@ -66,7 +67,8 @@ async function buildDocsConfigSet(gasket) {
 
     const pluginData = buildDocsConfigSet.findPluginData(plugin, metadata.plugins, logger);
     if (pluginData) {
-      const docsSetup = await handler();
+      // console.log(pluginData);
+      const docsSetup = await handler({ defaults });
       await builder.addPlugin(pluginData, docsSetup);
     }
   });

--- a/packages/gasket-plugin-docs/lib/utils/build-config-set.js
+++ b/packages/gasket-plugin-docs/lib/utils/build-config-set.js
@@ -56,7 +56,6 @@ async function buildDocsConfigSet(gasket) {
   const builder = new DocsConfigSetBuilder(gasket);
 
   await gasket.execApply('docsSetup', async (plugin, handler) => {
-    // console.log(plugin);
     //
     // If this is a lifecycle file, use it to modify the app-level docConfig
     //
@@ -67,7 +66,6 @@ async function buildDocsConfigSet(gasket) {
 
     const pluginData = buildDocsConfigSet.findPluginData(plugin, metadata.plugins, logger);
     if (pluginData) {
-      // console.log(pluginData);
       const docsSetup = await handler({ defaults });
       await builder.addPlugin(pluginData, docsSetup);
     }

--- a/packages/gasket-plugin-docs/test/utils/build-config-set.test.js
+++ b/packages/gasket-plugin-docs/test/utils/build-config-set.test.js
@@ -173,8 +173,14 @@ describe('utils - buildConfigSet', () => {
       assume(mockGasket.execApply).calledWith('docsSetup', sinon.match.func);
     });
 
-    it('docsSetup defaults are available to hooks', async () => {
+    it('docsSetup defaults are available to app-level hooks', async () => {
       await docsSetupCallback(null, mockHandler);
+      assume(mockHandler).calledWith(sinon.match.object);
+      assume(mockHandler.getCall(0).args[0]).property('defaults', mockDefaults);
+    });
+
+    it('docsSetup defaults are available to plugin-level hooks', async () => {
+      await docsSetupCallback({ name: 'example-plugin' }, mockHandler);
       assume(mockHandler).calledWith(sinon.match.object);
       assume(mockHandler.getCall(0).args[0]).property('defaults', mockDefaults);
     });


### PR DESCRIPTION
## Summary

- fix for the defaults to be passed to plugin-level docsSetup hooks

## Changelog

- fix for the defaults to be passed to plugin-level docsSetup hooks

## Test Plan

- Added test case
