### PR TITLE
Retain destOverride from provided create context

### DIFF
--- a/packages/gasket-cli/src/scaffold/actions/global-prompts.js
+++ b/packages/gasket-cli/src/scaffold/actions/global-prompts.js
@@ -122,7 +122,7 @@ async function chooseTestPlugin(context, prompt) {
  */
 async function allowExtantOverwriting(context, prompt) {
   const { dest, extant } = context;
-  if (extant) {
+  if (extant && !('destOverride' in context)) {
     const { destOverride } = await prompt([
       {
         name: 'destOverride',

--- a/packages/gasket-cli/test/unit/scaffold/actions/global-prompts.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/global-prompts.test.js
@@ -173,7 +173,7 @@ describe('globalPrompts', () => {
     });
   });
 
-  describe('allowExtantOverwriting', () => {
+  describe.only('allowExtantOverwriting', () => {
     it('does not set confirm if not an extant directory', async () => {
       await allowExtantOverwriting(mockContext, promptStub);
       assume(mockContext).does.not.own('destOverride');
@@ -184,6 +184,15 @@ describe('globalPrompts', () => {
       mockContext.extant = true;
       await allowExtantOverwriting(mockContext, promptStub);
       assume(mockContext).property('destOverride', 'roger roger');
+      assume(promptStub).is.called()
+    });
+
+    it('retains destOverride in context', async () => {
+      mockContext.extant = true;
+      mockContext.destOverride = true;
+      await allowExtantOverwriting(mockContext, promptStub);
+      assume(mockContext).property('destOverride', true);
+      assume(promptStub).is.not.called()
     });
   });
 });

--- a/packages/gasket-cli/test/unit/scaffold/actions/global-prompts.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/global-prompts.test.js
@@ -173,7 +173,7 @@ describe('globalPrompts', () => {
     });
   });
 
-  describe.only('allowExtantOverwriting', () => {
+  describe('allowExtantOverwriting', () => {
     it('does not set confirm if not an extant directory', async () => {
       await allowExtantOverwriting(mockContext, promptStub);
       assume(mockContext).does.not.own('destOverride');
@@ -184,7 +184,7 @@ describe('globalPrompts', () => {
       mockContext.extant = true;
       await allowExtantOverwriting(mockContext, promptStub);
       assume(mockContext).property('destOverride', 'roger roger');
-      assume(promptStub).is.called()
+      assume(promptStub).is.called();
     });
 
     it('retains destOverride in context', async () => {
@@ -192,7 +192,7 @@ describe('globalPrompts', () => {
       mockContext.destOverride = true;
       await allowExtantOverwriting(mockContext, promptStub);
       assume(mockContext).property('destOverride', true);
-      assume(promptStub).is.not.called()
+      assume(promptStub).is.not.called();
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

When setting `--config={ destOverride: true }` with `--no-prompt`, the prompt would be skipped, but override the `destOverride` value on context with undefined. This change first checks if it's on context or not before prompting, in the same manner that we handle other prompt-able context options.

## Changelog

**@gasket/cli**
- Retain destOverride from provided create context

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
- Updated unit tests