### PR TITLE
Normalize app plugin names

### DIFF
--- a/packages/gasket-engine/lib/engine.js
+++ b/packages/gasket-engine/lib/engine.js
@@ -37,7 +37,7 @@ class PluginEngine {
       .reduce((acc, pluginInfo) => {
         let keyName;
         if (isModulePath.test(pluginInfo.name)) {
-          keyName = pluginInfo.module.name || pluginInfo.name;
+          keyName = pluginInfo.module.name ? pluginIdentifier(pluginInfo.module.name).longName : pluginInfo.name;
         } else {
           keyName = pluginIdentifier(pluginInfo.name || pluginInfo.module.name).longName;
         }

--- a/packages/gasket-engine/test/constructor.test.js
+++ b/packages/gasket-engine/test/constructor.test.js
@@ -94,18 +94,18 @@ describe('constructor', () => {
       expect(engine._plugins).toHaveProperty('@user/gasket-plugin-one', mockPlugin.module);
     });
 
-    it('plugins loaded from paths use name from module', () => {
+    it('plugins loaded from paths use normalized name from module', () => {
       mockPlugin.name = '/path/to/some-local-plugin';
       mockPlugin.module.name = 'some-local';
       const engine = new PluginEngine(mockConfig);
-      expect(engine._plugins).toHaveProperty('some-local', mockPlugin.module);
+      expect(engine._plugins).toHaveProperty('gasket-plugin-some-local', mockPlugin.module);
     });
 
-    it('plugins loaded from paths use name from module (windows)', () => {
+    it('plugins loaded from paths use normalized name from module (windows)', () => {
       mockPlugin.name = 'C:\\\\path\\to\\some-local-plugin';
       mockPlugin.module.name = 'some-local';
       const engine = new PluginEngine(mockConfig);
-      expect(engine._plugins).toHaveProperty('some-local', mockPlugin.module);
+      expect(engine._plugins).toHaveProperty('gasket-plugin-some-local', mockPlugin.module);
     });
 
     it('plugins loaded from paths fallback to path if name not in module', () => {

--- a/packages/gasket-plugin-command/lib/plugin.d.ts
+++ b/packages/gasket-plugin-command/lib/plugin.d.ts
@@ -20,7 +20,7 @@ declare module '@gasket/engine' {
     id: string;
     description: string;
     flags: {
-      [K in keyof Flags]: flags.Definition<Flags[K]>
+      [K in keyof Flags]: flags.IFlag<Flags[K] | undefined>
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Although an atypical scenario, if a team is prototyping with app-level plugins, and adjusting timings, these were not being ordered correctly. For example, with:

```js
// ./plugins/plugin-a.js
module.exports = {
  name: 'alpha',
  hooks: {
    init(gasket) {
      console.log('INIT A');
    }
  }
};

// ./plugins/plugin-b.js
module.exports = {
  name: 'beta',
  hooks: {
    init: {
      timing: {
        before: ['alpha']
      },
      handler: function (gasket) {
        console.log('INIT B');
      }
    }
  }
};
```

when timings are set up, they are normalized to the [long form naming](https://github.com/godaddy/gasket/blob/main/packages/gasket-resolve/README.md#naming-convention), however the app plugin names themselves were not also being adjusted, so the timings would "miss".

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/engine**
- Fix to use long name for named app plugins

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

Locally tested (using above examples) and updated unit tests.