### PR TITLE
Ability to enable logger in production

### DIFF
--- a/packages/gasket-log/.mocharc.json
+++ b/packages/gasket-log/.mocharc.json
@@ -1,0 +1,3 @@
+{
+  "require": "@babel/register"
+}

--- a/packages/gasket-log/CHANGELOG.md
+++ b/packages/gasket-log/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/log`
 
+- Support enabling logging in production
+
 ### 6.1.0
 
 - Support for custom log levels ([#279])

--- a/packages/gasket-log/README.md
+++ b/packages/gasket-log/README.md
@@ -79,6 +79,15 @@ class YourComponent extends React.Component {
 }
 ```
 
+The constructor accepts an object with the following optional properties:
+
+| Property    | Description |
+|-------------|-------------|
+| `level`     | The maximum logging level to enable output for. Defaults to `info` |
+| `levels`    | Array of custom logging level names. |
+| `namespace` | String for namespacing your logs. See [diagnostics] for more information. Your namespace is automatically prefixed with `gasket:` |
+| `prod`      | If set to `true` enables logging even for production builds. By default production builds have no client-side logging. |
+
 > **NOTE:** The client logger uses [diagnostics] to output log messages to the
 > console. Ensure one of the trigger mechanics for [diagnostics in browser] is
 > set. The name used for diagnostics is `gasket*`.

--- a/packages/gasket-log/package.json
+++ b/packages/gasket-log/package.json
@@ -18,7 +18,7 @@
     "posttest": "npm run lint",
     "build": "babel ./src/client.js -d lib --delete-dir-on-start",
     "prepublishOnly": "npm run build",
-    "test:client": "DEBUG=gasket:* mocha --require @babel/register test/client.test.js",
+    "test:client": "mocha test/client.test.js",
     "test:server": "mocha test/server.test.js"
   },
   "repository": {

--- a/packages/gasket-log/src/client.js
+++ b/packages/gasket-log/src/client.js
@@ -13,12 +13,15 @@ export default class Log {
    * @param {Object} options configuration.
    * @private
    */
-  constructor({ level, levels = Log.levels, namespace } = {}) {
+  constructor({ level, levels = Log.levels, namespace, prod } = {}) {
     this.namespace = Array.isArray(namespace) ? namespace : [namespace];
     this.level = ~levels.indexOf(level) ? level : 'info';
 
     levels.forEach(lvl => {
-      this[lvl] = diagnostics(['gasket', lvl, ...this.namespace].filter(Boolean).join(':'));
+      this[lvl] = diagnostics(
+        ['gasket', lvl, ...this.namespace].filter(Boolean).join(':'),
+        { force: Boolean(prod) }
+      );
     });
   }
 

--- a/packages/gasket-log/test/client.test.js
+++ b/packages/gasket-log/test/client.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-process-env */
+
 import { describe, it } from 'mocha';
 import { config } from 'winston';
 import Log from '../src/client';
@@ -8,6 +10,8 @@ describe('Log', function () {
   let log;
 
   beforeEach(function () {
+    process.env.NODE_ENV = 'test';
+    process.env.DEBUG = 'gasket:*';
     log = new Log();
   });
 
@@ -53,6 +57,16 @@ describe('Log', function () {
 
     log = new Log({ level: 'debug' });
     assume(log).to.have.property('level', 'debug');
+  });
+
+  it('has an prod option to enable NODE_ENV=production logging', function () {
+    process.env.NODE_ENV = 'production';
+    const console = sinon.stub(global.console, 'log');
+
+    log = new Log({ namespace: 'uxcore2', prod: true });
+    log.info('something');
+
+    assume(console.callCount).equals(1);
   });
 
   describe('.log', function () {


### PR DESCRIPTION
- Allow enabling client-side logging for production
- Document the client logger constructor
- Use mocha config file for better IDE experience

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

If `NODE_ENV=production` is set, very common/recommended for producing builds, `diagnostics` is disabled unless you specifically force it to not be. Enable override of this behavior.