### PR TITLE
fix(git-plugin): add git plugin to CLI default plugins

### DIFF
--- a/packages/gasket-cli/CHANGELOG.md
+++ b/packages/gasket-cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/cli`
 
+- Add git plugin to CLI default plugins
+
 ### 6.27.0
 
 - Support for `GASKET_ENV` with fallback to `NODE_ENV` ([#387])

--- a/packages/gasket-cli/src/config/default-plugins.js
+++ b/packages/gasket-cli/src/config/default-plugins.js
@@ -2,5 +2,6 @@ module.exports = [
   require('@gasket/plugin-command'),
   require('@gasket/plugin-lifecycle'),
   require('@gasket/plugin-metadata'),
-  require('@gasket/plugin-start')
+  require('@gasket/plugin-start'),
+  require('@gasket/plugin-git')
 ];


### PR DESCRIPTION
## Summary
Add git plugin to CLI default plugins. Ensure prompt during create process.

## Changelog
- Add git plugin to CLI default plugins

## Test Plan
`.gitignore` is present after CLI create process
![Screen Shot 2022-07-06 at 2 13 37 PM](https://user-images.githubusercontent.com/105235096/177646088-0712eaff-b87f-4c0e-9ecc-ef7697127ea3.png)

