### PR TITLE
fix(types): execApply* callback handlers do not need gasket as arg

### DIFF
--- a/packages/gasket-engine/lib/engine.d.ts
+++ b/packages/gasket-engine/lib/engine.d.ts
@@ -13,6 +13,10 @@ declare module '@gasket/engine' {
     ...args: Parameters<HookExecTypes[Id]>
   ) => ReturnType<HookExecTypes[Id]>;
 
+  export type ApplyHookHandler<Id extends HookId> = (
+    ...args: Parameters<HookExecTypes[Id]>
+  ) => ReturnType<HookExecTypes[Id]>;
+
   type HookWithTimings<Id extends HookId> = {
     timing: {
       before?: Array<string>;
@@ -66,12 +70,12 @@ declare module '@gasket/engine' {
 
     execApply<Id extends HookId, Return = void>(
       hook: Id,
-      callback: (plugin: Plugin | null, handler: HookHandler<Id>) => Promise<Return>
+      callback: (plugin: Plugin | null, handler: ApplyHookHandler<Id>) => Promise<Return>
     ): Promise<Array<Return>>
 
     execApplySync<Id extends HookId, Return = void>(
       hook: Id,
-      callback: (plugin: Plugin | null, handler: HookHandler<Id>) => Return
+      callback: (plugin: Plugin | null, handler: ApplyHookHandler<Id>) => Return
     ): Array<Return>
   }
 
@@ -114,11 +118,11 @@ declare module '@gasket/engine' {
     ): ReturnType<HookExecTypes[Id]>;
     execApply<Id extends HookId, Return = void>(
       hook: Id,
-      callback: (plugin: Plugin, handler: HookHandler<Id>) => Promise<Return>
+      callback: (plugin: Plugin, handler: ApplyHookHandler<Id>) => Promise<Return>
     ): Promise<Return[]>;
     execApplySync<Id extends HookId, Return = void>(
       hook: Id,
-      callback: (plugin: Plugin, handler: HookHandler<Id>) => Return
+      callback: (plugin: Plugin, handler: ApplyHookHandler<Id>) => Return
     ): Return[];
   }
 }

--- a/packages/gasket-typescript-tests/test/engine.spec.ts
+++ b/packages/gasket-typescript-tests/test/engine.spec.ts
@@ -1,4 +1,10 @@
-import Gasket from '@gasket/engine';
+import Gasket, { MaybeAsync } from '@gasket/engine';
+
+declare module '@gasket/engine' {
+  interface HookExecTypes {
+    example(str: string, num: number, bool: boolean): MaybeAsync<boolean>
+  }
+}
 
 describe('@gasket/engine', () => {
   it('exposes the constructor interface', () => {
@@ -7,5 +13,21 @@ describe('@gasket/engine', () => {
       { root: __dirname, env: 'test' },
       { resolveFrom: __dirname }
     );
+  });
+
+  it('should', async function () {
+    const gasket = new Gasket(
+      { root: __dirname, env: 'test' },
+      { resolveFrom: __dirname }
+    );
+
+    await gasket.execApply('example', async function (plugin, handler) {
+      handler('a string', 123, true);
+    });
+
+    // eslint-disable-next-line no-sync
+    gasket.execApplySync('example', async function (plugin, handler) {
+      handler('a string', 123, true);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Found this typing bug while authoring a new plugin with TypeScript.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/engine**
- Fix types for execApply* callback handlers - do not need `gasket` arg

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Local plugin tested
- Added types unit test