### PR TITLE
Add middleware configuration check for fastify plugin 

### DIFF
--- a/packages/gasket-plugin-fastify/README.md
+++ b/packages/gasket-plugin-fastify/README.md
@@ -56,15 +56,15 @@ You can configure which paths middleware will run on by adding the middleware co
 ```js
   middleware: [
     {
-      plugin:'api-middleware', // Name of the Gasket plugin
+      plugin:'gasket-plugin-api-middleware', // Name of the Gasket plugin
       paths: ['/api']
     },
     {
-      plugin:'default-middlware',
+      plugin:'gasket-plugin-default-middlware',
       paths: [/\/default/]
     },
     {
-      plugin: 'abc-middleware'
+      plugin: 'gasket-plugin-abc-middleware'
       paths: ['/proxy', /\/home/]
     }
   ]

--- a/packages/gasket-plugin-fastify/README.md
+++ b/packages/gasket-plugin-fastify/README.md
@@ -56,15 +56,15 @@ You can configure which paths middleware will run on by adding the middleware co
 ```js
   middleware: [
     {
-      plugin:'gasket-plugin-api-middleware', // Name of the Gasket plugin
+      plugin:'gasket-plugin-example', // Name of the Gasket plugin
       paths: ['/api']
     },
     {
-      plugin:'gasket-plugin-default-middlware',
+      plugin:'@some/gasket-plugin-example',
       paths: [/\/default/]
     },
     {
-      plugin: 'gasket-plugin-abc-middleware'
+      plugin: '@another/gasket-plugin-example'
       paths: ['/proxy', /\/home/]
     }
   ]

--- a/packages/gasket-plugin-fastify/README.md
+++ b/packages/gasket-plugin-fastify/README.md
@@ -50,6 +50,26 @@ module.exports = {
 }
 ```
 
+### middleware
+
+You can configure which paths middleware will run on by adding the middleware configuration array to your local `gasket.config.js`. The array is made up of objects with the name of the middlware (Gasket plugin name) you want to configure and an array of path patterns representing the paths to match for this middleware. Pattern matching entries in the array can come in the form of path strings and/or regular expressions.
+```js
+  middleware: [
+    {
+      plugin:'api-middleware', // Name of the Gasket plugin
+      paths: ['/api']
+    },
+    {
+      plugin:'default-middlware',
+      paths: [/\/default/]
+    },
+    {
+      plugin: 'abc-middleware'
+      paths: ['/proxy', /\/home/]
+    }
+  ]
+```
+
 ## Lifecycles
 
 ### middleware


### PR DESCRIPTION
## Summary

Currently all server middleware runs on every request path. This has been less than ideal  in cases that call for certain middleware to be included only on particular routes. For example, middleware designed to only be run on /api/* routes would also apply to requests with the /proxy/* path. Going forward, it would be helpful for developers to have the option to configure which routes their middleware is run on in order to avoid any side effects or bugs due to unexpected middleware + request path combinations. 

## Changelog

@gasket/plugin-fastify
- Add check for middleware array in the gasket config

## Test Plan

- Unit tests
- Verified in a local gasket app
