### PR TITLE
Fix mermaid diagram generation

### DIFF
--- a/packages/gasket-plugin-docs-graphs/CHANGELOG.md
+++ b/packages/gasket-plugin-docs-graphs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-docs-graph`
 
+- Support showing deprecation for lifecycles
+
 ### 6.11.2
 
 - Use fs.promises ([#319])

--- a/packages/gasket-plugin-docs-graphs/lib/plugin.js
+++ b/packages/gasket-plugin-docs-graphs/lib/plugin.js
@@ -14,7 +14,9 @@ module.exports = {
 
       let graph = 'graph LR;\n';
       docsConfigSet.lifecycles.forEach(lifecycle => {
-        const name = lifecycle.name;
+        const name = lifecycle.deprecated
+          ? `${lifecycle.name}[${lifecycle.name} (deprecated)]`
+          : lifecycle.name;
         const from = lifecycle.parent || lifecycle.after || lifecycle.command || lifecycle.from;
         let styling = i => i;
         if (from === lifecycle.command) {

--- a/packages/gasket-plugin-docs-graphs/test/plugin.test.js
+++ b/packages/gasket-plugin-docs-graphs/test/plugin.test.js
@@ -58,6 +58,24 @@ describe('docs graph plugin', function () {
     assume(content).matches('crackle -- exec --> pop;');
   });
 
+  it('supports deprecated lifecycles', async function () {
+    docsConfigSet.lifecycles = [{
+      parent: 'snap',
+      name: 'crackle'
+    }, {
+      parent: 'crackle',
+      name: 'pop',
+      deprecated: true,
+      method: 'exec'
+    }];
+
+    const { targetRoot, link } = await hook({}, docsConfigSet);
+    const content = await read(path.join(targetRoot, link), 'utf-8');
+
+    assume(content).contains('snap --> crackle;');
+    assume(content).contains('crackle -- exec --> pop[pop (deprecated)];');
+  });
+
   it('generates the LHS of the arrows from the correct attribute', async function () {
     const lc = docsConfigSet.lifecycles = [{
       name: 'Anakin',

--- a/packages/gasket-plugin-webpack/CHANGELOG.md
+++ b/packages/gasket-plugin-webpack/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-webpack`
 
+- Fix invalid lifecycle names which was causing the lifecycle diagram to get a syntax error.
+
 ### 6.20.1
 
 - Fix migration links

--- a/packages/gasket-plugin-webpack/lib/index.js
+++ b/packages/gasket-plugin-webpack/lib/index.js
@@ -19,13 +19,15 @@ module.exports = {
           link: 'docs/webpack.md'
         }],
         lifecycles: [{
-          name: 'webpackChain (deprecated)',
+          name: 'webpackChain',
+          deprecated: true,
           method: 'execSync',
           description: 'Setup webpack config by chaining',
           link: 'README.md#webpackChain',
           parent: 'initWebpack'
         }, {
-          name: 'webpack (deprecated)',
+          name: 'webpack',
+          deprecated: true,
           method: 'execSync',
           description: 'Modify webpack config with partials or by mutating',
           link: 'README.md#webpack',


### PR DESCRIPTION
- (fix) Add `deprecated` property to lifecycles rather than annotating the name
- (feature) Ensure `(deprecated)` note is shown in the lifecycle diagram

## Summary

The lifecycle diagram code has a syntax error caused by the "(deprecated)" in the node. Remove from the name of the lifecycle and annotate nodes that are deprecated with custom text.