### PR TITLE
Fix webpack 5 compatibility issue

### DIFF
--- a/packages/gasket-react-intl/CHANGELOG.md
+++ b/packages/gasket-react-intl/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/react-intl`
 
+- Fix compatibility issue with Webpack 5 caused by top-level import of `path` module in code that could be run browser-side.
+
 ### 6.30.0
 
 - Fix to prevent next/router from changing locale in IntlProvider ([#401])

--- a/packages/gasket-react-intl/src/next.js
+++ b/packages/gasket-react-intl/src/next.js
@@ -1,9 +1,5 @@
-import path from 'path';
-import { localeUtils } from './utils';
+import { localeUtils, getLocalesParentDir } from './utils';
 import { manifest } from './config';
-
-// eslint-disable-next-line no-process-env
-const localesParentDir = path.dirname(process.env.GASKET_INTL_LOCALES_DIR);
 
 /**
  * Load locale file(s) for Next.js static pages
@@ -19,7 +15,9 @@ export function intlGetStaticProps(localePathPart = manifest.defaultPath) {
     if (!locale) {
       locale = ctx.params.locale;
     }
-    const localesProps = localeUtils.serverLoadData(localePathPart, locale, localesParentDir);
+
+    // eslint-disable-next-line no-process-env
+    const localesProps = localeUtils.serverLoadData(localePathPart, locale, getLocalesParentDir());
 
     return {
       props: {
@@ -44,7 +42,7 @@ export function intlGetServerSideProps(localePathPart = manifest.defaultPath) {
     if (!locale && res.locals && res.locals.gasketData && res.locals.gasketData.intl) {
       locale = res.locals.gasketData.intl.locale;
     }
-    const localesProps = localeUtils.serverLoadData(localePathPart, locale, localesParentDir);
+    const localesProps = localeUtils.serverLoadData(localePathPart, locale, getLocalesParentDir());
 
     return {
       props: {

--- a/packages/gasket-react-intl/src/utils.js
+++ b/packages/gasket-react-intl/src/utils.js
@@ -18,3 +18,11 @@ export function getActiveLocale() {
   }
   return manifest.defaultLocale;
 }
+
+let localesParentDir;
+export function getLocalesParentDir() {
+  return localesParentDir || (
+    // eslint-disable-next-line no-process-env
+    localesParentDir = require('path').dirname(process.env.GASKET_INTL_LOCALES_DIR)
+  );
+}

--- a/packages/gasket-react-intl/src/with-locale-required.js
+++ b/packages/gasket-react-intl/src/with-locale-required.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import path from 'path';
 import { manifest } from './config';
 import { localeUtils, LocaleStatus } from './utils';
 import useLocaleRequired from './use-locale-required';
@@ -24,7 +23,7 @@ function attachGetInitialProps(Wrapper, localePathPart) {
 
     if (res && res.locals && res.locals.gasketData) {
       const { locale = defaultLocale } = res.locals.gasketData.intl || {};
-      const localesParentDir = path.dirname(res.locals.localesDir);
+      const localesParentDir = require('path').dirname(res.locals.localesDir);
       localesProps = localeUtils.serverLoadData(localePathPart, locale, localesParentDir);
     }
 


### PR DESCRIPTION
Fix runtime error when using `@gasket/react-intl` with webpack 5:

> error - ./node_modules/@gasket/react-intl/lib/with-locale-required.js:24:0
> Module not found: Can't resolve 'path'

See [this #gasket-support](https://godaddy.slack.com/archives/CABCTNQ5P/p1660934419064829) thread for details.