### PR TITLE
fix(@gasket-plugin-docs): include LICENSE.md

### DIFF
--- a/packages/gasket-plugin-docs/CHANGELOG.md
+++ b/packages/gasket-plugin-docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-docs`
 
+- Include LICENSE.md in docsSetup hook files array
+
 ### 6.24.2
 
 - Update `docsSetupDefault` to include `LICENSE.md` ([#367])

--- a/packages/gasket-plugin-docs/lib/docs-setup.js
+++ b/packages/gasket-plugin-docs/lib/docs-setup.js
@@ -14,7 +14,8 @@ module.exports = function docsSetup() {
     link: 'README.md',
     files: [
       'README.md',
-      'docs/**/*'
+      'docs/**/*',
+      'LICENSE.md'
     ],
     transforms: [
       txGasketPackageLinks,

--- a/packages/gasket-plugin-docs/test/docs-setup.test.js
+++ b/packages/gasket-plugin-docs/test/docs-setup.test.js
@@ -19,6 +19,15 @@ describe('docsSetup', () => {
     assume(results.files).an('array');
   });
 
+  it('includes specific files', () => {
+    const results = docsSetup();
+    assume(results.files).lengthOf(3);
+    assume(results.files)
+      .includes('README.md')
+      .includes('docs/**/*')
+      .includes('LICENSE.md');
+  });
+
   it('includes expected transforms', () => {
     const {
       txGasketPackageLinks,


### PR DESCRIPTION
## Summary

Oversight on the docs plugin `docsSetup` configurations. Added LICENSE to the files array.

## Changelog

- Include LICENSE.md in docsSetup hook files array

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
Test case added

![Screen Shot 2022-06-09 at 12 00 43 PM](https://user-images.githubusercontent.com/105235096/172924004-d05a6e7e-0dee-4e0a-8415-1fa610d774c1.png)

