### PR TITLE
Add middleware configuration for express plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3908,7 +3908,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
       "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -3928,7 +3928,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 4"
       }
@@ -4464,7 +4464,7 @@
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
       "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -4478,7 +4478,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@hutson/parse-repository-url": {
       "version": "3.0.2",
@@ -10552,7 +10552,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -12063,12 +12063,6 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
-    },
-    "node_modules/browserslist-config-godaddy": {
-      "version": "3.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/browserslist-config-godaddy/-/browserslist-config-godaddy-3.0.1.tgz",
-      "integrity": "sha1-sdPfl9DEBxX3lYvkJNouJHv+EK8=",
-      "license": "UNLICENSED"
     },
     "node_modules/bs-logger": {
       "version": "0.2.6",
@@ -14963,7 +14957,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
@@ -15720,7 +15714,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -15738,7 +15731,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -16080,7 +16072,7 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
       "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.2.0",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -16647,7 +16639,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
       "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -16660,7 +16652,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "eslint-visitor-keys": "^2.0.0"
       },
@@ -16678,7 +16670,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       }
@@ -16687,7 +16679,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -16696,7 +16688,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -16711,7 +16703,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -16727,7 +16719,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -16739,13 +16731,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       },
@@ -16757,7 +16749,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -16766,7 +16758,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -16778,7 +16770,7 @@
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
       "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "acorn": "^8.7.0",
         "acorn-jsx": "^5.3.1",
@@ -16804,7 +16796,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
       "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -17213,7 +17205,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/fast-redact": {
       "version": "3.1.1",
@@ -17465,7 +17457,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -17800,7 +17792,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -17818,7 +17810,7 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/flux": {
       "version": "4.0.3",
@@ -18218,7 +18210,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/functions-have-names": {
       "version": "1.2.2",
@@ -18798,7 +18790,7 @@
       "version": "13.13.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
       "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -23012,7 +23004,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -23236,7 +23228,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -25267,7 +25259,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/natural-orderby": {
       "version": "2.0.3",
@@ -26388,7 +26380,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -27864,7 +27856,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -28558,7 +28550,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -28783,7 +28774,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -29545,7 +29535,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
       "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -29625,7 +29614,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       },
@@ -30467,7 +30456,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -32620,7 +32608,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -32641,7 +32629,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       },
@@ -32678,7 +32666,6 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
       "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -33263,7 +33250,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
@@ -34235,7 +34222,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -34908,10 +34895,10 @@
       }
     },
     "packages/create-gasket-app": {
-      "version": "6.31.0",
+      "version": "6.32.0",
       "license": "MIT",
       "dependencies": {
-        "@gasket/cli": "^6.31.0"
+        "@gasket/cli": "^6.32.0"
       },
       "bin": {
         "create-gasket-app": "lib/index.js"
@@ -34955,7 +34942,7 @@
     },
     "packages/gasket-cli": {
       "name": "@gasket/cli",
-      "version": "6.31.0",
+      "version": "6.32.0",
       "license": "MIT",
       "dependencies": {
         "@gasket/engine": "^6.30.2",
@@ -34973,7 +34960,6 @@
         "@oclif/plugin-help": "^5.1.10",
         "@oclif/plugin-not-found": "^2.2.4",
         "@oclif/plugin-warn-if-update-available": "^2.0.4",
-        "browserslist-config-godaddy": "^3.0.1",
         "concat-stream": "^2.0.0",
         "cross-spawn": "^7.0.1",
         "deepmerge": "^4.2.2",
@@ -35468,7 +35454,7 @@
     },
     "packages/gasket-plugin-https": {
       "name": "@gasket/plugin-https",
-      "version": "6.28.0",
+      "version": "6.32.0",
       "license": "MIT",
       "dependencies": {
         "@godaddy/terminus": "^4.2.0",
@@ -35496,7 +35482,7 @@
     },
     "packages/gasket-plugin-intl": {
       "name": "@gasket/plugin-intl",
-      "version": "6.30.1",
+      "version": "6.32.0",
       "license": "MIT",
       "dependencies": {
         "@gasket/helper-intl": "^6.26.1",
@@ -35512,7 +35498,7 @@
       "devDependencies": {
         "@gasket/engine": "^6.26.1",
         "@gasket/plugin-log": "^6.30.0",
-        "@gasket/react-intl": "^6.30.0",
+        "@gasket/react-intl": "^6.32.0",
         "assume": "^2.3.0",
         "assume-sinon": "^1.1.0",
         "eslint": "^8.7.0",
@@ -35752,7 +35738,7 @@
     },
     "packages/gasket-plugin-nextjs": {
       "name": "@gasket/plugin-nextjs",
-      "version": "6.31.1",
+      "version": "6.32.0",
       "license": "MIT",
       "dependencies": {
         "@gasket/plugin-webpack": "^6.26.1",
@@ -36237,14 +36223,14 @@
     },
     "packages/gasket-preset-api": {
       "name": "@gasket/preset-api",
-      "version": "6.31.0",
+      "version": "6.32.0",
       "license": "MIT",
       "dependencies": {
         "@gasket/plugin-config": "^6.26.1",
         "@gasket/plugin-docs": "^6.28.0",
         "@gasket/plugin-docsify": "^6.28.0",
         "@gasket/plugin-express": "^6.28.0",
-        "@gasket/plugin-https": "^6.28.0",
+        "@gasket/plugin-https": "^6.32.0",
         "@gasket/plugin-lint": "^6.30.2",
         "@gasket/plugin-log": "^6.30.0",
         "@gasket/plugin-swagger": "^6.31.0"
@@ -36255,13 +36241,13 @@
     },
     "packages/gasket-preset-nextjs": {
       "name": "@gasket/preset-nextjs",
-      "version": "6.31.1",
+      "version": "6.32.0",
       "license": "MIT",
       "dependencies": {
         "@gasket/plugin-express": "^6.28.0",
-        "@gasket/plugin-https": "^6.28.0",
+        "@gasket/plugin-https": "^6.32.0",
         "@gasket/plugin-log": "^6.30.0",
-        "@gasket/plugin-nextjs": "^6.31.1",
+        "@gasket/plugin-nextjs": "^6.32.0",
         "@gasket/plugin-redux": "^6.30.0",
         "@gasket/plugin-webpack": "^6.26.1"
       },
@@ -36281,7 +36267,7 @@
     },
     "packages/gasket-react-intl": {
       "name": "@gasket/react-intl",
-      "version": "6.30.0",
+      "version": "6.32.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -36388,10 +36374,10 @@
     },
     "packages/gasket-typescript-tests": {
       "name": "@gasket/typescript-tests",
-      "version": "6.31.1",
+      "version": "6.32.0",
       "license": "MIT",
       "devDependencies": {
-        "@gasket/cli": "^6.31.0",
+        "@gasket/cli": "^6.32.0",
         "@gasket/data": "^6.24.0",
         "@gasket/engine": "^6.30.2",
         "@gasket/fetch": "^6.28.1",
@@ -36405,23 +36391,23 @@
         "@gasket/plugin-docsify": "^6.28.0",
         "@gasket/plugin-elastic-apm": "^6.30.0",
         "@gasket/plugin-express": "^6.28.0",
-        "@gasket/plugin-https": "^6.28.0",
-        "@gasket/plugin-intl": "^6.30.1",
+        "@gasket/plugin-https": "^6.32.0",
+        "@gasket/plugin-intl": "^6.32.0",
         "@gasket/plugin-log": "^6.30.0",
         "@gasket/plugin-manifest": "^6.28.0",
         "@gasket/plugin-metadata": "^6.30.2",
         "@gasket/plugin-metrics": "^6.26.1",
-        "@gasket/plugin-nextjs": "^6.31.1",
+        "@gasket/plugin-nextjs": "^6.32.0",
         "@gasket/plugin-redux": "^6.30.0",
         "@gasket/plugin-service-worker": "^6.28.0",
         "@gasket/plugin-start": "^6.27.0",
         "@gasket/plugin-swagger": "^6.31.0",
         "@gasket/plugin-webpack": "^6.26.1",
         "@gasket/plugin-workbox": "^6.30.0",
-        "@gasket/preset-api": "^6.31.0",
-        "@gasket/preset-nextjs": "^6.31.1",
+        "@gasket/preset-api": "^6.32.0",
+        "@gasket/preset-nextjs": "^6.32.0",
         "@gasket/preset-pwa": "^6.30.0",
-        "@gasket/react-intl": "^6.30.0",
+        "@gasket/react-intl": "^6.32.0",
         "@gasket/redux": "^6.30.0",
         "@gasket/resolve": "^6.30.2",
         "@gasket/utils": "^6.26.1",
@@ -36464,9 +36450,9 @@
       }
     },
     "scripts/generate-docs-index": {
-      "version": "6.31.0",
+      "version": "6.32.0",
       "dependencies": {
-        "@gasket/cli": "^6.31.0"
+        "@gasket/cli": "^6.32.0"
       },
       "devDependencies": {
         "copy-dir": "^1.2.0",
@@ -39304,7 +39290,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
       "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -39321,7 +39307,7 @@
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -39630,7 +39616,6 @@
         "@oclif/test": "^1.1.0",
         "assume": "^2.3.0",
         "assume-sinon": "^1.1.0",
-        "browserslist-config-godaddy": "^3.0.1",
         "chai": "^4.2.0",
         "concat-stream": "^2.0.0",
         "cross-env": "^7.0.3",
@@ -40062,7 +40047,7 @@
         "@gasket/engine": "^6.26.1",
         "@gasket/helper-intl": "^6.26.1",
         "@gasket/plugin-log": "^6.30.0",
-        "@gasket/react-intl": "^6.30.0",
+        "@gasket/react-intl": "^6.32.0",
         "@hapi/accept": "^5.0.1",
         "assume": "^2.3.0",
         "assume-sinon": "^1.1.0",
@@ -40712,7 +40697,7 @@
         "@gasket/plugin-docs": "^6.28.0",
         "@gasket/plugin-docsify": "^6.28.0",
         "@gasket/plugin-express": "^6.28.0",
-        "@gasket/plugin-https": "^6.28.0",
+        "@gasket/plugin-https": "^6.32.0",
         "@gasket/plugin-lint": "^6.30.2",
         "@gasket/plugin-log": "^6.30.0",
         "@gasket/plugin-start": "^6.27.0",
@@ -40723,9 +40708,9 @@
       "version": "file:packages/gasket-preset-nextjs",
       "requires": {
         "@gasket/plugin-express": "^6.28.0",
-        "@gasket/plugin-https": "^6.28.0",
+        "@gasket/plugin-https": "^6.32.0",
         "@gasket/plugin-log": "^6.30.0",
-        "@gasket/plugin-nextjs": "^6.31.1",
+        "@gasket/plugin-nextjs": "^6.32.0",
         "@gasket/plugin-redux": "^6.30.0",
         "@gasket/plugin-start": "^6.27.0",
         "@gasket/plugin-webpack": "^6.26.1"
@@ -40830,7 +40815,7 @@
     "@gasket/typescript-tests": {
       "version": "file:packages/gasket-typescript-tests",
       "requires": {
-        "@gasket/cli": "^6.31.0",
+        "@gasket/cli": "^6.32.0",
         "@gasket/data": "^6.24.0",
         "@gasket/engine": "^6.30.2",
         "@gasket/fetch": "^6.28.1",
@@ -40844,23 +40829,23 @@
         "@gasket/plugin-docsify": "^6.28.0",
         "@gasket/plugin-elastic-apm": "^6.30.0",
         "@gasket/plugin-express": "^6.28.0",
-        "@gasket/plugin-https": "^6.28.0",
-        "@gasket/plugin-intl": "^6.30.1",
+        "@gasket/plugin-https": "^6.32.0",
+        "@gasket/plugin-intl": "^6.32.0",
         "@gasket/plugin-log": "^6.30.0",
         "@gasket/plugin-manifest": "^6.28.0",
         "@gasket/plugin-metadata": "^6.30.2",
         "@gasket/plugin-metrics": "^6.26.1",
-        "@gasket/plugin-nextjs": "^6.31.1",
+        "@gasket/plugin-nextjs": "^6.32.0",
         "@gasket/plugin-redux": "^6.30.0",
         "@gasket/plugin-service-worker": "^6.28.0",
         "@gasket/plugin-start": "^6.27.0",
         "@gasket/plugin-swagger": "^6.31.0",
         "@gasket/plugin-webpack": "^6.26.1",
         "@gasket/plugin-workbox": "^6.30.0",
-        "@gasket/preset-api": "^6.31.0",
-        "@gasket/preset-nextjs": "^6.31.1",
+        "@gasket/preset-api": "^6.32.0",
+        "@gasket/preset-nextjs": "^6.32.0",
         "@gasket/preset-pwa": "^6.30.0",
-        "@gasket/react-intl": "^6.30.0",
+        "@gasket/react-intl": "^6.32.0",
         "@gasket/redux": "^6.30.0",
         "@gasket/resolve": "^6.30.2",
         "@gasket/utils": "^6.26.1",
@@ -40981,7 +40966,7 @@
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
       "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -40992,7 +40977,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "dev": true
+      "devOptional": true
     },
     "@hutson/parse-repository-url": {
       "version": "3.0.2",
@@ -43244,7 +43229,8 @@
     "@mdx-js/react": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
-      "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg=="
+      "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
+      "requires": {}
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -44304,7 +44290,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.13.0",
@@ -44444,42 +44431,50 @@
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.0.0.tgz",
-      "integrity": "sha512-MdPdhdWLtQsjd29Wa4pABdhWbaRMACdM1h31BY+c6FghTZqNGT7pEYdBoaGeKtdTOBC/XNFQaKVj+r/Ei2ryWA=="
+      "integrity": "sha512-MdPdhdWLtQsjd29Wa4pABdhWbaRMACdM1h31BY+c6FghTZqNGT7pEYdBoaGeKtdTOBC/XNFQaKVj+r/Ei2ryWA==",
+      "requires": {}
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.0.0.tgz",
-      "integrity": "sha512-aVdtfx9jlaaxc3unA6l+M9YRnKIZjOhQPthLKqmTXC8UVkBLDRGwPKo+r8n3VZN8B34+yVajzPTZ+ptTSuZZCw=="
+      "integrity": "sha512-aVdtfx9jlaaxc3unA6l+M9YRnKIZjOhQPthLKqmTXC8UVkBLDRGwPKo+r8n3VZN8B34+yVajzPTZ+ptTSuZZCw==",
+      "requires": {}
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.0.0.tgz",
-      "integrity": "sha512-Ccj42ApsePD451AZJJf1QzTD1B/BOU392URJTeXFxSK709i0KUsGtbwyiqsKu7vsYxpTM0IA5clAKDyf9RCZyA=="
+      "integrity": "sha512-Ccj42ApsePD451AZJJf1QzTD1B/BOU392URJTeXFxSK709i0KUsGtbwyiqsKu7vsYxpTM0IA5clAKDyf9RCZyA==",
+      "requires": {}
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.0.0.tgz",
-      "integrity": "sha512-88V26WGyt1Sfd1emBYmBJRWMmgarrExpKNVmI9vVozha4kqs6FzQJ/Kp5+EYli1apgX44518/0+t9+NU36lThQ=="
+      "integrity": "sha512-88V26WGyt1Sfd1emBYmBJRWMmgarrExpKNVmI9vVozha4kqs6FzQJ/Kp5+EYli1apgX44518/0+t9+NU36lThQ==",
+      "requires": {}
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.0.0.tgz",
-      "integrity": "sha512-F7YXNLfGze+xv0KMQxrl2vkNbI9kzT9oDK55/kUuymh1ACyXkMV+VZWX1zEhSTfEKh7VkHVZGmVtHg8eTZ6PRg=="
+      "integrity": "sha512-F7YXNLfGze+xv0KMQxrl2vkNbI9kzT9oDK55/kUuymh1ACyXkMV+VZWX1zEhSTfEKh7VkHVZGmVtHg8eTZ6PRg==",
+      "requires": {}
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.0.0.tgz",
-      "integrity": "sha512-+rghFXxdIqJNLQK08kwPBD3Z22/0b2tEZ9lKiL/yTfuyj1wW8HUXu4bo/XkogATIYuXSghVQOOCwURXzHGKyZA=="
+      "integrity": "sha512-+rghFXxdIqJNLQK08kwPBD3Z22/0b2tEZ9lKiL/yTfuyj1wW8HUXu4bo/XkogATIYuXSghVQOOCwURXzHGKyZA==",
+      "requires": {}
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.0.0.tgz",
-      "integrity": "sha512-VaphyHZ+xIKv5v0K0HCzyfAaLhPGJXSk2HkpYfXIOKb7DjLBv0soHDxNv6X0vr2titsxE7klb++u7iOf7TSrFQ=="
+      "integrity": "sha512-VaphyHZ+xIKv5v0K0HCzyfAaLhPGJXSk2HkpYfXIOKb7DjLBv0soHDxNv6X0vr2titsxE7klb++u7iOf7TSrFQ==",
+      "requires": {}
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.2.0.tgz",
-      "integrity": "sha512-bhYIpsORb++wpsp91fymbFkf09Z/YEKR0DnFjxvN+8JHeCUD2unnh18jIMKnDJTWtvpTaGYPXELVe4OOzFI0xg=="
+      "integrity": "sha512-bhYIpsORb++wpsp91fymbFkf09Z/YEKR0DnFjxvN+8JHeCUD2unnh18jIMKnDJTWtvpTaGYPXELVe4OOzFI0xg==",
+      "requires": {}
     },
     "@svgr/babel-preset": {
       "version": "6.2.0",
@@ -45711,13 +45706,15 @@
     "acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "devOptional": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -45809,7 +45806,8 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "algoliasearch": {
       "version": "4.13.1",
@@ -46120,7 +46118,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assume-sinon/-/assume-sinon-1.1.0.tgz",
       "integrity": "sha512-Gpr+je1JmbBjz/I8pIHOjp3CCXyiUa5kOYu5QITYabj+GwlP98bLW0RsFx0zqUQxOufM1rJVz+Oql8EymqeP1g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ast-types-flow": {
       "version": "0.0.7",
@@ -46260,7 +46259,8 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -46884,11 +46884,6 @@
         "picocolors": "^1.0.0"
       }
     },
-    "browserslist-config-godaddy": {
-      "version": "3.0.1",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/browserslist-config-godaddy/-/browserslist-config-godaddy-3.0.1.tgz",
-      "integrity": "sha1-sdPfl9DEBxX3lYvkJNouJHv+EK8="
-    },
     "bs-logger": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
@@ -47196,7 +47191,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/chai-spies/-/chai-spies-1.0.0.tgz",
       "integrity": "sha512-elF2ZUczBsFoP07qCfMO/zeggs8pqCf3fZGyK5+2X4AndS8jycZYID91ztD9oQ7d/0tnS963dPkd0frQEThDsg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "chalk": {
       "version": "2.4.2",
@@ -48363,7 +48359,7 @@
     "create-gasket-app": {
       "version": "file:packages/create-gasket-app",
       "requires": {
-        "@gasket/cli": "^6.31.0",
+        "@gasket/cli": "^6.32.0",
         "assume": "^2.3.0",
         "assume-sinon": "^1.1.0",
         "cross-env": "^7.0.3",
@@ -48434,7 +48430,8 @@
     "css-declaration-sorter": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
-      "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg=="
+      "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg==",
+      "requires": {}
     },
     "css-loader": {
       "version": "6.7.1",
@@ -48617,7 +48614,8 @@
     "cssnano-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -49073,7 +49071,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "devOptional": true
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -49684,7 +49682,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
@@ -49694,7 +49691,6 @@
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "dev": true,
           "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -49967,7 +49963,7 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
       "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@eslint/eslintrc": "^1.2.0",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -50010,7 +50006,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -50019,7 +50015,7 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -50029,7 +50025,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -50038,25 +50034,25 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "devOptional": true
         },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "dev": true
+          "devOptional": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "devOptional": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -50421,7 +50417,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
       "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-unicorn": {
       "version": "40.1.0",
@@ -50455,7 +50452,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
       "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -50465,7 +50462,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "eslint-visitor-keys": "^2.0.0"
       },
@@ -50474,7 +50471,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
           "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -50482,13 +50479,13 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true
+      "devOptional": true
     },
     "espree": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
       "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "acorn": "^8.7.0",
         "acorn-jsx": "^5.3.1",
@@ -50504,7 +50501,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
       "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "estraverse": "^5.1.0"
       }
@@ -50828,7 +50825,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "devOptional": true
     },
     "fast-redact": {
       "version": "3.1.1",
@@ -51055,7 +51052,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "flat-cache": "^3.0.4"
       }
@@ -51317,7 +51314,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -51332,7 +51329,7 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
-      "dev": true
+      "devOptional": true
     },
     "flux": {
       "version": "4.0.3",
@@ -51602,7 +51599,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
+      "devOptional": true
     },
     "functions-have-names": {
       "version": "1.2.2",
@@ -51681,7 +51678,7 @@
     "generate-docs-index": {
       "version": "file:scripts/generate-docs-index",
       "requires": {
-        "@gasket/cli": "^6.31.0",
+        "@gasket/cli": "^6.32.0",
         "copy-dir": "^1.2.0",
         "eslint": "^8.7.0",
         "eslint-plugin-unicorn": "^40.1.0"
@@ -52039,7 +52036,8 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/global-jsdom/-/global-jsdom-8.4.0.tgz",
       "integrity": "sha512-0wBpSA/uTbPwMUldVKvPkJmQ30PZacTY8LzXSnTYlptZl6c5OFAVXSb24o1vdvjUNAmIksj+BAJb/c/KSPlLCQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "global-modules": {
       "version": "2.0.0",
@@ -52073,7 +52071,7 @@
       "version": "13.13.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
       "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "type-fest": "^0.20.2"
       }
@@ -52700,7 +52698,8 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1",
@@ -54135,7 +54134,8 @@
           "version": "7.5.7",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
           "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "xml-name-validator": {
           "version": "3.0.0",
@@ -54417,7 +54417,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -55197,7 +55198,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
+      "devOptional": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -55372,7 +55373,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -55702,7 +55703,8 @@
         "ws": {
           "version": "7.5.7",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-          "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A=="
+          "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+          "requires": {}
         }
       }
     },
@@ -56242,7 +56244,8 @@
       "version": "8.6.2",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.2.tgz",
       "integrity": "sha512-JNaekTlIwwyYGBN3zifZDxgz4bSL8sbEj58fdTZGmPSMMGXBZapFjcZk2I33Jy79c1fvCKHpF7MA/67FOTjvzA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "markdown-table": {
       "version": "1.1.3",
@@ -56970,7 +56973,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
+      "devOptional": true
     },
     "natural-orderby": {
       "version": "2.0.3",
@@ -57045,7 +57048,8 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/next-redux-wrapper/-/next-redux-wrapper-7.0.5.tgz",
       "integrity": "sha512-UFXdAWG5i+GFT8+Hoqpx3GArkPh34fVWF9YoA2VSHlBzsrPtnRd7NWM6FNSYUennpommTpWJ09mu+r/1UxyIkg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "nice-try": {
       "version": "1.0.5",
@@ -57847,7 +57851,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -58589,22 +58593,26 @@
     "postcss-discard-comments": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.1.tgz",
-      "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ=="
+      "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ==",
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+      "requires": {}
     },
     "postcss-discard-unused": {
       "version": "5.1.0",
@@ -58692,7 +58700,8 @@
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -58723,7 +58732,8 @@
     "postcss-normalize-charset": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -58867,7 +58877,8 @@
     "postcss-zindex": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-5.1.0.tgz",
-      "integrity": "sha512-fgFMf0OtVSBR1va1JNHYgMxYk73yhn/qb4uQDq1DLGYolz8gHCyr/sesEuGUaYs58E3ZJRcpoGuPVoB7Meiq9A=="
+      "integrity": "sha512-fgFMf0OtVSBR1va1JNHYgMxYk73yhn/qb4uQDq1DLGYolz8gHCyr/sesEuGUaYs58E3ZJRcpoGuPVoB7Meiq9A==",
+      "requires": {}
     },
     "predefine": {
       "version": "0.1.3",
@@ -58881,7 +58892,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true
+      "devOptional": true
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -58929,7 +58940,8 @@
     "prism-react-renderer": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.3.tgz",
-      "integrity": "sha512-Viur/7tBTCH2HmYzwCHmt2rEFn+rdIWNIINXyg0StiISbDiIhHKhrFuEK8eMkKgvsIYSjgGqy/hNyucHp6FpoQ=="
+      "integrity": "sha512-Viur/7tBTCH2HmYzwCHmt2rEFn+rdIWNIINXyg0StiISbDiIhHKhrFuEK8eMkKgvsIYSjgGqy/hNyucHp6FpoQ==",
+      "requires": {}
     },
     "prismjs": {
       "version": "1.28.0",
@@ -59427,7 +59439,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -59585,7 +59596,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -60208,7 +60218,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
       "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
@@ -60224,7 +60233,8 @@
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",
@@ -60273,7 +60283,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true
+      "devOptional": true
     },
     "regexpu-core": {
       "version": "5.0.1",
@@ -60914,7 +60924,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -61989,7 +61998,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.1.tgz",
       "integrity": "sha512-+PIZ/6Uk40mphiQJJI1202b+/dYeTVd9ZnMPR80pgiWbjIwvN2zIp4r9et0BgqBuShh48I0gttPlAXA7WVvBxw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "stylehacks": {
       "version": "5.1.0",
@@ -62594,7 +62604,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "prelude-ls": "^1.2.1"
       }
@@ -62609,7 +62619,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true
+      "devOptional": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -62636,8 +62646,7 @@
     "typescript": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
     },
     "typical": {
       "version": "2.6.1",
@@ -62989,12 +62998,14 @@
     "use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ=="
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "requires": {}
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "requires": {}
     },
     "use-latest": {
       "version": "1.2.1",
@@ -63043,7 +63054,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true
+      "devOptional": true
     },
     "v8-to-istanbul": {
       "version": "8.1.1",
@@ -63397,7 +63408,8 @@
         "ws": {
           "version": "7.5.7",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-          "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A=="
+          "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+          "requires": {}
         }
       }
     },
@@ -63773,7 +63785,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
+      "devOptional": true
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -64110,7 +64122,8 @@
     "ws": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/packages/gasket-plugin-express/docs/setup.md
+++ b/packages/gasket-plugin-express/docs/setup.md
@@ -106,6 +106,24 @@ module.exports = {
   }
 }
 ```
+You can configure which paths middleware will run on by adding the middleware configuration array to your local `gasket.config.js`. The array is made up of objects with the name of the middlware (Gasket plugin name) you want to configure and an array of path patterns representing the paths to match for this middleware. Pattern matching entries in the array can come in the form of path strings, path pattern strings, and/or regular expressions. Pattern matching logic follows Express's [app.use pattern matching].
+
+```js
+  middleware: [
+    {
+      plugin:'api-middleware', // Name of the Gasket plugin
+      paths: ['/api']
+    },
+    {
+      plugin:'default-middlware',
+      paths: [/\/default/]
+    },
+    {
+      plugin: 'abc-middleware'
+      paths: ['/proxy', /\/home/]
+    }
+  ]
+```
 
 <!-- LINKS -->
 
@@ -113,3 +131,4 @@ module.exports = {
 [plugins]:/packages/gasket-cli/docs/plugins.md
 [@gasket/plugin-redux]:/packages/gasket-plugin-redux/README.md
 [timing mechanism]:/packages/gasket-engine/README.md
+[app.use pattern matching]: http://expressjs.com/en/4x/api.html#path-examples

--- a/packages/gasket-plugin-express/docs/setup.md
+++ b/packages/gasket-plugin-express/docs/setup.md
@@ -111,15 +111,15 @@ You can configure which paths middleware will run on by adding the middleware co
 ```js
   middleware: [
     {
-      plugin:'api-middleware', // Name of the Gasket plugin
+      plugin:'gasket-plugin-example', // Name of the Gasket plugin
       paths: ['/api']
     },
     {
-      plugin:'default-middlware',
+      plugin:'@some/gasket-plugin-example',
       paths: [/\/default/]
     },
     {
-      plugin: 'abc-middleware'
+      plugin: '@another/gasket-plugin-example'
       paths: ['/proxy', /\/home/]
     }
   ]

--- a/packages/gasket-plugin-express/test/plugin.test.js
+++ b/packages/gasket-plugin-express/test/plugin.test.js
@@ -48,10 +48,12 @@ describe('Plugin', function () {
 
 // eslint-disable-next-line max-statements
 describe('createServers', () => {
-  let gasket, lifecycles;
+  let gasket, lifecycles, mockMwPlugins;
+  const sandbox = sinon.createSandbox();
 
   beforeEach(() => {
     sinon.resetHistory();
+    mockMwPlugins =  [];
 
     lifecycles = {
       middleware: sinon.stub().resolves([]),
@@ -60,9 +62,17 @@ describe('createServers', () => {
     };
 
     gasket = {
+      middleware: {},
       logger: {},
       config: {},
-      exec: sinon.stub().callsFake((lifecycle, ...args) => lifecycles[lifecycle](args))
+      exec: sinon.stub().callsFake((lifecycle, ...args) => lifecycles[lifecycle](args)),
+      execApply: sandbox.spy(async function (lifecycle, fn) {
+        for (let i = 0; i <  mockMwPlugins.length; i++) {
+          // eslint-disable-next-line  no-loop-func
+          fn(mockMwPlugins[i], () => mockMwPlugins[i]);
+        }
+        return sinon.stub();
+      })
     };
   });
 
@@ -79,7 +89,7 @@ describe('createServers', () => {
 
   it('executes the `middleware` lifecycle', async function () {
     await plugin.hooks.createServers(gasket, {});
-    assume(gasket.exec).has.been.calledWith('middleware', app);
+    assume(gasket.execApply).has.been.calledWith('middleware');
   });
 
   it('executes the `express` lifecycle', async function () {
@@ -94,14 +104,14 @@ describe('createServers', () => {
 
   it('executes the `middleware` lifecycle before the `express` lifecycle', async function () {
     await plugin.hooks.createServers(gasket, {});
-    assume(gasket.exec.firstCall).has.been.calledWith('middleware', app);
-    assume(gasket.exec.secondCall).has.been.calledWith('express', app);
+    assume(gasket.execApply.firstCall).has.been.calledWith('middleware');
+    assume(gasket.exec.firstCall).has.been.calledWith('express', app);
   });
 
   it('executes the `errorMiddleware` lifecycle after the `express` lifecycle', async function () {
     await plugin.hooks.createServers(gasket, {});
-    assume(gasket.exec.secondCall).has.been.calledWith('express', app);
-    assume(gasket.exec.thirdCall).has.been.calledWith('errorMiddleware');
+    assume(gasket.exec.firstCall).has.been.calledWith('express', app);
+    assume(gasket.exec.secondCall).has.been.calledWith('errorMiddleware');
   });
 
   it('adds the errorMiddleware', async () => {
@@ -143,7 +153,7 @@ describe('createServers', () => {
     assume(cookieParserUsage).to.not.be.null();
 
     const withEvent = event => calledEvent => calledEvent === event;
-    const middlewareInjection = findCall(gasket.exec, withEvent('middleware'));
+    const middlewareInjection = findCall(gasket.execApply, withEvent('middleware'));
     const routeInjection = findCall(gasket.exec, withEvent('express'));
 
     // callId can be used to determine relative call ordering
@@ -195,10 +205,27 @@ describe('createServers', () => {
     assume(app.use).called(2);
 
     sinon.resetHistory();
-    lifecycles.middleware.resolves([() => {}, null]);
+    mockMwPlugins = [
+      { name: 'middlware-1' },
+      null
+    ];
 
     await plugin.hooks.createServers(gasket, {});
     assume(app.use).called(3);
+  });
+
+  it('middleware paths in the config are used', async () => {
+    const paths = ['/home'];
+    gasket.config.middleware = [{
+      plugin: 'middlware-1',
+      paths
+    }];
+    mockMwPlugins = [
+      { name: 'middlware-1' }
+    ];
+    await plugin.hooks.createServers(gasket, {});
+
+    assume(app.use.thirdCall).has.been.calledWith(paths);
   });
 
   it('adds errorMiddleware from lifecycle (ignores falsy)', async () => {


### PR DESCRIPTION
## Summary

Currently all server middleware runs on every request path. This has been less than ideal  in cases that call for certain middleware to be included only on particular routes. For example, middleware designed to only be run on /api/* routes would also apply to requests with the /proxy/* path. Going forward, it would be helpful for developers to have the option to configure which routes their middleware is run on in order to avoid any side effects or bugs due to unexpected middleware + request path combinations. 

## Changelog

@gasket/plugin-express
- Add check for middleware array in the gasket config

## Test Plan

- Unit tests
- Verified in a local gasket app
