### PR TITLE
replace lodash.merge with smaller just.extend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37551,7 +37551,7 @@
         "@gasket/fetch": "^6.38.1",
         "@gasket/helper-intl": "^6.38.1",
         "hoist-non-react-statics": "^3.0.0",
-        "lodash.merge": "^4.6.0",
+        "just-extend": "^6.2.0",
         "prop-types": "^15.7.2"
       },
       "devDependencies": {
@@ -37618,6 +37618,11 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "packages/gasket-react-intl/node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw=="
     },
     "packages/gasket-react-intl/node_modules/react": {
       "version": "18.2.0",
@@ -42082,7 +42087,7 @@
         "hoist-non-react-statics": "^3.0.0",
         "intl": "^1.2.5",
         "jsdom": "^20.0.0",
-        "lodash.merge": "^4.6.0",
+        "just-extend": "^6.2.0",
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",
         "prop-types": "^15.7.2",
@@ -42114,6 +42119,11 @@
           "requires": {
             "@types/react": "*"
           }
+        },
+        "just-extend": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+          "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw=="
         },
         "react": {
           "version": "18.2.0",

--- a/packages/gasket-react-intl/package.json
+++ b/packages/gasket-react-intl/package.json
@@ -49,7 +49,7 @@
     "@gasket/fetch": "^6.38.1",
     "@gasket/helper-intl": "^6.38.1",
     "hoist-non-react-statics": "^3.0.0",
-    "lodash.merge": "^4.6.0",
+    "just-extend": "^6.2.0",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/packages/gasket-react-intl/src/with-intl-provider.js
+++ b/packages/gasket-react-intl/src/with-intl-provider.js
@@ -89,7 +89,7 @@ export default function withIntlProvider() {
       // If we have incoming pageProps, we need to update state but have to by
       // mutation rather than issuing a dispatch to avoid re-renders and timing issues
       if (localesProps) {
-        merge(state, localesProps);
+        extend(true, state, localesProps);
       }
 
       const locale = localesProps?.locale ||

--- a/packages/gasket-react-intl/src/with-intl-provider.js
+++ b/packages/gasket-react-intl/src/with-intl-provider.js
@@ -1,6 +1,6 @@
 import React, { useReducer } from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import merge from 'lodash.merge';
+import extend from 'just-extend';
 import { IntlProvider } from 'react-intl';
 import { GasketIntlContext } from './context';
 import { clientData, isBrowser } from './config';
@@ -17,7 +17,7 @@ export function init(localesProps) {
   if (isBrowser) {
     // merge any data set on window with what comes from SSR or static page props
     const { messages: dataMessages = {}, status: dataStatus = {} } = clientData;
-    return merge({}, { messages: dataMessages, status: dataStatus }, { messages, status });
+    return extend(true, {}, { messages: dataMessages, status: dataStatus }, { messages, status });
   }
 
   return { messages, status };


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Use [`just-extend`](https://github.com/angus-c/just/tree/master/packages/object-extend) with a deep clone option.  Library has been maintained for a long time and has wide ~220k usage.  Other benefits include readable source code.  considred [`just-merge`](https://github.com/angus-c/just/tree/master/packages/object-merge#just-merge) but it doesn't have the deep option

## Changelog

Replace lodash.merge with smaller library to reduce bundle size.  Should reduce `@gasket/react-intl` bundle size by 1/3rd.

## Test Plan

- existing test had a deep merge test, test fails if `extend(false,...` is used

