### PR TITLE
Plugin dependencies

### DIFF
--- a/packages/gasket-engine/CHANGELOG.md
+++ b/packages/gasket-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/engine`
 
+- Add missing dependencies property on the `Plugin` type
+
 ### 6.34.4
 
 - Upgrade eslint-plugin-unicorn v43 ([#436])

--- a/packages/gasket-engine/lib/engine.d.ts
+++ b/packages/gasket-engine/lib/engine.d.ts
@@ -31,6 +31,7 @@ declare module '@gasket/engine' {
 
   export type Plugin = {
     name: string;
+    dependencies?: Array<string>;
     hooks: {
       [K in HookId]?: Hook<K>;
     };

--- a/packages/gasket-typescript-tests/test/engine.spec.ts
+++ b/packages/gasket-typescript-tests/test/engine.spec.ts
@@ -1,4 +1,4 @@
-import Gasket, { MaybeAsync } from '@gasket/engine';
+import Gasket, { MaybeAsync, Plugin } from '@gasket/engine';
 
 declare module '@gasket/engine' {
   interface HookExecTypes {
@@ -15,7 +15,7 @@ describe('@gasket/engine', () => {
     );
   });
 
-  it('should', async function () {
+  it('should infer the types of lifecycle parameters', async function () {
     const gasket = new Gasket(
       { root: __dirname, env: 'test' },
       { resolveFrom: __dirname }
@@ -29,5 +29,17 @@ describe('@gasket/engine', () => {
     gasket.execApplySync('example', async function (plugin, handler) {
       handler('a string', 123, true);
     });
+  });
+
+  it('defines the structure of a Gasket plugin', () => {
+    const myPlugin: Plugin = {
+      name: 'my-plugin',
+      dependencies: ['foo', 'bar'],
+      hooks: {
+        example(gasket, a, b, c) {
+          return true;
+        }
+      }
+    };
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Add the `dependencies` property to the `Plugin` type so that plugin authors using TypeScript don't get a type error when populating dependencies.


## Changelog

Added

## Test Plan

Added TypeScript "test" to confirm the `dependencies` array is allowed by the compiler.