### PR TITLE
Add support for contextual thunk for locales path

### DIFF
--- a/packages/gasket-helper-intl/CHANGELOG.md
+++ b/packages/gasket-helper-intl/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/helper-intl`
 
+- Add support for contextual thunk for locales path ([#447])
+
 ### 6.26.1
 
 - Fix `LocaleStatus` enum to match to JS ([#383])
@@ -31,3 +33,4 @@
 [#268]: https://github.com/godaddy/gasket/pull/268
 [#276]: https://github.com/godaddy/gasket/pull/276
 [#383]: https://github.com/godaddy/gasket/pull/383
+[#447]: https://github.com/godaddy/gasket/pull/447

--- a/packages/gasket-helper-intl/docs/api.md
+++ b/packages/gasket-helper-intl/docs/api.md
@@ -11,6 +11,8 @@ Name | Description
 ------ | -----------
 [LocaleManifest] | Locale settings and known locale file paths
 [LocalePathPart] | Partial URL representing a directory containing locale .json files or a URL template with a `:locale` path param to a .json file.
+[LocalePathThunk] | Callback which receives a context object for resolving a LocalePathPath
+[LocalePathPartOrThunk] | A localePathPart string or callback which returns one
 [LocalePath] | URL path to a locale .json file
 [Lang] | Language code only
 [Locale] | Language code with region
@@ -29,7 +31,8 @@ Utility class for loading locale files
     * [new LocaleUtils(config)]
     * [.getFallbackLocale(locale)]
     * [.formatLocalePath(localePathPart, locale)]
-    * [.getLocalePath(localePathPart, locale)]
+    * [.resolveLocalePathPart(localePathPart, \[context\])]
+    * [.getLocalePath(localePathPart, locale, \[context\])]
     * [.pathToUrl(localePath)]
     * [.serverLoadData(localePathPart, locale, localesDir)]
 
@@ -79,7 +82,20 @@ and ends with .json file.
 | locale | [`Locale`] | Locale |
 
 
-### localeUtils.getLocalePath(localePathPart, locale)
+### localeUtils.resolveLocalePathPart(localePathPart, \[context\])
+
+Get a localePathPart from provided string or thunk callback results
+
+**Kind**: instance method of [`LocaleUtils`]  
+**Returns**: [`LocalePath`] - localePath  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| localePathPart | [`LocalePathPartOrThunk`] | Path containing locale files |
+| \[context\] | `object` | Context |
+
+
+### localeUtils.getLocalePath(localePathPart, locale, \[context\])
 
 Get a formatted localePath considering language mappings and fallbacks
 
@@ -88,8 +104,9 @@ Get a formatted localePath considering language mappings and fallbacks
 
 | Param | Type | Description |
 | --- | --- | --- |
-| localePathPart | [`LocalePathPart`] | Path containing locale files |
+| localePathPart | [`LocalePathPartOrThunk`] | Path containing locale files |
 | locale | [`Locale`] | Locale |
+| \[context\] | `object` | Context |
 
 
 ### localeUtils.pathToUrl(localePath)
@@ -192,6 +209,24 @@ or a URL template with a `:locale` path param to a .json file.
 "/locales/{locale}/component.json"
 ```
 
+## LocalePathThunk
+
+Callback which receives a context object for resolving a LocalePathPath
+
+**Kind**: global typedef  
+**Returns**: `string` - localePathPart  
+
+| Param | Type |
+| --- | --- |
+| context | `object` | 
+
+
+## LocalePathPartOrThunk
+
+A localePathPart string or callback which returns one
+
+**Kind**: global typedef  
+
 ## LocalePath
 
 URL path to a locale .json file
@@ -284,6 +319,8 @@ Fetch status of a locale file
 [LocaleUtils]:#localeutils
 [LocaleManifest]:#localemanifest
 [LocalePathPart]:#localepathpart
+[LocalePathThunk]:#localepaththunk
+[LocalePathPartOrThunk]:#localepathpartorthunk
 [LocalePath]:#localepath
 [Lang]:#lang
 [Locale]:#locale
@@ -296,6 +333,7 @@ Fetch status of a locale file
 [`Lang`]:#lang
 [`LocalePath`]:#localepath
 [`LocalePathPart`]:#localepathpart
+[`LocalePathPartOrThunk`]:#localepathpartorthunk
 [`LocalesProps`]:#localesprops
 [`LocaleStatus`]:#localestatus
 [.LOADING]:#localestatusloading
@@ -304,6 +342,7 @@ Fetch status of a locale file
 [new LocaleUtils(config)]:#new-localeutilsconfig
 [.getFallbackLocale(locale)]:#localeutilsgetfallbacklocalelocale
 [.formatLocalePath(localePathPart, locale)]:#localeutilsformatlocalepathlocalepathpart-locale
-[.getLocalePath(localePathPart, locale)]:#localeutilsgetlocalepathlocalepathpart-locale
+[.resolveLocalePathPart(localePathPart, \[context\])]:#localeutilsresolvelocalepathpartlocalepathpart-context
+[.getLocalePath(localePathPart, locale, \[context\])]:#localeutilsgetlocalepathlocalepathpart-locale-context
 [.pathToUrl(localePath)]:#localeutilspathtourllocalepath
 [.serverLoadData(localePathPart, locale, localesDir)]:#localeutilsserverloaddatalocalepathpart-locale-localesdir

--- a/packages/gasket-helper-intl/lib/index.d.ts
+++ b/packages/gasket-helper-intl/lib/index.d.ts
@@ -29,6 +29,17 @@ export interface LocaleManifest {
  * or a URL template with a `:locale` path param to a .json file.
  */
 export type LocalePathPart = string;
+
+/**
+ * Callback which receives a context object for resolving a LocalePathPath
+ */
+export type LocalePathThunk = (context: {}) => LocalePathPart;
+
+/**
+ * Callback which receives a context object for resolving a LocalePathPath
+ */
+export type LocalePathPartOrThunk = LocalePathPart|LocalePathThunk;
+
 /**
  * URL path to a locale .json file
  */
@@ -126,10 +137,11 @@ export class LocaleUtils {
      * Load locale file(s) and return localesProps.
      * Throws error if attempted to use in browser.
      *
-     * @param {LocalePathPart|LocalePathPart[]} localePathPart - Path(s) containing locale files
+     * @param {LocalePathPartOrThunk|LocalePathPartOrThunk[]} localePathPart - Path(s) containing locale files
      * @param {Locale} locale - Locale to load
      * @param {string} localesDir - Disk path to locale files dir
+     * @param {string} [context] - Context for resolving localePathThunk
      * @returns {LocalesProps} localesProps
      */
-    serverLoadData: (localePathPart: any, locale: any, localesDir: any) => any;
+    serverLoadData: (localePathPart: any, locale: any, localesDir: any, context?: {}) => any;
 }

--- a/packages/gasket-helper-intl/lib/index.d.ts
+++ b/packages/gasket-helper-intl/lib/index.d.ts
@@ -1,3 +1,5 @@
+import { IncomingMessage, OutgoingMessage } from 'http';
+
 /**
  * Locale settings and known locale file paths
  */
@@ -33,7 +35,17 @@ export type LocalePathPart = string;
 /**
  * Callback which receives a context object for resolving a LocalePathPath
  */
-export type LocalePathThunk = (context: {}) => LocalePathPart;
+export type LocalePathThunk = (context: {
+    // Any server render
+    req?: IncomingMessage,
+    res?: OutgoingMessage
+
+    // Possible Next.js contexts
+    // @see: https://nextjs.org/docs/api-reference/data-fetching/get-static-props#context-parameter
+    // @see: https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
+    // @see: https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props#context-parameter
+    [key: string]: any
+}) => LocalePathPart;
 
 /**
  * Callback which receives a context object for resolving a LocalePathPath

--- a/packages/gasket-helper-intl/lib/server.js
+++ b/packages/gasket-helper-intl/lib/server.js
@@ -10,13 +10,13 @@ const { LocaleUtils, LocaleStatus } = require('./index');
 function LocaleServerUtils() {
   LocaleUtils.apply(this, arguments);
 
-  this.serverLoadData = (localePathPart, locale, localesDir) => {
+  this.serverLoadData = (localePathPart, locale, localesDir, context = {}) => {
     if (Array.isArray(localePathPart)) {
-      const localesProps = localePathPart.map(p => this.serverLoadData(p, locale, localesDir));
+      const localesProps = localePathPart.map(p => this.serverLoadData(p, locale, localesDir, context));
       return merge(...localesProps);
     }
 
-    const localeFile = this.getLocalePath(localePathPart, locale);
+    const localeFile = this.getLocalePath(localePathPart, locale, context);
     const diskPath = path.join(localesDir, localeFile);
     let messages;
     let status;

--- a/packages/gasket-helper-intl/test/server.test.js
+++ b/packages/gasket-helper-intl/test/server.test.js
@@ -1,5 +1,6 @@
 const assume = require('assume');
 const path = require('path');
+const sinon = require('sinon');
 
 const { LocaleUtils } = require('../lib/server');
 
@@ -60,6 +61,19 @@ describe('LocaleUtils (Server)', function () {
         locale: 'fr-CA',
         messages: { 'fr-CA': { gasket_welcome: 'Hello!', gasket_learn: 'Learn Gasket' } },
         status: { '/locales/en-US.json': 'loaded' }
+      });
+    });
+
+    it('handles thunks for locale paths', function () {
+      const mockContext = { extra: true };
+      const mockThunk = sinon.stub().callsFake((context) => context.extra ? '/locales/extra' : '/locales');
+
+      const results = utils.serverLoadData(mockThunk, 'en-US', localesParentDir, mockContext);
+      assume(mockThunk).called();
+      assume(results).eqls({
+        locale: 'en-US',
+        messages: { 'en-US': { gasket_extra: 'Extra' } },
+        status: { '/locales/extra/en-US.json': 'loaded' }
       });
     });
   });

--- a/packages/gasket-helper-intl/test/shared.js
+++ b/packages/gasket-helper-intl/test/shared.js
@@ -82,6 +82,16 @@ module.exports = function sharedTests(UtilClass) {
     });
   });
 
+  describe('.resolveLocalePathPart', function () {
+    it('handles thunks for locale paths', function () {
+      const mockContext = { customRoot: '/bogus' };
+      const mockThunk = sinon.stub().callsFake((context) => context.customRoot + '/locales');
+      const results = utils.resolveLocalePathPart(mockThunk, mockContext);
+      assume(results).equals('/bogus/locales');
+      assume(mockThunk).called();
+    });
+  });
+
   describe('.getLocalePath', function () {
     it('returns formatted localePath', function () {
       const results = utils.getLocalePath('/locales', 'en-US');
@@ -146,6 +156,14 @@ module.exports = function sharedTests(UtilClass) {
       utils = new UtilClass(mockConfig);
       const results = utils.getLocalePath('/locales', 'da-DK');
       assume(results).equals('/locales/fake.json');
+    });
+
+    it('handles thunks for locale paths', function () {
+      const mockContext = { customRoot: '/bogus' };
+      const mockThunk = sinon.stub().callsFake((context) => context.customRoot + '/locales');
+      const results = utils.getLocalePath(mockThunk, 'en-US', mockContext);
+      assume(results).equals('/bogus/locales/en-US.json');
+      assume(mockThunk).called();
     });
   });
 };

--- a/packages/gasket-react-intl/CHANGELOG.md
+++ b/packages/gasket-react-intl/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/react-intl`
 
+- Add support for contextual thunk for locales path ([#447])
+
 ### 6.32.0
 
 - Fix compatibility issue with Webpack 5 caused by top-level import of `path`
@@ -157,3 +159,4 @@
 [#384]: https://github.com/godaddy/gasket/pull/384
 [#401]: https://github.com/godaddy/gasket/pull/401
 [#415]: https://github.com/godaddy/gasket/pull/415
+[#447]: https://github.com/godaddy/gasket/pull/447

--- a/packages/gasket-react-intl/src/locale-required.js
+++ b/packages/gasket-react-intl/src/locale-required.js
@@ -13,17 +13,14 @@ import useLocaleRequired from './use-locale-required';
  * @returns {JSX.Element|null} element
  */
 export default function LocaleRequired(props) {
-  const { localesPathPart = props.localesPath, loading = null, children } = props;
-  const loadState = useLocaleRequired(localesPathPart);
+  const { localesPath, loading = null, children } = props;
+  const loadState = useLocaleRequired(localesPath);
   if (loadState === LocaleStatus.LOADING) return loading;
   return <>{ children }</>;
 }
 
 LocaleRequired.propTypes = {
-  /** @deprecated use localesPathPart */
-  localesPath: PropTypes.string,
-
-  localesPathPart: PropTypes.oneOfType([
+  localesPath: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.func
   ]),

--- a/packages/gasket-react-intl/src/locale-required.js
+++ b/packages/gasket-react-intl/src/locale-required.js
@@ -13,18 +13,24 @@ import useLocaleRequired from './use-locale-required';
  * @returns {JSX.Element|null} element
  */
 export default function LocaleRequired(props) {
-  const { localesPath, loading = null, children } = props;
-  const loadState = useLocaleRequired(localesPath);
+  const { localesPathPart = props.localesPath, loading = null, children } = props;
+  const loadState = useLocaleRequired(localesPathPart);
   if (loadState === LocaleStatus.LOADING) return loading;
   return <>{ children }</>;
 }
 
 LocaleRequired.propTypes = {
+  /** @deprecated use localesPathPart */
   localesPath: PropTypes.string,
+
+  localesPathPart: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.function
+  ]),
   loading: PropTypes.node,
   children: PropTypes.node.isRequired
 };
 
 LocaleRequired.defaultProps = {
-  localesPath: manifest.defaultPath
+  localesPathPart: manifest.defaultPath
 };

--- a/packages/gasket-react-intl/src/locale-required.js
+++ b/packages/gasket-react-intl/src/locale-required.js
@@ -25,7 +25,7 @@ LocaleRequired.propTypes = {
 
   localesPathPart: PropTypes.oneOfType([
     PropTypes.string,
-    PropTypes.function
+    PropTypes.func
   ]),
   loading: PropTypes.node,
   children: PropTypes.node.isRequired

--- a/packages/gasket-react-intl/src/next.js
+++ b/packages/gasket-react-intl/src/next.js
@@ -17,7 +17,7 @@ export function intlGetStaticProps(localePathPart = manifest.defaultPath) {
     }
 
     // eslint-disable-next-line no-process-env
-    const localesProps = localeUtils.serverLoadData(localePathPart, locale, getLocalesParentDir());
+    const localesProps = localeUtils.serverLoadData(localePathPart, locale, getLocalesParentDir(), ctx);
 
     return {
       props: {
@@ -42,7 +42,7 @@ export function intlGetServerSideProps(localePathPart = manifest.defaultPath) {
     if (!locale && res.locals && res.locals.gasketData && res.locals.gasketData.intl) {
       locale = res.locals.gasketData.intl.locale;
     }
-    const localesProps = localeUtils.serverLoadData(localePathPart, locale, getLocalesParentDir());
+    const localesProps = localeUtils.serverLoadData(localePathPart, locale, getLocalesParentDir(), ctx);
 
     return {
       props: {

--- a/packages/gasket-react-intl/src/use-locale-required.js
+++ b/packages/gasket-react-intl/src/use-locale-required.js
@@ -7,12 +7,13 @@ import { GasketIntlContext } from './context';
 /**
  * React that fetches a locale file and returns loading status
  *
- * @param {LocalePathPart} localePathPart - Path containing locale files
+ * @param {LocalePathPartOrThunk} localePathPart - Path containing locale files
  * @returns {LocaleStatus} status
  */
 export default function useLocaleRequired(localePathPart) {
   const { locale, status = {}, dispatch } = useContext(GasketIntlContext);
 
+  // thunks are supported but with context will be browser-only (empty object)
   const localePath = localeUtils.getLocalePath(localePathPart, locale);
 
   const fileStatus = status[localePath];

--- a/packages/gasket-react-intl/test/locale-required.test.js
+++ b/packages/gasket-react-intl/test/locale-required.test.js
@@ -55,5 +55,27 @@ describe('LocaleRequired', function () {
       wrapper = doMount({ loading: 'loading...' });
       assume(wrapper.html()).includes('MockComponent');
     });
+
+    it('supports deprecated localesPath', function () {
+      useLocaleRequiredStub.returns(LOADING);
+      wrapper = doMount({ localesPath: '/bogus' });
+      assume(useLocaleRequiredStub).calledWith('/bogus');
+      assume(wrapper.html()).eqls(null);
+    });
+
+    it('supports localesPathPart', function () {
+      useLocaleRequiredStub.returns(LOADING);
+      wrapper = doMount({ localesPathPart: '/bogus' });
+      assume(useLocaleRequiredStub).calledWith('/bogus');
+      assume(wrapper.html()).eqls(null);
+    });
+
+    it('supports localesPathPart as thunk', function () {
+      const mockThunk = sinon.stub();
+      useLocaleRequiredStub.returns(LOADING);
+      wrapper = doMount({ localesPathPart: mockThunk });
+      assume(useLocaleRequiredStub).calledWith(mockThunk);
+      assume(wrapper.html()).eqls(null);
+    });
   });
 });

--- a/packages/gasket-react-intl/test/locale-required.test.js
+++ b/packages/gasket-react-intl/test/locale-required.test.js
@@ -56,24 +56,17 @@ describe('LocaleRequired', function () {
       assume(wrapper.html()).includes('MockComponent');
     });
 
-    it('supports deprecated localesPath', function () {
+    it('supports localesPath', function () {
       useLocaleRequiredStub.returns(LOADING);
       wrapper = doMount({ localesPath: '/bogus' });
       assume(useLocaleRequiredStub).calledWith('/bogus');
       assume(wrapper.html()).eqls(null);
     });
 
-    it('supports localesPathPart', function () {
-      useLocaleRequiredStub.returns(LOADING);
-      wrapper = doMount({ localesPathPart: '/bogus' });
-      assume(useLocaleRequiredStub).calledWith('/bogus');
-      assume(wrapper.html()).eqls(null);
-    });
-
-    it('supports localesPathPart as thunk', function () {
+    it('supports localesPath as thunk', function () {
       const mockThunk = sinon.stub();
       useLocaleRequiredStub.returns(LOADING);
-      wrapper = doMount({ localesPathPart: mockThunk });
+      wrapper = doMount({ localesPath: mockThunk });
       assume(useLocaleRequiredStub).calledWith(mockThunk);
       assume(wrapper.html()).eqls(null);
     });

--- a/packages/gasket-react-intl/test/next.test.js
+++ b/packages/gasket-react-intl/test/next.test.js
@@ -63,6 +63,23 @@ describe('Next.js functions', function () {
       });
     });
 
+    it('handles thunks for locale path part', async function () {
+      const mockContext = { params: { locale: 'en-US' }, extra: true };
+      const mockThunk = sinon.stub().callsFake((context) => context.extra ? '/locales/extra' : '/locales');
+
+      const results = await next.intlGetStaticProps(mockThunk)(mockContext);
+      assume(mockThunk).calledWith(mockContext);
+      assume(results).eqls({
+        props: {
+          localesProps: {
+            locale: 'en-US',
+            messages: { 'en-US': { gasket_extra: 'Extra' } },
+            status: { '/locales/extra/en-US.json': 'loaded' }
+          }
+        }
+      });
+    });
+
     it('returns localesProps for multiple locale path parts', async function () {
       const results = await next.intlGetStaticProps(['/locales', '/locales/extra'])({ params: { locale: 'en-US' } });
       assume(results).eqls({
@@ -141,6 +158,23 @@ describe('Next.js functions', function () {
 
     it('returns localesProps for other path part', async function () {
       const results = await next.intlGetServerSideProps('/locales/extra')({ res });
+      assume(results).eqls({
+        props: {
+          localesProps: {
+            locale: 'en-US',
+            messages: { 'en-US': { gasket_extra: 'Extra' } },
+            status: { '/locales/extra/en-US.json': 'loaded' }
+          }
+        }
+      });
+    });
+
+    it('handles thunks for locale path part', async function () {
+      const mockContext = { res, extra: true };
+      const mockThunk = sinon.stub().callsFake((context) => context.extra ? '/locales/extra' : '/locales');
+
+      const results = await next.intlGetServerSideProps(mockThunk)(mockContext);
+      assume(mockThunk).calledWith(mockContext);
       assume(results).eqls({
         props: {
           localesProps: {

--- a/packages/gasket-react-intl/test/use-locale-required.test.js
+++ b/packages/gasket-react-intl/test/use-locale-required.test.js
@@ -54,6 +54,15 @@ describe('useLocaleRequired', function () {
     assume(fetchStub).calledWith('/locales/en.json');
   });
 
+  it('handle thunks for locale paths', function () {
+    const mockThunk = sinon.stub().callsFake(() => '/custom/locales');
+
+    const results = useLocaleRequired(mockThunk);
+    assume(results).equals(LOADING);
+    assume(fetchStub).called();
+    assume(fetchStub).calledWith('/custom/locales/en.json');
+  });
+
   it('returns LOADING if fetching', function () {
     const results = useLocaleRequired('/locales');
     assume(results).equals(LOADING);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Some situations require changing the target locales path part based on page request details. To support this, the various locales components and HOC allow for a thunk to be passed, which will receive a context object based on the render state which can be used to determine the locales path to use.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/react-intl**
- Add support for contextual thunk for locales path

**@gasket/helper-intl**
- Add support for contextual thunk for locales path

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- expanded unit tests
- locally tested in canary app