### PR TITLE
feat:(@gasket/plugin-docs) Configuration section in generated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ Available structure
 | [plugins/]         | One-off plugins for apps                               |
 | [public/]          | NextJS static files                                    |
 | [public/locales/]  | Locale JSON files with translation strings             |
-| test/              | Test files                                             |
-| test/              | Test files                                             |
+| [test/][6]         | Test files                                             |
+| [test/][7]         | Test files                                             |
 | [app.config.js]    | App configuration with environment overrides           |
 | [cypress.json]     | Cypress configuration                                  |
 | [gasket.config.js] | Gasket config for an app                               |
@@ -211,7 +211,7 @@ Available configuration options in the `gasket.config.js`
 
 | Name             | Description                         | Type   | Default | From                |
 | ---------------- | ----------------------------------- | ------ | ------- | ------------------- |
-| [docs][6]        | Docs config object                  | object | {}      | @gasket/plugin-docs |
+| [docs][8]        | Docs config object                  | object | {}      | @gasket/plugin-docs |
 | [docs.outputDir] | Output directory for generated docs | string | .docs   | @gasket/plugin-docs |
 
 <!-- LINKS -->
@@ -284,6 +284,9 @@ Available configuration options in the `gasket.config.js`
 [plugins/]:/packages/gasket-cli/docs/plugins.md#one-off-plugins
 [public/]:https://nextjs.org/docs/basic-features/static-file-serving
 [public/locales/]:/packages/gasket-plugin-intl/README.md#Options
+[test/]:/packages/gasket-plugin-cypress/README.md
+[6]:/packages/gasket-plugin-jest/README.md
+[7]:/packages/gasket-plugin-mocha/README.md
 [app.config.js]:/packages/gasket-plugin-config/README.md
 [cypress.json]:https://docs.cypress.io/guides/references/configuration
 [gasket.config.js]:/packages/gasket-cli/docs/configuration.md
@@ -336,7 +339,7 @@ Available configuration options in the `gasket.config.js`
 [@gasket/typescript-tests]:/packages/gasket-typescript-tests/README.md
 [@gasket/utils]:/packages/gasket-utils/README.md
 [create-gasket-app]:/packages/create-gasket-app/README.md
-[6]:/packages/gasket-plugin-docs/README.md#configuration
+[8]:/packages/gasket-plugin-docs/README.md#configuration
 [docs.outputDir]:/packages/gasket-plugin-docs/README.md#configuration
 <!-- END GENERATED -->
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,15 @@ Supporting modules
 | [@gasket/utils]            | 6.24.0  | Reusable utilities for Gasket internals                                              |
 | [create-gasket-app]        | 6.24.1  | starter pack for creating a gasket app                                               |
 
+## Configurations
+
+Available configuration options in the `gasket.config.js`
+
+| Name             | Description                         | Type   | Default | From                |
+| ---------------- | ----------------------------------- | ------ | ------- | ------------------- |
+| [docs][6]        | Docs config object                  | object | {}      | @gasket/plugin-docs |
+| [docs.outputDir] | Output directory for generated docs | string | .docs   | @gasket/plugin-docs |
+
 <!-- LINKS -->
 
 [Quick Start Guide]:docs/quick-start.md
@@ -327,6 +336,8 @@ Supporting modules
 [@gasket/typescript-tests]:/packages/gasket-typescript-tests/README.md
 [@gasket/utils]:/packages/gasket-utils/README.md
 [create-gasket-app]:/packages/create-gasket-app/README.md
+[6]:/packages/gasket-plugin-docs/README.md#configuration
+[docs.outputDir]:/packages/gasket-plugin-docs/README.md#configuration
 <!-- END GENERATED -->
 
 ## License

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ Available structure
 | [plugins/]         | One-off plugins for apps                               |
 | [public/]          | NextJS static files                                    |
 | [public/locales/]  | Locale JSON files with translation strings             |
-| [test/][6]         | Test files                                             |
-| [test/][7]         | Test files                                             |
+| test/              | Test files                                             |
+| test/              | Test files                                             |
 | [app.config.js]    | App configuration with environment overrides           |
 | [cypress.json]     | Cypress configuration                                  |
 | [gasket.config.js] | Gasket config for an app                               |
@@ -211,7 +211,7 @@ Available configuration options in the `gasket.config.js`
 
 | Name             | Description                         | Type   | Default | From                |
 | ---------------- | ----------------------------------- | ------ | ------- | ------------------- |
-| [docs][8]        | Docs config object                  | object | {}      | @gasket/plugin-docs |
+| [docs][6]        | Docs config object                  | object | {}      | @gasket/plugin-docs |
 | [docs.outputDir] | Output directory for generated docs | string | .docs   | @gasket/plugin-docs |
 
 <!-- LINKS -->
@@ -284,9 +284,6 @@ Available configuration options in the `gasket.config.js`
 [plugins/]:/packages/gasket-cli/docs/plugins.md#one-off-plugins
 [public/]:https://nextjs.org/docs/basic-features/static-file-serving
 [public/locales/]:/packages/gasket-plugin-intl/README.md#Options
-[test/]:/packages/gasket-plugin-cypress/README.md
-[6]:/packages/gasket-plugin-jest/README.md
-[7]:/packages/gasket-plugin-mocha/README.md
 [app.config.js]:/packages/gasket-plugin-config/README.md
 [cypress.json]:https://docs.cypress.io/guides/references/configuration
 [gasket.config.js]:/packages/gasket-cli/docs/configuration.md
@@ -339,7 +336,7 @@ Available configuration options in the `gasket.config.js`
 [@gasket/typescript-tests]:/packages/gasket-typescript-tests/README.md
 [@gasket/utils]:/packages/gasket-utils/README.md
 [create-gasket-app]:/packages/create-gasket-app/README.md
-[8]:/packages/gasket-plugin-docs/README.md#configuration
+[6]:/packages/gasket-plugin-docs/README.md#configuration
 [docs.outputDir]:/packages/gasket-plugin-docs/README.md#configuration
 <!-- END GENERATED -->
 

--- a/README.md
+++ b/README.md
@@ -209,10 +209,10 @@ Supporting modules
 
 Available configuration options in the `gasket.config.js`
 
-| Name             | Description                         | Type   | Default | From                |
-| ---------------- | ----------------------------------- | ------ | ------- | ------------------- |
-| [docs][6]        | Docs config object                  | object | {}      | @gasket/plugin-docs |
-| [docs.outputDir] | Output directory for generated docs | string | .docs   | @gasket/plugin-docs |
+| Name             | Description                         | Type   | Default |
+| ---------------- | ----------------------------------- | ------ | ------- |
+| [docs][6]        | Docs config object                  | object | {}      |
+| [docs.outputDir] | Output directory for generated docs | string | .docs   |
 
 <!-- LINKS -->
 

--- a/packages/gasket-plugin-docs/lib/metadata.js
+++ b/packages/gasket-plugin-docs/lib/metadata.js
@@ -38,6 +38,17 @@ module.exports = function metadata(gasket, meta) {
       name: outputDir + '/',
       description: 'Output of the docs command',
       link: 'README.md#options'
+    }],
+    configurations: [{
+      name: 'docs',
+      description: 'Docs config object',
+      type: 'object',
+      default: '{}'
+    },{
+      name: 'docs.outputDir',
+      description: 'Output directory for generated docs',
+      type: 'string',
+      default: '.docs'
     }]
   };
 };

--- a/packages/gasket-plugin-docs/lib/metadata.js
+++ b/packages/gasket-plugin-docs/lib/metadata.js
@@ -41,11 +41,13 @@ module.exports = function metadata(gasket, meta) {
     }],
     configurations: [{
       name: 'docs',
+      link: 'README.md#configuration',
       description: 'Docs config object',
       type: 'object',
       default: '{}'
-    },{
+    }, {
       name: 'docs.outputDir',
+      link: 'README.md#configuration',
       description: 'Output directory for generated docs',
       type: 'string',
       default: '.docs'

--- a/packages/gasket-plugin-docs/lib/utils/config-set-builder.js
+++ b/packages/gasket-plugin-docs/lib/utils/config-set-builder.js
@@ -354,6 +354,7 @@ class DocsConfigSetBuilder {
   getConfigSet() {
     const detailDocsConfigs = detailDocsTypes
       .reduce((acc, metaType) => ({ ...acc, [metaType]: this._flattenDetails(metaType) }), {});
+
     // sortByName
     // - project, scoped, non-scoped
 

--- a/packages/gasket-plugin-docs/lib/utils/config-set-builder.js
+++ b/packages/gasket-plugin-docs/lib/utils/config-set-builder.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const defaultsDeep = require('lodash.defaultsdeep');
 const { promisify } = require('util');
-const { sortModules, sortStructures, sortCommands, sortLifecycles, sortGuides } = require('./sorts');
+const { sortModules, sortStructures, sortCommands, sortLifecycles, sortGuides, sortConfigurations } = require('./sorts');
 
 // TODO: Need to review for native promise usage
 const glob = promisify(require('glob'));
@@ -23,6 +23,9 @@ const detailDocsHelpers = {
   },
   lifecycles: {
     sort: sortLifecycles
+  },
+  configurations: {
+    sort: sortConfigurations
   }
 };
 
@@ -351,7 +354,6 @@ class DocsConfigSetBuilder {
   getConfigSet() {
     const detailDocsConfigs = detailDocsTypes
       .reduce((acc, metaType) => ({ ...acc, [metaType]: this._flattenDetails(metaType) }), {});
-
     // sortByName
     // - project, scoped, non-scoped
 

--- a/packages/gasket-plugin-docs/lib/utils/generate-index.js
+++ b/packages/gasket-plugin-docs/lib/utils/generate-index.js
@@ -33,14 +33,15 @@ function generateContent(docsConfigSet) {
   addContent(`[${appDocs.name}] — ${appDocs.description}`);
   refMap.set(appDocs.name, formatLink(appDocs.link, appDocs.targetRoot));
 
-  const addSection = (sectionTitle, sectionDesc, docs, { includeVersion = true } = {}) => {
+  const addSection = (sectionTitle, sectionDesc, docs, { includeVersion = true } = {}, additionalHeaders = []) => {
     if (!docs || !docs.length) return;
 
     addContent(`## ${sectionTitle}`);
     addContent(sectionDesc);
     addTable([
-      includeVersion ? ['Name', 'Version', 'Description'] : ['Name', 'Description'],
+      includeVersion ? ['Name', 'Version', 'Description'].concat(additionalHeaders) : ['Name', 'Description'].concat(additionalHeaders),
       ...docs.map(moduleDoc => {
+        const additionalHeaderValues = additionalHeaders.map(h => moduleDoc[h.toLowerCase()]);
         const { name, description, link, version, targetRoot } = moduleDoc;
         let itemName = name;
         if (link) {
@@ -48,7 +49,7 @@ function generateContent(docsConfigSet) {
           itemName = ref === name ? `[${name}]` : `[${name}][${ref}]`;
           refMap.set(ref, formatLink(link, targetRoot));
         }
-        return [itemName, ...(includeVersion ? [version, description] : [description])];
+        return [itemName, ...(includeVersion ? [version, description, ...additionalHeaderValues] : [description, ...additionalHeaderValues])];
       })
     ]);
   };
@@ -60,6 +61,7 @@ function generateContent(docsConfigSet) {
   addSection('Presets', 'All configured presets', docsConfigSet.presets);
   addSection('Plugins', 'All configured plugins', docsConfigSet.plugins);
   addSection('Modules', 'Dependencies and supporting modules', docsConfigSet.modules);
+  addSection('Configuration', 'Available configuration options in the `gasket.config.js`', docsConfigSet.configurations, { includeVersion: false }, ['Type', 'Default', 'From']);
 
   addContent('<!-- LINKS -->');
   for (const [name, link] of refMap) {

--- a/packages/gasket-plugin-docs/lib/utils/generate-index.js
+++ b/packages/gasket-plugin-docs/lib/utils/generate-index.js
@@ -34,7 +34,6 @@ function generateContent(docsConfigSet) {
   refMap.set(appDocs.name, formatLink(appDocs.link, appDocs.targetRoot));
 
   const addSection = (sectionTitle, sectionDesc, docs, { includeVersion = true, additionalHeaders = [] } = {}) => {
-    console.log(sectionTitle, docs);
     if (!docs || !docs.length) return;
 
     addContent(`## ${sectionTitle}`);

--- a/packages/gasket-plugin-docs/lib/utils/generate-index.js
+++ b/packages/gasket-plugin-docs/lib/utils/generate-index.js
@@ -33,7 +33,13 @@ function generateContent(docsConfigSet) {
   addContent(`[${appDocs.name}] — ${appDocs.description}`);
   refMap.set(appDocs.name, formatLink(appDocs.link, appDocs.targetRoot));
 
-  const addSection = (sectionTitle, sectionDesc, docs, { includeVersion = true, additionalHeaders = [] } = {}) => {
+  const addSection = (sectionTitle, sectionDesc, docs,
+    {
+      includeVersion = true,
+      additionalHeaders = [],
+      linkFallbacks = false
+    } = {}
+  ) => {
     if (!docs || !docs.length) return;
 
     addContent(`## ${sectionTitle}`);
@@ -44,12 +50,12 @@ function generateContent(docsConfigSet) {
         : ['Name', 'Description'].concat(additionalHeaders),
       ...docs.map(moduleDoc => {
         const additionalHeaderValues = additionalHeaders.map(h => moduleDoc[h.toLowerCase()]);
-        const { name, description, link = 'README.md', version, targetRoot, from } = moduleDoc;
+        const { name, description, link, version, targetRoot } = moduleDoc;
         let itemName = name;
-        if (link || from) {
+        if (link || linkFallbacks) {
           const ref = uniqueRef(name);
           itemName = ref === name ? `[${name}]` : `[${name}][${ref}]`;
-          refMap.set(ref, formatLink(link, targetRoot));
+          refMap.set(ref, formatLink(link || 'README.md', targetRoot));
         }
 
         return [
@@ -74,7 +80,7 @@ function generateContent(docsConfigSet) {
     'Configurations',
     'Available configuration options in the `gasket.config.js`',
     docsConfigSet.configurations,
-    { includeVersion: false, additionalHeaders: ['Type', 'Default', 'From'] }
+    { includeVersion: false, additionalHeaders: ['Type', 'Default', 'From'], linkFallbacks: true }
   );
 
   addContent('<!-- LINKS -->');

--- a/packages/gasket-plugin-docs/lib/utils/generate-index.js
+++ b/packages/gasket-plugin-docs/lib/utils/generate-index.js
@@ -33,13 +33,15 @@ function generateContent(docsConfigSet) {
   addContent(`[${appDocs.name}] — ${appDocs.description}`);
   refMap.set(appDocs.name, formatLink(appDocs.link, appDocs.targetRoot));
 
-  const addSection = (sectionTitle, sectionDesc, docs, { includeVersion = true } = {}, additionalHeaders = []) => {
+  const addSection = (sectionTitle, sectionDesc, docs, { includeVersion = true, additionalHeaders = [] } = {}) => {
     if (!docs || !docs.length) return;
 
     addContent(`## ${sectionTitle}`);
     addContent(sectionDesc);
     addTable([
-      includeVersion ? ['Name', 'Version', 'Description'].concat(additionalHeaders) : ['Name', 'Description'].concat(additionalHeaders),
+      includeVersion
+        ? ['Name', 'Version', 'Description'].concat(additionalHeaders)
+        : ['Name', 'Description'].concat(additionalHeaders),
       ...docs.map(moduleDoc => {
         const additionalHeaderValues = additionalHeaders.map(h => moduleDoc[h.toLowerCase()]);
         const { name, description, link, version, targetRoot } = moduleDoc;
@@ -49,7 +51,13 @@ function generateContent(docsConfigSet) {
           itemName = ref === name ? `[${name}]` : `[${name}][${ref}]`;
           refMap.set(ref, formatLink(link, targetRoot));
         }
-        return [itemName, ...(includeVersion ? [version, description, ...additionalHeaderValues] : [description, ...additionalHeaderValues])];
+        return [
+          itemName,
+          ...(includeVersion
+            ? [version, description, ...additionalHeaderValues]
+            : [description, ...additionalHeaderValues]
+          )
+        ];
       })
     ]);
   };
@@ -61,7 +69,12 @@ function generateContent(docsConfigSet) {
   addSection('Presets', 'All configured presets', docsConfigSet.presets);
   addSection('Plugins', 'All configured plugins', docsConfigSet.plugins);
   addSection('Modules', 'Dependencies and supporting modules', docsConfigSet.modules);
-  addSection('Configuration', 'Available configuration options in the `gasket.config.js`', docsConfigSet.configurations, { includeVersion: false }, ['Type', 'Default', 'From']);
+  addSection(
+    'Configurations',
+    'Available configuration options in the `gasket.config.js`',
+    docsConfigSet.configurations,
+    { includeVersion: false, additionalHeaders: ['Type', 'Default', 'From'] }
+  );
 
   addContent('<!-- LINKS -->');
   for (const [name, link] of refMap) {

--- a/packages/gasket-plugin-docs/lib/utils/generate-index.js
+++ b/packages/gasket-plugin-docs/lib/utils/generate-index.js
@@ -34,6 +34,7 @@ function generateContent(docsConfigSet) {
   refMap.set(appDocs.name, formatLink(appDocs.link, appDocs.targetRoot));
 
   const addSection = (sectionTitle, sectionDesc, docs, { includeVersion = true, additionalHeaders = [] } = {}) => {
+    console.log(sectionTitle, docs);
     if (!docs || !docs.length) return;
 
     addContent(`## ${sectionTitle}`);
@@ -44,13 +45,14 @@ function generateContent(docsConfigSet) {
         : ['Name', 'Description'].concat(additionalHeaders),
       ...docs.map(moduleDoc => {
         const additionalHeaderValues = additionalHeaders.map(h => moduleDoc[h.toLowerCase()]);
-        const { name, description, link, version, targetRoot } = moduleDoc;
+        const { name, description, link = 'README.md', version, targetRoot, from } = moduleDoc;
         let itemName = name;
-        if (link) {
+        if (link || from) {
           const ref = uniqueRef(name);
           itemName = ref === name ? `[${name}]` : `[${name}][${ref}]`;
           refMap.set(ref, formatLink(link, targetRoot));
         }
+
         return [
           itemName,
           ...(includeVersion

--- a/packages/gasket-plugin-docs/lib/utils/generate-index.js
+++ b/packages/gasket-plugin-docs/lib/utils/generate-index.js
@@ -80,7 +80,7 @@ function generateContent(docsConfigSet) {
     'Configurations',
     'Available configuration options in the `gasket.config.js`',
     docsConfigSet.configurations,
-    { includeVersion: false, additionalHeaders: ['Type', 'Default', 'From'], linkFallbacks: true }
+    { includeVersion: false, additionalHeaders: ['Type', 'Default'], linkFallbacks: true }
   );
 
   addContent('<!-- LINKS -->');

--- a/packages/gasket-plugin-docs/lib/utils/sorts.js
+++ b/packages/gasket-plugin-docs/lib/utils/sorts.js
@@ -142,6 +142,11 @@ const sortCommands = sortByKey('name', alphaCompare);
 // TODO (kinetifex): eventually sort by parent and order when doing graphing work
 const sortLifecycles = sortByKey('name', alphaCompare);
 
+/**
+ * Sort an array of configurations by name
+ *
+ * @type {function(DetailDocsConfig[]): DetailDocsConfig[]}
+ */
 const sortConfigurations = sortByKey('name', alphaCompare);
 
 module.exports = {

--- a/packages/gasket-plugin-docs/lib/utils/sorts.js
+++ b/packages/gasket-plugin-docs/lib/utils/sorts.js
@@ -142,10 +142,13 @@ const sortCommands = sortByKey('name', alphaCompare);
 // TODO (kinetifex): eventually sort by parent and order when doing graphing work
 const sortLifecycles = sortByKey('name', alphaCompare);
 
+const sortConfigurations = sortByKey('name', alphaCompare);
+
 module.exports = {
   sortModules,
   sortGuides,
   sortStructures,
   sortCommands,
-  sortLifecycles
+  sortLifecycles,
+  sortConfigurations
 };

--- a/packages/gasket-plugin-docs/test/utils/config-set-builder.test.js
+++ b/packages/gasket-plugin-docs/test/utils/config-set-builder.test.js
@@ -319,7 +319,8 @@ describe('utils - DocsConfigSetBuilder', () => {
         'structures',
         'lifecycles',
         'guides',
-        'commands'
+        'commands',
+        'configurations'
       ];
       const actual = Object.keys(results);
 
@@ -335,13 +336,15 @@ describe('utils - DocsConfigSetBuilder', () => {
         path: '/path/to/node_modules/example-plugin',
         commands: [{ name: 'example-command' }],
         structures: [{ name: 'example-structure' }],
-        lifecycles: [{ name: 'example-lifecycle' }]
+        lifecycles: [{ name: 'example-lifecycle' }],
+        configurations: [{ name: 'example-gasket-config' }]
       }, {
         name: '@some/example-plugin',
         path: '/path/to/node_modules/@some/example-plugin',
         commands: [{ name: 'some-example-command' }],
         structures: [{ name: 'some-example-structure' }],
-        lifecycles: [{ name: 'some-example-lifecycle' }]
+        lifecycles: [{ name: 'some-example-lifecycle' }],
+        configurations: [{ name: 'some-example-gasket-config' }]
       }]);
     });
 
@@ -351,6 +354,7 @@ describe('utils - DocsConfigSetBuilder', () => {
       assume(results.commands).lengthOf(2);
       assume(results.structures).lengthOf(2);
       assume(results.lifecycles).lengthOf(2);
+      assume(results.configurations).lengthOf(2);
     });
 
     it('subDocsConfig includes "from" of parent plugin', async () => {

--- a/packages/gasket-plugin-docs/test/utils/generate-index.test.js
+++ b/packages/gasket-plugin-docs/test/utils/generate-index.test.js
@@ -258,7 +258,7 @@ describe('Utils - generateIndex', () => {
       });
 
       describe('configurations', () => {
-        checkSection('configurations', 'Configurations', false, ['Type', 'Default', 'From']);
+        checkSection('configurations', 'Configurations', false, ['Type', 'Default']);
       });
     });
   });

--- a/packages/gasket-plugin-docs/test/utils/generate-index.test.js
+++ b/packages/gasket-plugin-docs/test/utils/generate-index.test.js
@@ -73,6 +73,13 @@ const fullDocsConfigSet = {
   configurations: [{
     name: 'example-gasket-config-param',
     link: 'README.md#configurations',
+    description: 'example-description',
+    type: 'string',
+    default: 'example-default',
+    targetRoot: '/path/to/app/.docs/test-app/plugins/example-plugin',
+    from: 'example-plugin'
+  }, {
+    name: 'some-example-gasket-config-param',
     description: 'some-description',
     type: 'string',
     default: 'some-default',
@@ -130,7 +137,7 @@ describe('Utils - generateIndex', () => {
         //
         // count the number of ref-style links
         //
-        assume(content.match(/\[.+]:/g) || []).lengthOf(9);
+        assume(content.match(/\[.+]:/g) || []).lengthOf(10);
       });
 
       it('makes unique references', async () => {
@@ -157,6 +164,12 @@ describe('Utils - generateIndex', () => {
         const content = await generateContent(fullDocsConfigSet);
         assume(content).includes(`[${config.name}]:`);
         assume(content).includes(`:${expected}`);
+      });
+
+      it('add link fallbacks if configured', async () => {
+        const config = fullDocsConfigSet.configurations[1];
+        const content = await generateContent(fullDocsConfigSet);
+        assume(content).includes(`[${config.name}]:`);
       });
 
       it('does not add links if not configured', async () => {

--- a/packages/gasket-plugin-docs/test/utils/generate-index.test.js
+++ b/packages/gasket-plugin-docs/test/utils/generate-index.test.js
@@ -19,6 +19,7 @@ const emptyDocsConfigSet = {
   commands: [],
   lifecycles: [],
   transforms: [],
+  configurations: [],
   root: '/path/to/app',
   docsRoot: '/path/to/app/.docs'
 };
@@ -69,6 +70,15 @@ const fullDocsConfigSet = {
     targetRoot: '/path/to/app/.docs/test-app/plugins/example-plugin'
   }],
   transforms: [],
+  configurations: [{
+    name: 'example-gasket-config-param',
+    link: 'README.md#configurations',
+    description: 'some-description',
+    type: 'string',
+    default: 'some-default',
+    targetRoot: '/path/to/app/.docs/test-app/plugins/example-plugin',
+    from: 'some-plugin'
+  }],
   root: '/path/to/app',
   docsRoot: '/path/to/app/.docs'
 };
@@ -120,7 +130,7 @@ describe('Utils - generateIndex', () => {
         //
         // count the number of ref-style links
         //
-        assume(content.match(/\[.+]:/g) || []).lengthOf(8);
+        assume(content.match(/\[.+]:/g) || []).lengthOf(9);
       });
 
       it('makes unique references', async () => {
@@ -158,7 +168,7 @@ describe('Utils - generateIndex', () => {
 
     describe('Sections', () => {
 
-      function checkSection(name, title, includeVersion) {
+      function checkSection(name, title, includeVersion, additionalHeaders = []) {
         const fullContent = generateContent(fullDocsConfigSet);
 
         it(`adds section title`, () => {
@@ -175,6 +185,23 @@ describe('Utils - generateIndex', () => {
           it(`includes version in table`, () => {
             assume(fullContent).includes('| Version');
             assume(fullContent).includes('| ----');
+          });
+        }
+
+        if (additionalHeaders.length) {
+          it(`includes additional headers in table`, () => {
+            additionalHeaders.forEach(h => {
+              assume(fullContent).includes(`| ${h}`);
+              assume(fullContent).includes('| ----');
+            });
+          });
+
+          it(`includes additional header values in table`, () => {
+            additionalHeaders.forEach(h => {
+              const value = fullDocsConfigSet[name][0][h.toLowerCase()];
+              assume(fullContent).includes(`| ${value}`);
+              assume(fullContent).includes('| ----');
+            });
           });
         }
 
@@ -215,6 +242,10 @@ describe('Utils - generateIndex', () => {
 
       describe('guides', () => {
         checkSection('guides', 'Guides');
+      });
+
+      describe('configurations', () => {
+        checkSection('configurations', 'Configurations', false, ['Type', 'Default', 'From']);
       });
     });
   });

--- a/packages/gasket-plugin-docs/test/utils/sorts.test.js
+++ b/packages/gasket-plugin-docs/test/utils/sorts.test.js
@@ -1,5 +1,5 @@
 const assume = require('assume');
-const { sortModules, sortStructures, sortCommands, sortGuides } = require('../../lib/utils/sorts');
+const { sortModules, sortStructures, sortCommands, sortGuides, sortConfigurations } = require('../../lib/utils/sorts');
 
 describe('utils - sorts', () => {
 
@@ -184,6 +184,27 @@ describe('utils - sorts', () => {
       ];
 
       const results = sortCommands(begin.map(name => ({ name }))).map(p => p.name);
+      assume(results).eqls(expected);
+    });
+  });
+
+  describe('sortConfigurations', () => {
+    it('sorts alphabetically', () => {
+      const begin = [
+        'b',
+        'd',
+        'c',
+        'a'
+      ];
+
+      const expected = [
+        'a',
+        'b',
+        'c',
+        'd'
+      ];
+
+      const results = sortConfigurations(begin.map(name => ({ name }))).map(p => p.name);
       assume(results).eqls(expected);
     });
   });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
Ticket: [PFX-81](https://jira.godaddy.com/browse/PFX-81)
- Allow for `configurations` in metadata config object
- Add support to `DocsConfigSetBuilder` class
- Expand `addSection` in `generate-index.js` to allow for additional table headers & values
- Add configurations alpha sort to `sorts.js`
- Update associated tests, add new tests for the additional table headers & values and add sorts test

## Changelog
- Allow for `configurations` in metadata config object

## Test Plan
Update associated tests, add new tests for the additional table headers & values and add sorts test.

![Screen Shot 2022-06-08 at 11 54 38 AM](https://user-images.githubusercontent.com/105235096/172697430-85a2d63f-8a9b-45a9-b087-953d48cc5611.png)

![Screen Shot 2022-06-08 at 11 54 29 AM](https://user-images.githubusercontent.com/105235096/172697472-19317dbc-a66f-4256-96f2-158ef54ace82.png)
---
## Result
![Screen Shot 2022-06-08 at 11 48 56 AM](https://user-images.githubusercontent.com/105235096/172697369-78e5ff9e-3386-409e-9910-317f00ca9918.png)


