### PR TITLE
Doc how to configure cache dir for deployments

### DIFF
--- a/packages/gasket-plugin-nextjs/docs/deployment.md
+++ b/packages/gasket-plugin-nextjs/docs/deployment.md
@@ -128,3 +128,20 @@ Follow the [Docker deployment guide] to see a sample `Dockerfile`.
 
 [config]: /packages/gasket-cli/docs/configuration.md
 [Docker deployment guide]: docker-deployment.md
+
+## Gotchas
+
+### Cache directory
+
+The Gasket CLI is built upon `@oclif` and uses some plugins that need access to
+read/write to a cache directory. Based on the [oclif docs], this is configured
+to the following defaults:
+ - macOS: `~/Library/Caches/@gasket/cli`
+ - Unix: `~/.cache/@gasket/cli`
+ - Windows: `%LOCALAPPDATA%\@gasket\cli`
+
+For some deployment environments, this may need to be adjusted from the
+defaults. To override where the cache directory is for your deployment, you can
+set the `GASKET_CACHE_DIR` env variable, such as in the `Dockerfile`.
+
+[oclif docs]: https://oclif.io/docs/config


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

We have an open PR (https://github.com/oclif/plugin-warn-if-update-available/pull/280) to gracefully fail the CLI version check, which can cause some deployment environments to fail if they cannot write to the default cache directory. In lieu of that fix, it is also possible to configure the cache directory via environment variable, as documented in this PR.

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/plugin-nextjs**
- Docs for cache dir gotchas during deployments

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

Verifiable in a local gasket app using `GASKET_CACHE_DIR`