### PR TITLE
fix(types): add typings for configurations

### DIFF
--- a/packages/gasket-plugin-metadata/CHANGELOG.md
+++ b/packages/gasket-plugin-metadata/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-metadata`
 
+- Add missing `configurations` property to plugin metadata type
+
 ### 6.35.0
 
 - Fix package object type ([#489])

--- a/packages/gasket-plugin-metadata/lib/index.d.ts
+++ b/packages/gasket-plugin-metadata/lib/index.d.ts
@@ -40,6 +40,9 @@ export interface PluginData extends ModuleData {
   /** App files and directories used by plugin */
   structures?: Array<DetailData>,
 
+  /** Configuration options for gasket.config.js */
+  configurations?: Array<DetailData & { type: 'object' }>
+
   /** Description of lifecycles invoked by plugin */
   lifecycles?: Array<LifecycleData>,
 

--- a/packages/gasket-typescript-tests/test/plugin-metadata.spec.ts
+++ b/packages/gasket-typescript-tests/test/plugin-metadata.spec.ts
@@ -23,8 +23,8 @@ describe('@gasket/plugin-metadata', () => {
     });
   });
 
-  it('adds a manifest property to Gasket', () => {
-    const metadata: SlimGasket = {
+  it('adds a metadata property to Gasket', () => {
+    const gasket1: SlimGasket = {
       metadata: {
         app: {
           name: 'example',
@@ -34,13 +34,26 @@ describe('@gasket/plugin-metadata', () => {
             name: 'example'
           }
         },
-        plugins: [],
+        plugins: [
+          {
+            module: {},
+            name: '@mock/gasket-plugin-x',
+            configurations: [
+              {
+                name: 'configX',
+                description: 'Configures the X plugin',
+                type: 'object',
+                link: 'https://some.docs.url/'
+              }
+            ]
+          }
+        ],
         presets: [],
         modules: []
       }
     };
 
-    const metadata2: SlimGasket = {
+    const gasket2: SlimGasket = {
       metadata: {
         app: {
           name: 'example',


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Add missing `configurations` to plugin metadata type to fix compilation errors in TypeScript.

## Changelog

Added changelog entry to `@gasket/plugin-metadata`.

## Test Plan

Unit tests added.