### PR TITLE
Handle globs using Windows separators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37448,6 +37448,15 @@
         "fast-uri": "^2.0.0"
       }
     },
+    "packages/gasket-plugin-swagger/node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-3.0.1.tgz",
+      "integrity": "sha512-X9BL9/N7827M9UTBVsa5G3xOoD3MQ6EqX+D6EyJyF8LdvWTHQJ//BDN4FAEaGZUA2sL+GEMC6+KNjHESnPwQuw==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stringify": "^4.2.0"
+      }
+    },
     "packages/gasket-plugin-swagger/node_modules/ajv": {
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
@@ -37484,41 +37493,56 @@
         "node": ">= 0.6"
       }
     },
-    "packages/gasket-plugin-swagger/node_modules/fastify": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.12.0.tgz",
-      "integrity": "sha512-Hh2GCsOCqnOuewWSvqXlpq5V/9VA+/JkVoooQWUhrU6gryO9+/UGOoF/dprGcKSDxkM/9TkMXSffYp8eA/YhYQ==",
+    "packages/gasket-plugin-swagger/node_modules/fast-json-stringify": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-4.2.0.tgz",
+      "integrity": "sha512-9RWBl82H7jwnPlkZ/ghi0VD5OFZVdwgwVui0nYzjnXbPQxJ3ES1+SQcWIoeCJOgrY7JkBkY/69UNZSroFPDRdQ==",
       "dev": true,
       "dependencies": {
-        "@fastify/ajv-compiler": "^3.3.1",
+        "ajv": "^8.10.0",
+        "ajv-formats": "^2.1.1",
+        "deepmerge": "^4.2.2",
+        "fast-uri": "^2.0.0",
+        "rfdc": "^1.2.0",
+        "string-similarity": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "packages/gasket-plugin-swagger/node_modules/fastify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.1.0.tgz",
+      "integrity": "sha512-nze95u3wpVIsOXMmSi5kgUaEIZq2HJmerk/+ivFBPtYozAydoDg92BcsxDtO4cb8vW4RBkahx8zL5PgH9YulCw==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/ajv-compiler": "^3.1.0",
         "@fastify/error": "^3.0.0",
-        "@fastify/fast-json-stringify-compiler": "^4.1.0",
+        "@fastify/fast-json-stringify-compiler": "^3.0.1",
         "abstract-logging": "^2.0.1",
-        "avvio": "^8.2.0",
-        "fast-content-type-parse": "^1.0.0",
-        "find-my-way": "^7.3.0",
-        "light-my-request": "^5.6.1",
-        "pino": "^8.5.0",
+        "avvio": "^8.1.3",
+        "find-my-way": "^6.3.0",
+        "light-my-request": "^5.0.0",
+        "pino": "^8.0.0",
         "process-warning": "^2.0.0",
         "proxy-addr": "^2.0.7",
         "rfdc": "^1.3.0",
-        "secure-json-parse": "^2.5.0",
+        "secure-json-parse": "^2.4.0",
         "semver": "^7.3.7",
-        "tiny-lru": "^10.0.0"
+        "tiny-lru": "^8.0.2"
       }
     },
     "packages/gasket-plugin-swagger/node_modules/find-my-way": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.4.0.tgz",
-      "integrity": "sha512-JFT7eURLU5FumlZ3VBGnveId82cZz7UR7OUu+THQJOwdQXxmS/g8v0KLoFhv97HreycOrmAbqjXD/4VG2j0uMQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-6.4.0.tgz",
+      "integrity": "sha512-OAxMF75jKPpy8jUb29WupNfypFAzBuAiPM6xS17twiP07hJb0tKkD6Fy8dy8pN14AD8hMlc0jA6q0d+Dg5reUQ==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
-        "fast-querystring": "^1.0.0",
         "safe-regex2": "^2.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "packages/gasket-plugin-swagger/node_modules/json-schema-traverse": {
@@ -37579,15 +37603,6 @@
       "dev": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0"
-      }
-    },
-    "packages/gasket-plugin-swagger/node_modules/tiny-lru": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-10.0.1.tgz",
-      "integrity": "sha512-Vst+6kEsWvb17Zpz14sRJV/f8bUWKhqm6Dc+v08iShmIJ/WxqWytHzCTd6m88pS33rE2zpX34TRmOpAJPloNCA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "packages/gasket-plugin-webpack": {
@@ -42142,6 +42157,15 @@
             "fast-uri": "^2.0.0"
           }
         },
+        "@fastify/fast-json-stringify-compiler": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-3.0.1.tgz",
+          "integrity": "sha512-X9BL9/N7827M9UTBVsa5G3xOoD3MQ6EqX+D6EyJyF8LdvWTHQJ//BDN4FAEaGZUA2sL+GEMC6+KNjHESnPwQuw==",
+          "dev": true,
+          "requires": {
+            "fast-json-stringify": "^4.2.0"
+          }
+        },
         "ajv": {
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
@@ -42171,36 +42195,48 @@
           "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
           "dev": true
         },
-        "fastify": {
-          "version": "https://registry.npmjs.org/fastify/-/fastify-4.12.0.tgz",
-          "integrity": "sha512-Hh2GCsOCqnOuewWSvqXlpq5V/9VA+/JkVoooQWUhrU6gryO9+/UGOoF/dprGcKSDxkM/9TkMXSffYp8eA/YhYQ==",
+        "fast-json-stringify": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-4.2.0.tgz",
+          "integrity": "sha512-9RWBl82H7jwnPlkZ/ghi0VD5OFZVdwgwVui0nYzjnXbPQxJ3ES1+SQcWIoeCJOgrY7JkBkY/69UNZSroFPDRdQ==",
           "dev": true,
           "requires": {
-            "@fastify/ajv-compiler": "^3.3.1",
+            "ajv": "^8.10.0",
+            "ajv-formats": "^2.1.1",
+            "deepmerge": "^4.2.2",
+            "fast-uri": "^2.0.0",
+            "rfdc": "^1.2.0",
+            "string-similarity": "^4.0.1"
+          }
+        },
+        "fastify": {
+          "version": "https://registry.npmjs.org/fastify/-/fastify-4.1.0.tgz",
+          "integrity": "sha512-nze95u3wpVIsOXMmSi5kgUaEIZq2HJmerk/+ivFBPtYozAydoDg92BcsxDtO4cb8vW4RBkahx8zL5PgH9YulCw==",
+          "dev": true,
+          "requires": {
+            "@fastify/ajv-compiler": "^3.1.0",
             "@fastify/error": "^3.0.0",
-            "@fastify/fast-json-stringify-compiler": "^4.1.0",
+            "@fastify/fast-json-stringify-compiler": "^3.0.1",
             "abstract-logging": "^2.0.1",
-            "avvio": "^8.2.0",
-            "fast-content-type-parse": "^1.0.0",
-            "find-my-way": "^7.3.0",
-            "light-my-request": "^5.6.1",
-            "pino": "^8.5.0",
+            "avvio": "^8.1.3",
+            "find-my-way": "^6.3.0",
+            "light-my-request": "^5.0.0",
+            "pino": "^8.0.0",
             "process-warning": "^2.0.0",
             "proxy-addr": "^2.0.7",
             "rfdc": "^1.3.0",
-            "secure-json-parse": "^2.5.0",
+            "secure-json-parse": "^2.4.0",
             "semver": "^7.3.7",
-            "tiny-lru": "^10.0.0"
+            "tiny-lru": "^8.0.2"
           }
         },
         "find-my-way": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.4.0.tgz",
-          "integrity": "sha512-JFT7eURLU5FumlZ3VBGnveId82cZz7UR7OUu+THQJOwdQXxmS/g8v0KLoFhv97HreycOrmAbqjXD/4VG2j0uMQ==",
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-6.4.0.tgz",
+          "integrity": "sha512-OAxMF75jKPpy8jUb29WupNfypFAzBuAiPM6xS17twiP07hJb0tKkD6Fy8dy8pN14AD8hMlc0jA6q0d+Dg5reUQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-querystring": "^1.0.0",
             "safe-regex2": "^2.0.0"
           }
         },
@@ -42260,12 +42296,6 @@
           "requires": {
             "atomic-sleep": "^1.0.0"
           }
-        },
-        "tiny-lru": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-10.0.1.tgz",
-          "integrity": "sha512-Vst+6kEsWvb17Zpz14sRJV/f8bUWKhqm6Dc+v08iShmIJ/WxqWytHzCTd6m88pS33rE2zpX34TRmOpAJPloNCA==",
-          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -37448,15 +37448,6 @@
         "fast-uri": "^2.0.0"
       }
     },
-    "packages/gasket-plugin-swagger/node_modules/@fastify/fast-json-stringify-compiler": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-3.0.1.tgz",
-      "integrity": "sha512-X9BL9/N7827M9UTBVsa5G3xOoD3MQ6EqX+D6EyJyF8LdvWTHQJ//BDN4FAEaGZUA2sL+GEMC6+KNjHESnPwQuw==",
-      "dev": true,
-      "dependencies": {
-        "fast-json-stringify": "^4.2.0"
-      }
-    },
     "packages/gasket-plugin-swagger/node_modules/ajv": {
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
@@ -37493,56 +37484,41 @@
         "node": ">= 0.6"
       }
     },
-    "packages/gasket-plugin-swagger/node_modules/fast-json-stringify": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-4.2.0.tgz",
-      "integrity": "sha512-9RWBl82H7jwnPlkZ/ghi0VD5OFZVdwgwVui0nYzjnXbPQxJ3ES1+SQcWIoeCJOgrY7JkBkY/69UNZSroFPDRdQ==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^8.10.0",
-        "ajv-formats": "^2.1.1",
-        "deepmerge": "^4.2.2",
-        "fast-uri": "^2.0.0",
-        "rfdc": "^1.2.0",
-        "string-similarity": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "packages/gasket-plugin-swagger/node_modules/fastify": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.1.0.tgz",
-      "integrity": "sha512-nze95u3wpVIsOXMmSi5kgUaEIZq2HJmerk/+ivFBPtYozAydoDg92BcsxDtO4cb8vW4RBkahx8zL5PgH9YulCw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.12.0.tgz",
+      "integrity": "sha512-Hh2GCsOCqnOuewWSvqXlpq5V/9VA+/JkVoooQWUhrU6gryO9+/UGOoF/dprGcKSDxkM/9TkMXSffYp8eA/YhYQ==",
       "dev": true,
       "dependencies": {
-        "@fastify/ajv-compiler": "^3.1.0",
+        "@fastify/ajv-compiler": "^3.3.1",
         "@fastify/error": "^3.0.0",
-        "@fastify/fast-json-stringify-compiler": "^3.0.1",
+        "@fastify/fast-json-stringify-compiler": "^4.1.0",
         "abstract-logging": "^2.0.1",
-        "avvio": "^8.1.3",
-        "find-my-way": "^6.3.0",
-        "light-my-request": "^5.0.0",
-        "pino": "^8.0.0",
+        "avvio": "^8.2.0",
+        "fast-content-type-parse": "^1.0.0",
+        "find-my-way": "^7.3.0",
+        "light-my-request": "^5.6.1",
+        "pino": "^8.5.0",
         "process-warning": "^2.0.0",
         "proxy-addr": "^2.0.7",
         "rfdc": "^1.3.0",
-        "secure-json-parse": "^2.4.0",
+        "secure-json-parse": "^2.5.0",
         "semver": "^7.3.7",
-        "tiny-lru": "^8.0.2"
+        "tiny-lru": "^10.0.0"
       }
     },
     "packages/gasket-plugin-swagger/node_modules/find-my-way": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-6.4.0.tgz",
-      "integrity": "sha512-OAxMF75jKPpy8jUb29WupNfypFAzBuAiPM6xS17twiP07hJb0tKkD6Fy8dy8pN14AD8hMlc0jA6q0d+Dg5reUQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.4.0.tgz",
+      "integrity": "sha512-JFT7eURLU5FumlZ3VBGnveId82cZz7UR7OUu+THQJOwdQXxmS/g8v0KLoFhv97HreycOrmAbqjXD/4VG2j0uMQ==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
         "safe-regex2": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "packages/gasket-plugin-swagger/node_modules/json-schema-traverse": {
@@ -37603,6 +37579,15 @@
       "dev": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0"
+      }
+    },
+    "packages/gasket-plugin-swagger/node_modules/tiny-lru": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-10.0.1.tgz",
+      "integrity": "sha512-Vst+6kEsWvb17Zpz14sRJV/f8bUWKhqm6Dc+v08iShmIJ/WxqWytHzCTd6m88pS33rE2zpX34TRmOpAJPloNCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "packages/gasket-plugin-webpack": {
@@ -42157,15 +42142,6 @@
             "fast-uri": "^2.0.0"
           }
         },
-        "@fastify/fast-json-stringify-compiler": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-3.0.1.tgz",
-          "integrity": "sha512-X9BL9/N7827M9UTBVsa5G3xOoD3MQ6EqX+D6EyJyF8LdvWTHQJ//BDN4FAEaGZUA2sL+GEMC6+KNjHESnPwQuw==",
-          "dev": true,
-          "requires": {
-            "fast-json-stringify": "^4.2.0"
-          }
-        },
         "ajv": {
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
@@ -42195,48 +42171,36 @@
           "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
           "dev": true
         },
-        "fast-json-stringify": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-4.2.0.tgz",
-          "integrity": "sha512-9RWBl82H7jwnPlkZ/ghi0VD5OFZVdwgwVui0nYzjnXbPQxJ3ES1+SQcWIoeCJOgrY7JkBkY/69UNZSroFPDRdQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^8.10.0",
-            "ajv-formats": "^2.1.1",
-            "deepmerge": "^4.2.2",
-            "fast-uri": "^2.0.0",
-            "rfdc": "^1.2.0",
-            "string-similarity": "^4.0.1"
-          }
-        },
         "fastify": {
-          "version": "https://registry.npmjs.org/fastify/-/fastify-4.1.0.tgz",
-          "integrity": "sha512-nze95u3wpVIsOXMmSi5kgUaEIZq2HJmerk/+ivFBPtYozAydoDg92BcsxDtO4cb8vW4RBkahx8zL5PgH9YulCw==",
+          "version": "https://registry.npmjs.org/fastify/-/fastify-4.12.0.tgz",
+          "integrity": "sha512-Hh2GCsOCqnOuewWSvqXlpq5V/9VA+/JkVoooQWUhrU6gryO9+/UGOoF/dprGcKSDxkM/9TkMXSffYp8eA/YhYQ==",
           "dev": true,
           "requires": {
-            "@fastify/ajv-compiler": "^3.1.0",
+            "@fastify/ajv-compiler": "^3.3.1",
             "@fastify/error": "^3.0.0",
-            "@fastify/fast-json-stringify-compiler": "^3.0.1",
+            "@fastify/fast-json-stringify-compiler": "^4.1.0",
             "abstract-logging": "^2.0.1",
-            "avvio": "^8.1.3",
-            "find-my-way": "^6.3.0",
-            "light-my-request": "^5.0.0",
-            "pino": "^8.0.0",
+            "avvio": "^8.2.0",
+            "fast-content-type-parse": "^1.0.0",
+            "find-my-way": "^7.3.0",
+            "light-my-request": "^5.6.1",
+            "pino": "^8.5.0",
             "process-warning": "^2.0.0",
             "proxy-addr": "^2.0.7",
             "rfdc": "^1.3.0",
-            "secure-json-parse": "^2.4.0",
+            "secure-json-parse": "^2.5.0",
             "semver": "^7.3.7",
-            "tiny-lru": "^8.0.2"
+            "tiny-lru": "^10.0.0"
           }
         },
         "find-my-way": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-6.4.0.tgz",
-          "integrity": "sha512-OAxMF75jKPpy8jUb29WupNfypFAzBuAiPM6xS17twiP07hJb0tKkD6Fy8dy8pN14AD8hMlc0jA6q0d+Dg5reUQ==",
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.4.0.tgz",
+          "integrity": "sha512-JFT7eURLU5FumlZ3VBGnveId82cZz7UR7OUu+THQJOwdQXxmS/g8v0KLoFhv97HreycOrmAbqjXD/4VG2j0uMQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
+            "fast-querystring": "^1.0.0",
             "safe-regex2": "^2.0.0"
           }
         },
@@ -42296,6 +42260,12 @@
           "requires": {
             "atomic-sleep": "^1.0.0"
           }
+        },
+        "tiny-lru": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-10.0.1.tgz",
+          "integrity": "sha512-Vst+6kEsWvb17Zpz14sRJV/f8bUWKhqm6Dc+v08iShmIJ/WxqWytHzCTd6m88pS33rE2zpX34TRmOpAJPloNCA==",
+          "dev": true
         }
       }
     },

--- a/packages/gasket-cli/CHANGELOG.md
+++ b/packages/gasket-cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/cli`
 
+- Fix generation of files on Windows during gasket create when plugins use globs containing Windows separators 
+
 ### 6.34.6
 
 - Retain destOverride from provided create context ([#480])

--- a/packages/gasket-cli/package.json
+++ b/packages/gasket-cli/package.json
@@ -28,6 +28,7 @@
     "test:integration:coverage": "nyc --reporter=text --reporter=json-summary --all run-s test:integration",
     "test:mocha": "mocha --require test/setup.js --recursive \"test/**/*.test.js\"",
     "test:unit": "mocha --require test/setup.js --recursive \"test/unit/**/*.test.js\"",
+    "test:unit:watch": "npm run test:unit -- --watch",
     "test:unit:coverage": "nyc --reporter=text --reporter=lcov --all run-s test:unit"
   },
   "repository": {

--- a/packages/gasket-cli/src/scaffold/actions/generate-files.js
+++ b/packages/gasket-cli/src/scaffold/actions/generate-files.js
@@ -79,6 +79,7 @@ async function getDescriptors(context) {
     await Promise.all(files.globSets.map(async set => {
       const { globs, source } = set;
       const matches = await Promise.all(globs.map(async pattern => {
+        pattern = splitSep(pattern).join('/');  // Glob uses / for all OS's
         const srcPaths = await glob(pattern, { nodir: true });
         return assembleDescriptors(dest, source.name, pattern, srcPaths);
       }));

--- a/packages/gasket-cli/test/unit/scaffold/actions/generate-files.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/actions/generate-files.test.js
@@ -276,6 +276,17 @@ describe('generateFiles', () => {
       assume(results).lengthOf(5);
     });
 
+    it('works with Windows path separators', async function () {
+      mockContext.files.globSets = [{
+        globs: [fixtures + '\\generator\\**\\*'],
+        source: {
+          name: '@gasket/plugin-example'
+        }
+      }];
+      const results = await generateFiles._getDescriptors(mockContext);
+      assume(results).lengthOf(5);
+    });
+
     it('reduces duplicates with overrides prop', async function () {
       mockContext.files.globSets = [{
         globs: [fixtures + '/generator/*'],
@@ -333,7 +344,7 @@ describe('generateFiles', () => {
         // mixed slashes for testing
         'C:\\path\\to/my-app',
         from,
-        'C:\\gasket-cli\\test\\fixtures/rel/../generator/*',
+        'C:/gasket-cli/test/fixtures/rel/../generator/*',
         [
           'C:\\gasket-cli\\test\\fixtures\\generator\\file-a.md',
           // glob may return with forward-slash
@@ -341,7 +352,7 @@ describe('generateFiles', () => {
         ]
       );
       assume(results[0]).objectContaining({
-        pattern: 'C:\\gasket-cli\\test\\fixtures/rel/../generator/*',
+        pattern: 'C:/gasket-cli/test/fixtures/rel/../generator/*',
         base: 'C:\\gasket-cli\\test\\fixtures\\generator',
         srcFile: sinon.match('C:\\gasket-cli\\test\\fixtures\\generator\\file-a.md'),
         targetFile: 'C:\\path\\to\\my-app\\file-a.md',


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Glob patterns are being generated with Windows separators when running `gasket create` on Windows which causes `glob` to not find any files. Fix up pattern before passing to `glob`.

[Slack thread](https://godaddy.slack.com/archives/CABCTNQ5P/p1675467873303189) for context.

## Changelog

- Fix generation of files on Windows during gasket create when plugins use globs containing Windows separators 

## Test Plan

I tested the code on my Windows machine, and it fixed the creation of generated files.