### PR TITLE
Avoid config redux state overwrite

### DIFF
--- a/packages/gasket-plugin-config/CHANGELOG.md
+++ b/packages/gasket-plugin-config/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-config`
 
+- Avoid potential overwriting of custom config state
+
 ### 6.20.4
 
 - More descriptive error handling for hooks that do not return results ([#359])

--- a/packages/gasket-plugin-config/lib/plugin.js
+++ b/packages/gasket-plugin-config/lib/plugin.js
@@ -26,7 +26,10 @@ module.exports = {
       const { redux } = req.config || {};
       return {
         ...state,
-        config: redux
+        config: {
+          ...state.config,
+          ...redux
+        }
       };
     },
     metadata(gasket, meta) {

--- a/packages/gasket-plugin-config/test/plugin.test.js
+++ b/packages/gasket-plugin-config/test/plugin.test.js
@@ -232,5 +232,22 @@ describe('Plugin', () => {
         config: { something: 'public' }
       });
     });
+
+    it('does not overwrite any previously-prevent config state', async () => {
+      delete req.config;
+      const startingState = {
+        config: { some: { custom: 'config' } }
+      };
+
+      const newState = await plugin.hooks.initReduxState(
+        gasket,
+        startingState,
+        req,
+        res);
+
+      expect(newState).toEqual({
+        config: { some: { custom: 'config' } }
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Don't have `@gasket/plugin-config` shadow prior `config` redux state which could be overwriting custom initial state.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
