### PR TITLE
GasketEngine types tweaks

### DIFF
--- a/packages/gasket-engine/lib/engine.d.ts
+++ b/packages/gasket-engine/lib/engine.d.ts
@@ -45,59 +45,7 @@ declare module '@gasket/engine' {
     env: string
   }
 
-  export interface Gasket {
-    config: GasketConfig;
-
-    exec<Id extends HookId>(
-      hook: Id,
-      ...args: Parameters<HookExecTypes[Id]>
-    ): Promise<Array<ResolvedType<ReturnType<HookExecTypes[Id]>>>>;
-
-    execSync<Id extends HookId>(
-      hook: Id,
-      ...args: Parameters<HookExecTypes[Id]>
-    ): Promise<Array<ResolvedType<ReturnType<HookExecTypes[Id]>>>>;
-
-    execWaterfall<Id extends HookId>(
-      hook: Id,
-      ...args: Parameters<HookExecTypes[Id]>
-    ): ReturnType<HookExecTypes[Id]>;
-
-    execWaterfallSync<Id extends HookId>(
-      hook: Id,
-      ...args: Parameters<HookExecTypes[Id]>
-    ): ReturnType<HookExecTypes[Id]>;
-
-    execApply<Id extends HookId, Return = void>(
-      hook: Id,
-      callback: (plugin: Plugin | null, handler: ApplyHookHandler<Id>) => Promise<Return>
-    ): Promise<Array<Return>>
-
-    execApplySync<Id extends HookId, Return = void>(
-      hook: Id,
-      callback: (plugin: Plugin | null, handler: ApplyHookHandler<Id>) => Return
-    ): Array<Return>
-  }
-
-  type PartialRecursive<T> =
-    T extends Object
-      ? { [K in keyof T]?: PartialRecursive<T[K]> } | undefined
-      : T | undefined
-
-  export type GasketConfigFile = Omit<GasketConfig, 'root' | 'env' | 'command'> & {
-    root?: string,
-    env?: string,
-
-    plugins?: {
-      presets?: Array<string>;
-      add?: Array<string | Plugin>;
-      remove?: Array<string>;
-    },
-
-    environments?: Record<string, PartialRecursive<GasketConfig>>
-  }
-
-  export default class GasketEngine implements Gasket {
+  export default class GasketEngine {
     constructor(config: GasketConfigFile, context?: { resolveFrom?: string });
     config: GasketConfig;
     exec<Id extends HookId>(
@@ -124,5 +72,25 @@ declare module '@gasket/engine' {
       hook: Id,
       callback: (plugin: Plugin, handler: ApplyHookHandler<Id>) => Return
     ): Return[];
+  }
+
+  export interface Gasket extends GasketEngine {}
+
+  type PartialRecursive<T> =
+    T extends Object
+      ? { [K in keyof T]?: PartialRecursive<T[K]> } | undefined
+      : T | undefined
+
+  export type GasketConfigFile = Omit<GasketConfig, 'root' | 'env' | 'command'> & {
+    root?: string,
+    env?: string,
+
+    plugins?: {
+      presets?: Array<string>;
+      add?: Array<string | Plugin>;
+      remove?: Array<string>;
+    },
+
+    environments?: Record<string, PartialRecursive<GasketConfig>>
   }
 }

--- a/packages/gasket-plugin-log/lib/index.d.ts
+++ b/packages/gasket-plugin-log/lib/index.d.ts
@@ -17,6 +17,6 @@ declare module '@gasket/engine' {
   }
 
   export interface Gasket {
-    logger?: Log
+    logger: Log
   }
 }

--- a/packages/gasket-plugin-log/lib/index.d.ts
+++ b/packages/gasket-plugin-log/lib/index.d.ts
@@ -1,5 +1,5 @@
 import type { LoggerOptions } from 'winston'
-import type Transport from 'winston-transport';
+import type * as Transport from 'winston-transport';
 import type { MaybeAsync, MaybeMultiple } from '@gasket/engine';
 import type Log from '@gasket/log';
 
@@ -17,6 +17,6 @@ declare module '@gasket/engine' {
   }
 
   export interface Gasket {
-    logger: Log
+    logger?: Log
   }
 }

--- a/packages/gasket-typescript-tests/test/plugin-log.spec.ts
+++ b/packages/gasket-typescript-tests/test/plugin-log.spec.ts
@@ -32,6 +32,15 @@ describe('@gasket/plugin-log', () => {
     };
   });
 
+  it('errors for incorrect transport types', () => {
+    // @ts-expect-error
+    const handler: Hook<'logTransports'> = (gasket: Gasket) => {
+      return [
+        () => {}
+      ];
+    };
+  });
+
   it('adds a logger property to Gasket', () => {
     const logger: Log = {
       alert(...args: any): void {},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Extending the `Gasket` interface was causing _incorrectly implements interface_ errors when building. I do not believe we need to export the impl class, but just the base engine class as the default. The `Gasket` interface will now extend the GasketEngine, and plugins can further extend the Gasket interface as needed.

Additionally this fixes a _default imported_ error for Winston Transports.

## Changelog

**@gasket/engine**
- Export engine type separate from extensible interface

**@gasket/plugin-log**
- Adjust winston-transport type imports to avoid _default-imported_ errors

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Locally tested in custom TS-authored plugin