### PR TITLE
Support Fastify with Manifest plugin

### DIFF
--- a/packages/gasket-plugin-manifest/lib/index.js
+++ b/packages/gasket-plugin-manifest/lib/index.js
@@ -14,15 +14,13 @@ module.exports = {
     metadata(gasket, meta) {
       return {
         ...meta,
-        lifecycles: [
-          {
-            name: 'manifest',
-            method: 'execWaterfall',
-            description: 'Modify the the web manifest for a request',
-            link: 'README.md#manifest',
-            parent: 'middleware'
-          }
-        ]
+        lifecycles: [{
+          name: 'manifest',
+          method: 'execWaterfall',
+          description: 'Modify the the web manifest for a request',
+          link: 'README.md#manifest',
+          parent: 'middleware'
+        }]
       };
     }
   }

--- a/packages/gasket-plugin-manifest/lib/index.js
+++ b/packages/gasket-plugin-manifest/lib/index.js
@@ -1,6 +1,6 @@
 const build = require('./build');
 const configure = require('./configure');
-const express = require('./express');
+const serve = require('./serve');
 const middleware = require('./middleware');
 
 module.exports = {
@@ -8,18 +8,21 @@ module.exports = {
   hooks: {
     build,
     configure,
-    express,
+    express: serve,
+    fastify: serve,
     middleware,
     metadata(gasket, meta) {
       return {
         ...meta,
-        lifecycles: [{
-          name: 'manifest',
-          method: 'execWaterfall',
-          description: 'Modify the the web manifest for a request',
-          link: 'README.md#manifest',
-          parent: 'middleware'
-        }]
+        lifecycles: [
+          {
+            name: 'manifest',
+            method: 'execWaterfall',
+            description: 'Modify the the web manifest for a request',
+            link: 'README.md#manifest',
+            parent: 'middleware'
+          }
+        ]
       };
     }
   }

--- a/packages/gasket-plugin-manifest/lib/serve.js
+++ b/packages/gasket-plugin-manifest/lib/serve.js
@@ -2,7 +2,7 @@ const baseConfig = require('./base-config');
 /**
  * If configured, serve the resolved manifest.json
  * @param  {Gasket} gasket The gasket API
- * @param  {Express} app gasket's express server
+ * @param  {Express | Fastify} app gasket's express/fastify server
  * @async
  */
 async function serve(gasket, app) {

--- a/packages/gasket-plugin-manifest/lib/serve.js
+++ b/packages/gasket-plugin-manifest/lib/serve.js
@@ -5,10 +5,10 @@ const baseConfig = require('./base-config');
  * @param  {Express} app gasket's express server
  * @async
  */
-async function express(gasket, app) {
+async function serve(gasket, app) {
   const { config } = gasket;
-  const { staticOutput } = (config && config.manifest || {});
-  const { path } = (config && config.manifest || {});
+  const { staticOutput } = (config && config.manifest) || {};
+  const { path } = (config && config.manifest) || {};
 
   if (!staticOutput) {
     app.get(path || baseConfig.path, (req, res) => {
@@ -17,4 +17,4 @@ async function express(gasket, app) {
   }
 }
 
-module.exports = express;
+module.exports = serve;

--- a/packages/gasket-plugin-manifest/test/index.test.js
+++ b/packages/gasket-plugin-manifest/test/index.test.js
@@ -3,7 +3,6 @@ const assume = require('assume');
 const plugin = require('../lib');
 
 describe('Plugin', function () {
-
   it('is an object', function () {
     assume(plugin).is.an('object');
   });
@@ -17,6 +16,7 @@ describe('Plugin', function () {
       'build',
       'configure',
       'express',
+      'fastify',
       'middleware',
       'metadata'
     ];

--- a/packages/gasket-plugin-manifest/test/serve.test.js
+++ b/packages/gasket-plugin-manifest/test/serve.test.js
@@ -1,24 +1,24 @@
 const assume = require('assume');
 const sinon = require('sinon');
 
-const express = require('../lib/express');
+const serve = require('../lib/serve');
 
-describe('express', function () {
+describe('serve', function () {
   afterEach(function () {
     sinon.reset();
   });
 
   it('is a function', function () {
-    assume(express).is.a('asyncfunction');
-    assume(express).has.length(2);
+    assume(serve).is.a('asyncfunction');
+    assume(serve).has.length(2);
   });
 
-  it('adds a route to the express server', async function () {
+  it('adds a route to the express/fastify server', async function () {
     const app = {
       get: sinon.stub()
     };
 
-    await express({}, app);
+    await serve({}, app);
     assume(app.get.calledOnce).is.true();
   });
 
@@ -32,7 +32,7 @@ describe('express', function () {
     };
 
     const app = { get };
-    await express({}, app);
+    await serve({}, app);
   });
 
   it('returns the configured manifest on the configured path if option is set', async function (done) {
@@ -54,6 +54,6 @@ describe('express', function () {
     };
 
     const app = { get };
-    await express(gasket, app);
+    await serve(gasket, app);
   });
 });


### PR DESCRIPTION
## Summary

Need to add support for Fastify where Express hooks exist. 

## Changelog

- Add Fastify hook
- extract reusable code into `serve.js` to be used by both Express/Fastify hooks

## Test Plan

<img width="748" alt="Screen Shot 2022-07-06 at 10 33 31 AM" src="https://user-images.githubusercontent.com/104379885/177609731-c2ccdaf3-cb23-4383-bf1a-8ce5fdcea9ee.png">

