### PR TITLE
Fix diagram syntax for deprecation

### DIFF
--- a/packages/gasket-plugin-docs-graphs/CHANGELOG.md
+++ b/packages/gasket-plugin-docs-graphs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-docs-graph`
 
+- Fix syntax error with the deprecation note in the lifecycle diagram
+
 ### 6.24.2
 
 - Support showing deprecation for lifecycles ([#376])

--- a/packages/gasket-plugin-docs-graphs/lib/plugin.js
+++ b/packages/gasket-plugin-docs-graphs/lib/plugin.js
@@ -15,7 +15,7 @@ module.exports = {
       let graph = 'graph LR;\n';
       docsConfigSet.lifecycles.forEach(lifecycle => {
         const name = lifecycle.deprecated
-          ? `${lifecycle.name}[${lifecycle.name} (deprecated)]`
+          ? `${lifecycle.name}["${lifecycle.name} (deprecated)"]`
           : lifecycle.name;
         const from = lifecycle.parent || lifecycle.after || lifecycle.command || lifecycle.from;
         let styling = i => i;

--- a/packages/gasket-plugin-docs-graphs/test/plugin.test.js
+++ b/packages/gasket-plugin-docs-graphs/test/plugin.test.js
@@ -73,7 +73,7 @@ describe('docs graph plugin', function () {
     const content = await read(path.join(targetRoot, link), 'utf-8');
 
     assume(content).contains('snap --> crackle;');
-    assume(content).contains('crackle -- exec --> pop[pop (deprecated)];');
+    assume(content).contains('crackle -- exec --> pop["pop (deprecated)"];');
   });
 
   it('generates the LHS of the arrows from the correct attribute', async function () {


### PR DESCRIPTION
Fix error when rendering caused by unsupported syntax

```
Uncaught Error: Parse error on line 37:
...--> webpack[webpack (deprecated)];initW
```