### PR TITLE
feat(preload locales): Adds the ability to preload locales.

### DIFF
--- a/packages/gasket-plugin-intl/README.md
+++ b/packages/gasket-plugin-intl/README.md
@@ -60,6 +60,7 @@ required. However, these options exist to customize an app's setup.
   - `excludes` - (string[]) List of modules to ignore
 - `nextRouting` - (boolean) Enable [Next.js Routing] when used with
   [@gasket/plugin-nextjs]. (default: true)
+- `preloadLocales` (boolean) - Preloads the locale files from the manifest file in the middlewareHook.
 
 #### Example config
 
@@ -73,7 +74,8 @@ module.exports = {
     localesMap: {
       'zh-HK': 'zh-TW',
       'zh-SG': 'zh-CN'
-    }
+    },
+    preloadLocales: true
   }
 }
 ```

--- a/packages/gasket-plugin-intl/README.md
+++ b/packages/gasket-plugin-intl/README.md
@@ -60,7 +60,8 @@ required. However, these options exist to customize an app's setup.
   - `excludes` - (string[]) List of modules to ignore
 - `nextRouting` - (boolean) Enable [Next.js Routing] when used with
   [@gasket/plugin-nextjs]. (default: true)
-- `preloadLocales` (boolean) - Preloads the locale files from the manifest file in the middlewareHook.
+- `preloadLocales` (boolean) - Preloads the locale files from the manifest at startup,
+  allowing a faster first response.
 
 #### Example config
 

--- a/packages/gasket-plugin-intl/lib/configure.js
+++ b/packages/gasket-plugin-intl/lib/configure.js
@@ -57,7 +57,8 @@ module.exports = function configureHook(gasket, config) {
     defaultLocale = defaultLanguage || 'en',
     localesMap = languageMap || {},
     localesDir,
-    manifestFilename = 'locales-manifest.json'
+    manifestFilename = 'locales-manifest.json',
+    preloadLocales = false
   } = intlConfig;
 
   const fullLocalesDir = path.join(root, localesDir);
@@ -86,6 +87,7 @@ module.exports = function configureHook(gasket, config) {
    * @property {object} localesMap - Mapping of locales to share files
    * @property {string} localesDir - Path to on-disk directory where locale files exists
    * @property {string} manifestFilename - Name of the manifest file
+   * @property {boolean} preloadLocales - Preloads locale files if set to true
    * @property {object} modules - Enable locale files collation from node modules
    * @property {string} modules.localesDir - Lookup dir for module files
    * @property {string[]} modules.excludes - List of modules to ignore
@@ -100,6 +102,7 @@ module.exports = function configureHook(gasket, config) {
       localesMap,
       localesDir: fullLocalesDir,
       manifestFilename,
+      preloadLocales,
       modules
     }
   };

--- a/packages/gasket-plugin-intl/lib/middleware.js
+++ b/packages/gasket-plugin-intl/lib/middleware.js
@@ -43,7 +43,7 @@ module.exports = function middlewareHook(gasket) {
   const localesParentDir = path.dirname(localesDir);
   const localeUtils = new LocaleUtils({ manifest, basePath });
   if (preloadLocales) {
-    Object.keys(manifest.paths).map((localePath) => require(path.join(localesDir.slice(0, -8), localePath)));
+    Object.keys(manifest.paths).map((localePath) => require(path.join(localesParentDir, localePath)));
   }
 
   return async function intlMiddleware(req, res, next) {

--- a/packages/gasket-plugin-intl/lib/middleware.js
+++ b/packages/gasket-plugin-intl/lib/middleware.js
@@ -29,11 +29,22 @@ function formatLocale(language) {
 }
 
 module.exports = function middlewareHook(gasket) {
-  const { defaultLocale, basePath, localesMap, localesDir, manifestFilename, locales } = getIntlConfig(gasket);
+  const {
+    defaultLocale,
+    basePath,
+    localesMap,
+    localesDir,
+    manifestFilename,
+    locales,
+    preloadLocales
+  } = getIntlConfig(gasket);
 
   const manifest = require(path.join(localesDir, manifestFilename));
   const localesParentDir = path.dirname(localesDir);
   const localeUtils = new LocaleUtils({ manifest, basePath });
+  if (preloadLocales) {
+    Object.keys(manifest.paths).map((localePath) => require(path.join(localesDir.slice(0, -8), localePath)));
+  }
 
   return async function intlMiddleware(req, res, next) {
     let preferredLocale = defaultLocale;

--- a/packages/gasket-plugin-intl/test/configure.test.js
+++ b/packages/gasket-plugin-intl/test/configure.test.js
@@ -49,12 +49,21 @@ describe('configure', function () {
       localesMap: {},
       localesDir: '/path/to/root/public/locales',
       manifestFilename: 'locales-manifest.json',
+      preloadLocales: false,
       modules: false
     });
   });
 
   it('user config overrides defaults', function () {
-    const results = configure(mockGasket, { root, intl: { user: 'stuff', basePath: 'custom', defaultLocale: 'en-US' } });
+    const results = configure(mockGasket, {
+      root,
+      intl: {
+        user: 'stuff',
+        basePath: 'custom',
+        defaultLocale: 'en-US',
+        preloadLocales: true
+      }
+    });
     assume(results.intl).eqls({
       user: 'stuff',
       basePath: 'custom',
@@ -63,6 +72,7 @@ describe('configure', function () {
       localesMap: {},
       localesDir: '/path/to/root/public/locales',
       manifestFilename: 'locales-manifest.json',
+      preloadLocales: true,
       modules: false
     });
   });

--- a/packages/gasket-plugin-intl/test/middleware.test.js
+++ b/packages/gasket-plugin-intl/test/middleware.test.js
@@ -49,6 +49,13 @@ describe('middleware', function () {
       next = sinon.stub();
     });
 
+    it('preloadLocales is true', async function () {
+      mockGasket.config.intl.preloadLocales = true;
+      layer = middlewareHook(mockGasket);
+      await layer(req, res, next);
+      assume(mockGasket.execWaterfall).calledWith('intlLocale', 'fr-FR', { req, res });
+    });
+
     it('executes expected lifecycle', async function () {
       await layer(req, res, next);
       assume(mockGasket.execWaterfall).calledWith('intlLocale', 'fr-FR', { req, res });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
Adds the ability to preload locales (in the middleware lifecycle) by setting `preloadLocales: true` in gasket.config.intl.

In SERP when we switched over to using gasket/plugin-intl , we noticed that the load performance can be improved by preloading the locales.
https://github.com/gdcorp-site/serp-app/blob/main/lifecycles/middleware.js#L8-L11

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
Ability to preload locales in middleware lifecycle.

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

npm linked the package to serp-app and tested.

<img width="1674" alt="image" src="https://user-images.githubusercontent.com/86019758/204567658-46178eca-73f7-40fb-ab6e-134bc01e9107.png">

<img width="1674" alt="image" src="https://user-images.githubusercontent.com/86019758/204567793-04836537-4ce1-4ebd-b9ea-fb2699c9ff63.png">

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/86019758/204567965-06d88a46-97cc-4eef-b578-5300facb269f.png">


<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
