### PR TITLE
Support GASKET_ENV with process exposure

### DIFF
--- a/packages/gasket-cli/CHANGELOG.md
+++ b/packages/gasket-cli/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `@gasket/cli`
 
+- Support for `GASKET_ENV` with fallback to `NODE_ENV`
+- expose Gasket settings on process.env
+
 ### 6.24.3
 
 - Support for --require flag to load modules before Gasket initializes ([#370])

--- a/packages/gasket-cli/src/config/utils.js
+++ b/packages/gasket-cli/src/config/utils.js
@@ -47,6 +47,12 @@ function getEnvironment(flags, commandId, warn) {
     return 'local';
   }
 
+  const { NODE_ENV } = process.env;
+  if (NODE_ENV) {
+    warn(`No env specified, falling back to NODE_ENV: "${ NODE_ENV }".`);
+    return NODE_ENV;
+  }
+
   warn('No env specified, falling back to "development".');
   return 'development';
 }

--- a/packages/gasket-cli/src/hooks/init.js
+++ b/packages/gasket-cli/src/hooks/init.js
@@ -31,6 +31,12 @@ async function initHook({ id, config: oclifConfig, argv }) {
 
   try {
     const env = getEnvironment(flags, id, warn);
+
+    // expose Gasket settings on process
+    process.env.GASKET_ENV = env;
+    process.env.GASKET_CONFIG = flags.config;
+    process.env.GASKET_ROOT = flags.root;
+
     const gasketConfig = await getGasketConfig(flags, env, id);
 
     if (gasketConfig) {

--- a/packages/gasket-cli/test/unit/config/utils.test.js
+++ b/packages/gasket-cli/test/unit/config/utils.test.js
@@ -36,8 +36,9 @@ describe('config utils', () => {
     });
   });
 
-  after(function () {
+  afterEach(function () {
     sinon.restore();
+    delete process.env.NODE_ENV;
   });
 
   describe('getGasketConfig', () => {
@@ -110,12 +111,24 @@ describe('config utils', () => {
       assume(results).equals('local');
     });
 
-    it('returns development when no flag or local command', function () {
+    it('returns NODE_ENV when no flag or local command', function () {
+      process.env.NODE_ENV = 'fake';
+      const results = utils.getEnvironment(flags, commandId, warnStub);
+      assume(results).equals('fake');
+    });
+
+    it('warns for NODE_ENV when no flag or local command', function () {
+      process.env.NODE_ENV = 'fake';
+      utils.getEnvironment(flags, commandId, warnStub);
+      assume(warnStub).calledWith('No env specified, falling back to NODE_ENV: "fake".');
+    });
+
+    it('returns development when no flag, NODE_ENV, or local command', function () {
       const results = utils.getEnvironment(flags, commandId, warnStub);
       assume(results).equals('development');
     });
 
-    it('warns when no flag or local command', function () {
+    it('warns when no flag, NODE_ENV, or local command', function () {
       utils.getEnvironment(flags, commandId, warnStub);
       assume(warnStub).calledWith('No env specified, falling back to "development".');
     });

--- a/packages/gasket-cli/test/unit/hooks/init.test.js
+++ b/packages/gasket-cli/test/unit/hooks/init.test.js
@@ -42,6 +42,9 @@ describe('init hook', () => {
 
   afterEach(function () {
     sinon.restore();
+    delete process.env.GASKET_ENV;
+    delete process.env.GASKET_CONFIG;
+    delete process.env.GASKET_ROOT;
   });
 
   it('ends early for create command', async () => {
@@ -52,6 +55,18 @@ describe('init hook', () => {
   it('parses flags', async () => {
     await initHook({ id: 'build', argv: [] });
     assume(parseStub).called();
+  });
+
+  it('set env vars from flags', async () => {
+    assume(process.env).not.property('GASKET_ENV');
+    assume(process.env).not.property('GASKET_ROOT');
+    assume(process.env).not.property('GASKET_CONFIG');
+
+    await initHook({ id: 'build', argv: [] });
+
+    assume(process.env.GASKET_ENV).equals('development');
+    assume(process.env.GASKET_ROOT).equals('/path/to/app');
+    assume(process.env.GASKET_CONFIG).equals('gasket.config');
   });
 
   it('gets the gasket.config', async () => {

--- a/packages/gasket-plugin-command/CHANGELOG.md
+++ b/packages/gasket-plugin-command/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-command`
 
+- Support for `GASKET_ENV` with fallback to `NODE_ENV`
+
 ### 6.24.3
 
 - Support for --require flag to load modules before Gasket initializes ([#370])

--- a/packages/gasket-plugin-command/lib/command.js
+++ b/packages/gasket-plugin-command/lib/command.js
@@ -96,7 +96,7 @@ class GasketCommand extends Command {
  * @type {object} flags
  * @property {string} config - Fully qualified gasket config to load (default: `'gasket.config'`)
  * @property {string} root - Top-level app directory (default: `process.cwd()`)
- * @property {string} env - Target runtime environment (default: `NODE_ENV` or `'development'`)
+ * @property {string} env - Target runtime environment (default: `GASKET_ENV` or `'development'`)
  */
 GasketCommand.flags = {
   config: flags.string({
@@ -111,7 +111,7 @@ GasketCommand.flags = {
     description: 'Top-level app directory'
   }),
   env: flags.string({
-    env: 'NODE_ENV',
+    env: 'GASKET_ENV',
     description: 'Target runtime environment'
   }),
   require: flags.string({

--- a/packages/gasket-plugin-start/CHANGELOG.md
+++ b/packages/gasket-plugin-start/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-start`
 
+- Support for `GASKET_ENV` with fallback to `NODE_ENV`
+
 ### 6.13.0
 
 - Add `--exit` flag to build command ([#325])

--- a/packages/gasket-plugin-start/lib/get-commands.js
+++ b/packages/gasket-plugin-start/lib/get-commands.js
@@ -52,7 +52,7 @@ module.exports = function getCommands(gasket, { GasketCommand, flags }) {
   LocalCommand.description = 'Build then start your app in local environment';
   LocalCommand.flags = {
     env: flags.string({
-      env: 'NODE_ENV',
+      env: 'GASKET_ENV',
       description: 'Target runtime environment',
       default: 'local'
     })


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

For situations where an app needs to known the gasket CLI settings without access to the actually GasketEngine instance.  Also introduces the distinct GASKET_ENV var, which will still fallback to NODE_ENV if neither it nor `--env` flag are set.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/cli**
- Support for GASKET_ENV with fallback to NODE_ENV
- expose gasket settings on process.env

**@gasket/plugin-command**
- Support for GASKET_ENV with fallback to NODE_ENV

**@gasket/plugin-start**
- Support for GASKET_ENV with fallback to NODE_ENV

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
- Updated unit tests and locally testing in an app