### PR TITLE
Add missing property from http config

### DIFF
--- a/packages/gasket-plugin-https/CHANGELOG.md
+++ b/packages/gasket-plugin-https/CHANGELOG.md
@@ -1,8 +1,10 @@
 # `@gasket/plugin-https`
 
+- Add `hostname` config setting to type declarations
+
 ### 6.11.0
 
--  Added healthcheck.html to terminus options. ([#315])
+- Added healthcheck.html to terminus options. ([#315])
 
 ### 6.10.0
 

--- a/packages/gasket-plugin-https/lib/index.d.ts
+++ b/packages/gasket-plugin-https/lib/index.d.ts
@@ -38,6 +38,7 @@ declare module '@gasket/engine' {
     >;  
 
   interface ServerOptions {
+    hostname?: string,
     http?: number | false | null | MaybeMultiple<BaseListenerConfig>,
     https?: MaybeMultiple<BaseListenerConfig & HttpsSettings & {
       sni?: Record<string, HttpsSettings>

--- a/packages/gasket-typescript-tests/test/plugin-https.spec.ts
+++ b/packages/gasket-typescript-tests/test/plugin-https.spec.ts
@@ -5,6 +5,12 @@ import '@gasket/plugin-https';
 describe('@gasket/plugin-https', () => {
   const { log } = console;
 
+  it('adds an optional hostname config property', () => {
+    const config: GasketConfigFile = {
+      hostname: 'example.com'
+    };
+  });
+
   it('adds an optional http config property', () => {
     const config: GasketConfigFile = {
       http: 8080,


### PR DESCRIPTION
- Add missing `hostname` property from config typings

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

When type checking `gasket.config.js` I noticed this `hostname` property was being flagged as invalid.