### PR TITLE
Prefer --require for starting Elastic APM

### DIFF
--- a/packages/gasket-plugin-elastic-apm/README.md
+++ b/packages/gasket-plugin-elastic-apm/README.md
@@ -72,6 +72,27 @@ module.exports = {
 };
 ```
 
+### Custom Start Configurations
+
+For scenarios where you need to configure the start options for the APM agent,
+you can do so in a custom setup script and require it instead.
+
+For example, add a `setup.js` script to the root of your app:
+
+```
+// setup.js
+require('elastic-apm-node').start({
+  // any configuration options
+})
+```
+
+Then adjust your start script to require it instead:
+
+```diff
+-   "start": "gasket start --require elastic-apm-node/start",
++   "start": "gasket start --require ./setup.js",
+```
+
 ### Custom Filters
 
 According to the [Elastic APM docs], the _Elastic APM agent for Node.js is a

--- a/packages/gasket-plugin-elastic-apm/README.md
+++ b/packages/gasket-plugin-elastic-apm/README.md
@@ -13,7 +13,7 @@ gasket create <app-name> --plugins @gasket/plugin-elastic-apm
 #### Existing apps
 
 ```
-npm i @gasket/plugin-elastic-apm
+npm install @gasket/plugin-elastic-apm elastic-apm-node
 ```
 
 Modify `plugins` section of your `gasket.config.js`:
@@ -28,34 +28,34 @@ module.exports = {
 }
 ```
 
-## Configuration
+Add a `--require` flag to a `package.json` start script:
 
-Configurations for the plugin can be added under `elasticAPM` in the config.
-This object accepts the same properties as the Elastic APM Node.js agent. (See
-the [configuration options documentation])
-
-#### Example configuration
-
-```js
-module.exports = {
-  plugins: {
-    add: ['@gasket/plugin-elastic-apm']
-  },
-  elasticAPM: {
-    secretToken: '****',
-    serverUrl: 'http://localhost:9200'
+```diff
+  "scripts": {
+    "build": "gasket build",
+-   "start": "gasket start",
++   "start": "gasket start --require elastic-apm-node/start",
+    "local": "gasket local"
   }
-}
 ```
 
-You may also configure the APM agent with environment variables (e.g:
-`ELASTIC_APM_SERVER_URL`) instead of using the config object. These environment
-variables are also described in the [configuration options documentation].
+## Configuration
 
-The APM server URL (as either `elasticAPM.serverUrl` or
-`ELASTIC_APM_SERVER_URL`) and secret token (as either `elasticAPM.secretToken`
-or `ELASTIC_APM_SECRET_TOKEN`) are both required configuration fields. If either
+The [start recommendations] for the APM agent are to require it as early as
+possible in your app. For Gasket apps, using `--require elastic-apm-node/start`
+will accomplish this. To configure the APM agent, set the environment variables
+described in the [configuration options documentation].
+
+In particular, the APM server URL (`ELASTIC_APM_SERVER_URL`) and secret token
+(`ELASTIC_APM_SECRET_TOKEN`) are both required configuration. If either
 of these are not present, the APM agent will be disabled.
+
+### Plugin Configurations
+
+The Gasket plugin provides some additional setup helpers. These can be
+configured under `elasticAPM` in the `gasket.config.js`.
+
+- **`sensitiveCookies`** - (string[]) A list of sensitive cookies to filter
 
 #### Filtering Sensitive Cookies
 
@@ -72,9 +72,19 @@ module.exports = {
 };
 ```
 
+### Custom Filters
+
+According to the [Elastic APM docs], the _Elastic APM agent for Node.js is a
+singleton_. This means that you can require and configure singleton in various
+hooks of your Gasket app, such as with the [init] or [middleware] lifecycles.
+
 ## How it works
 
-This plugins hooks the [preboot] lifecycle from [@gasket/plugin-start].
+This plugin hooks the Gasket [preboot] lifecycle from [@gasket/plugin-start]
+and will set up additional filtering, such as for sensitive cookies. If the
+`preboot` hook finds that the APM agent has not yet been started using the
+recommended `--require elastic-apm-node/start`, it will start it here.
+However, you risk not bootstrapping necessary modules with a late start.
 
 ## License
 
@@ -83,4 +93,8 @@ This plugins hooks the [preboot] lifecycle from [@gasket/plugin-start].
 <!-- LINKS -->
 
 [preboot]:/packages/gasket-plugin-start/README.md#preboot
+[init]:packages/gasket-plugin-command/README.md#init
+[middleware]:/packages/gasket-plugin-express/README.md#middleware
 [configuration options documentation]:https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html
+[start recommendations]:https://www.elastic.co/guide/en/apm/agent/nodejs/master/agent-api.html#apm-start
+[Elastic APM docs]:https://www.elastic.co/guide/en/apm/agent/nodejs/master/agent-api.html

--- a/packages/gasket-plugin-elastic-apm/lib/index.js
+++ b/packages/gasket-plugin-elastic-apm/lib/index.js
@@ -32,7 +32,17 @@ module.exports = {
   hooks: {
     configure: {
       handler: async (gasket, config) => {
+        const { logger } = gasket;
         config.elasticAPM = config.elasticAPM || {};
+
+        const { serverUrl, secretToken } = config.elasticAPM;
+        if (isDefined(serverUrl)) {
+          logger.notice('DEPRECATED config `elasticAPM.serverUrl`. Use env var: ELASTIC_APM_SERVER_URL');
+        }
+        if (isDefined(secretToken)) {
+          logger.notice('DEPRECATED config `elasticAPM.secretToken`. Use env var: ELASTIC_APM_SECRET_TOKEN');
+        }
+
         // eslint-disable-next-line no-process-env
         config.elasticAPM.active = isActive(config.elasticAPM, process.env);
 

--- a/packages/gasket-plugin-elastic-apm/lib/index.js
+++ b/packages/gasket-plugin-elastic-apm/lib/index.js
@@ -1,4 +1,7 @@
 const { filterSensitiveCookies } = require('./cookies');
+const { dependencies } = require('../package.json');
+
+const isDefined = o => typeof o !== 'undefined';
 
 /**
  * Determines if the Elastic APM agent has sufficient config to be active
@@ -43,6 +46,19 @@ module.exports = {
             ...config.elasticAPM
           })
           .addFilter(filterSensitiveCookies(config));
+      }
+    },
+    create: {
+      timing: {
+        after: ['@gasket/plugin-start']
+      },
+      handler(gasket, { pkg }) {
+        pkg.add('dependencies', {
+          'elastic-apm-node': dependencies['elastic-apm-node']
+        });
+        pkg.add('scripts', {
+          start: 'gasket start --require elastic-apm-node/start'
+        });
       }
     }
   }

--- a/packages/gasket-plugin-elastic-apm/test/create.test.js
+++ b/packages/gasket-plugin-elastic-apm/test/create.test.js
@@ -1,0 +1,3 @@
+describe('create lifecycle', function () {
+  
+});

--- a/packages/gasket-plugin-elastic-apm/test/create.test.js
+++ b/packages/gasket-plugin-elastic-apm/test/create.test.js
@@ -1,3 +1,34 @@
+const plugin = require('../lib/index');
+const { create } = plugin.hooks;
+
 describe('create lifecycle', function () {
-  
+
+  it('plugin exposes a create lifecycle hook', () => {
+    expect(typeof plugin.hooks).toStrictEqual('object');
+    expect(typeof plugin.hooks.create).toStrictEqual('object');
+    expect(typeof plugin.hooks.create.timing).toStrictEqual('object');
+    expect(typeof plugin.hooks.create.handler).toStrictEqual('function');
+  });
+
+  it('timing is after start plugin', function () {
+    expect(create.timing).toEqual({
+      after: ['@gasket/plugin-start']
+    });
+  });
+
+  it('adds the start script with --require', async () => {
+    const add = jest.fn();
+    await create.handler({}, { pkg: { add } });
+    expect(add).toHaveBeenCalledWith('scripts', {
+      start: 'gasket start --require elastic-apm-node/start'
+    });
+  });
+
+  it('adds expected dependencies', async () => {
+    const add = jest.fn();
+    await create.handler({}, { pkg: { add } });
+    expect(add).toHaveBeenCalledWith('dependencies', {
+      'elastic-apm-node': require('../package.json').dependencies['elastic-apm-node']
+    });
+  });
 });

--- a/packages/gasket-plugin-elastic-apm/test/index.test.js
+++ b/packages/gasket-plugin-elastic-apm/test/index.test.js
@@ -12,7 +12,6 @@ const mockAPM = {
 jest.mock('elastic-apm-node', () => mockAPM);
 const apm = require('elastic-apm-node');
 const plugin = require('../lib/index');
-const { filterSensitiveCookies } = require('../lib/cookies');
 
 describe('Plugin', () => {
   let mockGasket;

--- a/packages/gasket-plugin-elastic-apm/test/index.test.js
+++ b/packages/gasket-plugin-elastic-apm/test/index.test.js
@@ -5,14 +5,34 @@ const apmGeneric = {
 
 const mockAPM = {
   start: jest.fn().mockReturnValue(apmGeneric),
-  addFilter: jest.fn().mockReturnValue(apmGeneric)
+  addFilter: jest.fn().mockReturnValue(apmGeneric),
+  isStarted: jest.fn()
 };
 
 jest.mock('elastic-apm-node', () => mockAPM);
 const apm = require('elastic-apm-node');
 const plugin = require('../lib/index');
+const { filterSensitiveCookies } = require('../lib/cookies');
 
 describe('Plugin', () => {
+  let mockGasket;
+
+  beforeEach(function () {
+    mockAPM.isStarted.mockReset();
+    mockGasket = {
+      logger: {
+        notice: jest.fn()
+      },
+      config: {
+        root: '/some/path'
+      }
+    };
+  });
+
+  afterEach(function () {
+    jest.clearAllMocks();
+  });
+
   it('exposes a configure lifecycle hook', () => {
     expect(typeof plugin.hooks).toStrictEqual('object');
     expect(typeof plugin.hooks.configure).toStrictEqual('object');
@@ -25,28 +45,68 @@ describe('Plugin', () => {
     expect(typeof plugin.hooks.preboot.handler).toStrictEqual('function');
   });
 
+  it('skips start call if already started', async () => {
+    mockAPM.isStarted.mockReturnValue(true);
+    await plugin.hooks.preboot.handler(mockGasket);
+    expect(apm.start).not.toHaveBeenCalled();
+  });
+
+  it('adds apm filters', async () => {
+    mockAPM.isStarted.mockReturnValue(true);
+    await plugin.hooks.preboot.handler(mockGasket);
+    expect(apm.addFilter).toHaveBeenCalledTimes(1);
+  });
+
   it('calls apm.start()', async () => {
-    const config = await plugin.hooks.configure.handler({}, {
+    mockGasket.config = await plugin.hooks.configure.handler(mockGasket, {
+      ...mockGasket.config,
       elasticAPM: {
         secretToken: 'abcd',
         serverUrl: 'https://example.com'
       }
     });
-    await plugin.hooks.preboot.handler({ config });
+    await plugin.hooks.preboot.handler(mockGasket);
 
     expect(apm.start).toHaveBeenCalledTimes(1);
     expect(apm.start).toHaveBeenCalledWith({ active: true, secretToken: 'abcd', serverUrl: 'https://example.com' });
   });
 
   it('disables the agent if one of serverUrl and secretToken are not defined', async () => {
-    const config = await plugin.hooks.configure.handler({}, {});
-    await plugin.hooks.preboot.handler({ config });
+    mockGasket.config = await plugin.hooks.configure.handler(mockGasket, mockGasket.config);
+    await plugin.hooks.preboot.handler(mockGasket);
     expect(apm.start).toHaveBeenCalledWith({ active: false });
   });
 
   it('respects a user-defined "active" config value', async () => {
-    const config = await plugin.hooks.configure.handler({}, { elasticAPM: { active: true } });
-    await plugin.hooks.preboot.handler({ config });
+    mockGasket.config = await plugin.hooks.configure.handler(mockGasket, {
+      ...mockGasket.config,
+      elasticAPM: { active: true }
+    });
+    await plugin.hooks.preboot.handler(mockGasket);
     expect(apm.start).toHaveBeenCalledWith({ active: true });
+  });
+
+  it('warns if starting within preboot', async function () {
+    await plugin.hooks.preboot.handler(mockGasket);
+    expect(apm.start).toHaveBeenCalledTimes(1);
+    expect(mockGasket.logger.notice).toHaveBeenCalledWith(
+      expect.stringContaining('DEPRECATED started Elastic APM agent late')
+    );
+  });
+
+  it('warns if using deprecated gasket.config', async function () {
+    mockGasket.config = await plugin.hooks.configure.handler(mockGasket, {
+      ...mockGasket.config,
+      elasticAPM: {
+        secretToken: 'abcd',
+        serverUrl: 'https://example.com'
+      }
+    });
+    expect(mockGasket.logger.notice).toHaveBeenCalledWith(
+      expect.stringMatching('DEPRECATED config `elasticAPM.serverUrl`. Use env var: ELASTIC_APM_SERVER_URL')
+    );
+    expect(mockGasket.logger.notice).toHaveBeenCalledWith(
+      expect.stringMatching('DEPRECATED config `elasticAPM.secretToken`. Use env var: ELASTIC_APM_SECRET_TOKEN')
+    );
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

The [start recommendations] for the APM agent are to require it as early as possible in your app. For Gasket apps, using the new `--require` from https://github.com/godaddy/gasket/pull/370 can accomplish this.

[start recommendations]:https://www.elastic.co/guide/en/apm/agent/nodejs/master/agent-api.html#apm-start

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/plugin-elastic-apm**
- create hook to add dep and require script
- only start apm agent if not done with --require

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

- Updated/added unit tests
- Local app tested:
![Screen Shot 2022-06-09 at 11 50 33 AM](https://user-images.githubusercontent.com/63810935/172922356-91187cc5-2db6-4d06-9e08-68006732e6be.png)

