### PR TITLE
fix testURL deprecation warning 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4542,15 +4542,15 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.3.1.tgz",
-      "integrity": "sha512-pMmvfOPmoa1c1QpfFW0nXYtNLpofqo4BrCIk6f2kW4JFeNlHV2t3vd+3iDLf31e2ot2Mec0uqZfmI+U0K2CFag==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.2.tgz",
+      "integrity": "sha512-JKs3VUtse0vQfCaFGJRX1bir9yBdtasxziSyu+pIiEllAQOe4oQhdCYIf3+Lx+nGglFktSKToBnRJfD5QKp+NQ==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^29.3.1",
-        "@jest/types": "^29.3.1",
+        "@jest/fake-timers": "^29.4.2",
+        "@jest/types": "^29.4.2",
         "@types/node": "*",
-        "jest-mock": "^29.3.1"
+        "jest-mock": "^29.4.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4591,20 +4591,38 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.3.1.tgz",
-      "integrity": "sha512-iHTL/XpnDlFki9Tq0Q1GGuVeQ8BHZGIYsvCO5eN/O/oJaRzofG9Xndd9HuSDBI/0ZS79pg0iwn07OMTQ7ngF2A==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.2.tgz",
+      "integrity": "sha512-Ny1u0Wg6kCsHFWq7A/rW/tMhIedq2siiyHyLpHCmIhP7WmcAmd2cx95P+0xtTZlj5ZbJxIRQi4OPydZZUoiSQQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.3.1",
-        "@sinonjs/fake-timers": "^9.1.2",
+        "@jest/types": "^29.4.2",
+        "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.3.1",
-        "jest-mock": "^29.3.1",
-        "jest-util": "^29.3.1"
+        "jest-message-util": "^29.4.2",
+        "jest-mock": "^29.4.2",
+        "jest-util": "^29.4.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@jest/fake-timers/node_modules/@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0"
       }
     },
     "node_modules/@jest/globals": {
@@ -4766,12 +4784,12 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-      "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.2.tgz",
+      "integrity": "sha512-ZrGzGfh31NtdVH8tn0mgJw4khQuNHiKqdzJAFbCaERbyCP9tHlxWuL/mnMu8P7e/+k4puWjI1NOzi/sFsjce/g==",
       "dev": true,
       "dependencies": {
-        "@sinclair/typebox": "^0.24.1"
+        "@sinclair/typebox": "^0.25.16"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4937,12 +4955,12 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.3.1.tgz",
-      "integrity": "sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.2.tgz",
+      "integrity": "sha512-CKlngyGP0fwlgC1BRUtPZSiWLBhyS9dKwKmyGxk8Z6M82LBEGB2aLQSg+U1MyLsU+M7UjnlLllBM2BLWKVm/Uw==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.0.0",
+        "@jest/schemas": "^29.4.2",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -9156,9 +9174,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.24.47",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.47.tgz",
-      "integrity": "sha512-J4Xw0xYK4h7eC34MNOPQi6IkNxGRck6n4VJpWDzXIFVTW8I/D43Gf+NfWz/v/7NHlzWOPd3+T4PJ4OqklQ2u7A==",
+      "version": "0.25.21",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
+      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==",
       "dev": true
     },
     "node_modules/@sindresorhus/is": {
@@ -22190,18 +22208,18 @@
       }
     },
     "node_modules/jest-environment-jsdom": {
-      "version": "29.2.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.2.1.tgz",
-      "integrity": "sha512-MipBdmrjgzEdQMkK7b7wBShOfv1VqO6FVwa9S43bZwKYLC4dlWnPiCgNpZX3ypNEpJO8EMpMhg4HrUkWUZXGiw==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.4.2.tgz",
+      "integrity": "sha512-v1sH4Q0JGM+LPEGqHNM+m+uTMf3vpXpKiuDYqWUAh+0c9+nc7scGE+qTR5JuE+OOTDnwfzPgcv9sMq6zWAOaVg==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.2.1",
-        "@jest/fake-timers": "^29.2.1",
-        "@jest/types": "^29.2.1",
+        "@jest/environment": "^29.4.2",
+        "@jest/fake-timers": "^29.4.2",
+        "@jest/types": "^29.4.2",
         "@types/jsdom": "^20.0.0",
         "@types/node": "*",
-        "jest-mock": "^29.2.1",
-        "jest-util": "^29.2.1",
+        "jest-mock": "^29.4.2",
+        "jest-util": "^29.4.2",
         "jsdom": "^20.0.0"
       },
       "engines": {
@@ -22446,18 +22464,18 @@
       }
     },
     "node_modules/jest-message-util": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.3.1.tgz",
-      "integrity": "sha512-lMJTbgNcDm5z+6KDxWtqOFWlGQxD6XaYwBqHR8kmpkP+WWWG90I35kdtQHY67Ay5CSuydkTBbJG+tH9JShFCyA==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.2.tgz",
+      "integrity": "sha512-SElcuN4s6PNKpOEtTInjOAA8QvItu0iugkXqhYyguRvQoXapg5gN+9RQxLAkakChZA7Y26j6yUCsFWN+hlKD6g==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.3.1",
+        "@jest/types": "^29.4.2",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.3.1",
+        "pretty-format": "^29.4.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -22524,12 +22542,12 @@
       }
     },
     "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.3.1.tgz",
-      "integrity": "sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.2.tgz",
+      "integrity": "sha512-qKlHR8yFVCbcEWba0H0TOC8dnLlO4vPlyEjRPw31FZ2Rupy9nLa8ZLbYny8gWEl8CkEhJqAE6IzdNELTBVcBEg==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.0.0",
+        "@jest/schemas": "^29.4.2",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -22568,14 +22586,14 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.3.1.tgz",
-      "integrity": "sha512-H8/qFDtDVMFvFP4X8NuOT3XRDzOUTz+FeACjufHzsOIBAxivLqkB1PoLCaJx9iPPQ8dZThHPp/G3WRWyMgA3JA==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.2.tgz",
+      "integrity": "sha512-x1FSd4Gvx2yIahdaIKoBjwji6XpboDunSJ95RpntGrYulI1ByuYQCKN/P7hvk09JB74IonU3IPLdkutEWYt++g==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.3.1",
+        "@jest/types": "^29.4.2",
         "@types/node": "*",
-        "jest-util": "^29.3.1"
+        "jest-util": "^29.4.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -23156,12 +23174,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.3.1.tgz",
-      "integrity": "sha512-7YOVZaiX7RJLv76ZfHt4nbNEzzTRiMW/IiOG7ZOKmTXmoGBxUDefgMAxQubu6WPVqP5zSzAdZG0FfLcC7HOIFQ==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.2.tgz",
+      "integrity": "sha512-wKnm6XpJgzMUSRFB7YF48CuwdzuDIHenVuoIb1PLuJ6F+uErZsuDkU+EiExkChf6473XcawBrSfDSnXl+/YG4g==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.3.1",
+        "@jest/types": "^29.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -36797,7 +36815,7 @@
         "eslint-plugin-react": "^7.22.0",
         "eslint-plugin-unicorn": "^44.0.0",
         "jest": "^29.3.1",
-        "jest-environment-jsdom": "^29.0.0",
+        "jest-environment-jsdom": "^29.4.2",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
@@ -42976,15 +42994,15 @@
       }
     },
     "@jest/environment": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.3.1.tgz",
-      "integrity": "sha512-pMmvfOPmoa1c1QpfFW0nXYtNLpofqo4BrCIk6f2kW4JFeNlHV2t3vd+3iDLf31e2ot2Mec0uqZfmI+U0K2CFag==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.2.tgz",
+      "integrity": "sha512-JKs3VUtse0vQfCaFGJRX1bir9yBdtasxziSyu+pIiEllAQOe4oQhdCYIf3+Lx+nGglFktSKToBnRJfD5QKp+NQ==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^29.3.1",
-        "@jest/types": "^29.3.1",
+        "@jest/fake-timers": "^29.4.2",
+        "@jest/types": "^29.4.2",
         "@types/node": "*",
-        "jest-mock": "^29.3.1"
+        "jest-mock": "^29.4.2"
       }
     },
     "@jest/expect": {
@@ -43015,17 +43033,37 @@
       }
     },
     "@jest/fake-timers": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.3.1.tgz",
-      "integrity": "sha512-iHTL/XpnDlFki9Tq0Q1GGuVeQ8BHZGIYsvCO5eN/O/oJaRzofG9Xndd9HuSDBI/0ZS79pg0iwn07OMTQ7ngF2A==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.2.tgz",
+      "integrity": "sha512-Ny1u0Wg6kCsHFWq7A/rW/tMhIedq2siiyHyLpHCmIhP7WmcAmd2cx95P+0xtTZlj5ZbJxIRQi4OPydZZUoiSQQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.3.1",
-        "@sinonjs/fake-timers": "^9.1.2",
+        "@jest/types": "^29.4.2",
+        "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.3.1",
-        "jest-mock": "^29.3.1",
-        "jest-util": "^29.3.1"
+        "jest-message-util": "^29.4.2",
+        "jest-mock": "^29.4.2",
+        "jest-util": "^29.4.2"
+      },
+      "dependencies": {
+        "@sinonjs/commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "@sinonjs/fake-timers": {
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+          "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^2.0.0"
+          }
+        }
       }
     },
     "@jest/globals": {
@@ -43147,12 +43185,12 @@
       }
     },
     "@jest/schemas": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-      "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.2.tgz",
+      "integrity": "sha512-ZrGzGfh31NtdVH8tn0mgJw4khQuNHiKqdzJAFbCaERbyCP9tHlxWuL/mnMu8P7e/+k4puWjI1NOzi/sFsjce/g==",
       "dev": true,
       "requires": {
-        "@sinclair/typebox": "^0.24.1"
+        "@sinclair/typebox": "^0.25.16"
       }
     },
     "@jest/source-map": {
@@ -43281,12 +43319,12 @@
       }
     },
     "@jest/types": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.3.1.tgz",
-      "integrity": "sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.2.tgz",
+      "integrity": "sha512-CKlngyGP0fwlgC1BRUtPZSiWLBhyS9dKwKmyGxk8Z6M82LBEGB2aLQSg+U1MyLsU+M7UjnlLllBM2BLWKVm/Uw==",
       "dev": true,
       "requires": {
-        "@jest/schemas": "^29.0.0",
+        "@jest/schemas": "^29.4.2",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -46541,9 +46579,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinclair/typebox": {
-      "version": "0.24.47",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.47.tgz",
-      "integrity": "sha512-J4Xw0xYK4h7eC34MNOPQi6IkNxGRck6n4VJpWDzXIFVTW8I/D43Gf+NfWz/v/7NHlzWOPd3+T4PJ4OqklQ2u7A==",
+      "version": "0.25.21",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
+      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==",
       "dev": true
     },
     "@sindresorhus/is": {
@@ -56458,18 +56496,18 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "29.2.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.2.1.tgz",
-      "integrity": "sha512-MipBdmrjgzEdQMkK7b7wBShOfv1VqO6FVwa9S43bZwKYLC4dlWnPiCgNpZX3ypNEpJO8EMpMhg4HrUkWUZXGiw==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.4.2.tgz",
+      "integrity": "sha512-v1sH4Q0JGM+LPEGqHNM+m+uTMf3vpXpKiuDYqWUAh+0c9+nc7scGE+qTR5JuE+OOTDnwfzPgcv9sMq6zWAOaVg==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.2.1",
-        "@jest/fake-timers": "^29.2.1",
-        "@jest/types": "^29.2.1",
+        "@jest/environment": "^29.4.2",
+        "@jest/fake-timers": "^29.4.2",
+        "@jest/types": "^29.4.2",
         "@types/jsdom": "^20.0.0",
         "@types/node": "*",
-        "jest-mock": "^29.2.1",
-        "jest-util": "^29.2.1",
+        "jest-mock": "^29.4.2",
+        "jest-util": "^29.4.2",
         "jsdom": "^20.0.0"
       }
     },
@@ -56647,18 +56685,18 @@
       }
     },
     "jest-message-util": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.3.1.tgz",
-      "integrity": "sha512-lMJTbgNcDm5z+6KDxWtqOFWlGQxD6XaYwBqHR8kmpkP+WWWG90I35kdtQHY67Ay5CSuydkTBbJG+tH9JShFCyA==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.2.tgz",
+      "integrity": "sha512-SElcuN4s6PNKpOEtTInjOAA8QvItu0iugkXqhYyguRvQoXapg5gN+9RQxLAkakChZA7Y26j6yUCsFWN+hlKD6g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.3.1",
+        "@jest/types": "^29.4.2",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.3.1",
+        "pretty-format": "^29.4.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -56704,12 +56742,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.3.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.3.1.tgz",
-          "integrity": "sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==",
+          "version": "29.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.2.tgz",
+          "integrity": "sha512-qKlHR8yFVCbcEWba0H0TOC8dnLlO4vPlyEjRPw31FZ2Rupy9nLa8ZLbYny8gWEl8CkEhJqAE6IzdNELTBVcBEg==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.0.0",
+            "@jest/schemas": "^29.4.2",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -56740,14 +56778,14 @@
       }
     },
     "jest-mock": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.3.1.tgz",
-      "integrity": "sha512-H8/qFDtDVMFvFP4X8NuOT3XRDzOUTz+FeACjufHzsOIBAxivLqkB1PoLCaJx9iPPQ8dZThHPp/G3WRWyMgA3JA==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.2.tgz",
+      "integrity": "sha512-x1FSd4Gvx2yIahdaIKoBjwji6XpboDunSJ95RpntGrYulI1ByuYQCKN/P7hvk09JB74IonU3IPLdkutEWYt++g==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.3.1",
+        "@jest/types": "^29.4.2",
         "@types/node": "*",
-        "jest-util": "^29.3.1"
+        "jest-util": "^29.4.2"
       }
     },
     "jest-pnp-resolver": {
@@ -57189,12 +57227,12 @@
       }
     },
     "jest-util": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.3.1.tgz",
-      "integrity": "sha512-7YOVZaiX7RJLv76ZfHt4nbNEzzTRiMW/IiOG7ZOKmTXmoGBxUDefgMAxQubu6WPVqP5zSzAdZG0FfLcC7HOIFQ==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.2.tgz",
+      "integrity": "sha512-wKnm6XpJgzMUSRFB7YF48CuwdzuDIHenVuoIb1PLuJ6F+uErZsuDkU+EiExkChf6473XcawBrSfDSnXl+/YG4g==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.3.1",
+        "@jest/types": "^29.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",

--- a/packages/gasket-plugin-jest/generator/jest.config.js
+++ b/packages/gasket-plugin-jest/generator/jest.config.js
@@ -5,7 +5,9 @@ const createJestConfig = nextJest(pathToApp);
 const customJestConfig = {
   testEnvironment: 'jest-environment-jsdom',
   collectCoverageFrom: ['**/*.js'],
-  testURL: 'http://localhost/'
+  testEnvironmentOptions: {
+    url: 'http://localhost/'
+  }
 };
 
 module.exports = createJestConfig(customJestConfig);

--- a/packages/gasket-plugin-jest/jest.config.js
+++ b/packages/gasket-plugin-jest/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   collectCoverageFrom: ['index.js'],
-  testURL: 'http://localhost/',
+  testEnvironmentOptions: {
+    url: 'http://localhost/'
+  },
   testMatch: ['**/test/*.test.js']
 };

--- a/packages/gasket-plugin-jest/lib/index.js
+++ b/packages/gasket-plugin-jest/lib/index.js
@@ -24,7 +24,8 @@ module.exports = {
 
           pkg.add('devDependencies', {
             '@testing-library/react': devDependencies['@testing-library/react'],
-            '@testing-library/jest-dom': devDependencies['@testing-library/jest-dom']
+            '@testing-library/jest-dom': devDependencies['@testing-library/jest-dom'],
+            'jest-environment-jsdom': devDependencies['jest-environment-jsdom']
           });
         }
 

--- a/packages/gasket-plugin-jest/package.json
+++ b/packages/gasket-plugin-jest/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-unicorn": "^44.0.0",
     "jest": "^29.3.1",
-    "jest-environment-jsdom": "^29.0.0",
+    "jest-environment-jsdom": "^29.4.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/gasket-plugin-jest/test/index.test.js
+++ b/packages/gasket-plugin-jest/test/index.test.js
@@ -79,7 +79,7 @@ describe('Plugin', function () {
 
     expect(customJestConfig).toHaveProperty('testEnvironment', 'jest-environment-jsdom');
     expect(customJestConfig).toHaveProperty('collectCoverageFrom', ['**/*.js']);
-    expect(customJestConfig).toHaveProperty('testURL', 'http://localhost/');
+    expect(customJestConfig).toHaveProperty('testEnvironmentOptions', { url: 'http://localhost/' });
   });
 
   describe('react', function () {


### PR DESCRIPTION
## Summary

We reveived a message in #gasket-support reporting an error with the generated jest config file pertaining to the deprecation of `testURL` and missing `jest-environment-jsdom`.  

## Changelog

- replaced `testURL` with `testEnvironmentOptions.url`
- add `jest-environment-jsdom` to devDependencies via create hook


## Test Plan
<img width="599" alt="Screen Shot 2023-02-08 at 10 07 32 AM" src="https://user-images.githubusercontent.com/104379885/217616337-094a3fdc-2b34-45e2-b21d-abc0f43639be.png">
Installed the local `@gasket/plugin-jest` package and no longer see the deprecation warning and errors!
