### PR TITLE
Fail bad requires in gasket.config

### DIFF
--- a/packages/gasket-resolve/lib/config.js
+++ b/packages/gasket-resolve/lib/config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { readdir } = require('fs').promises;
 const defaultsDeep = require('lodash.defaultsdeep');
-const { applyConfigOverrides, tryRequire } = require('@gasket/utils');
+const { applyConfigOverrides, tryResolve } = require('@gasket/utils');
 const { flattenPresets } = require('./preset-utils');
 const jsExtension = /\.(js|cjs)$/i;
 
@@ -18,7 +18,10 @@ async function loadGasketConfigFile(root, env, commandId, configFile = 'gasket.c
 
 function loadConfigFile(root, configFile) {
   const absolutePath = !path.isAbsolute(configFile) ? path.join(root, configFile) : configFile;
-  return tryRequire(absolutePath);
+  const resolvedPath = tryResolve(absolutePath);
+  if (resolvedPath) {
+    return require(resolvedPath);
+  }
 }
 
 async function addUserPlugins(gasketConfig) {

--- a/packages/gasket-resolve/package.json
+++ b/packages/gasket-resolve/package.json
@@ -70,6 +70,9 @@
       "unicorn/filename-case": "error"
     }
   },
+  "eslintIgnore": [
+    "test/fixtures"
+  ],
   "jest": {
     "testEnvironment": "node"
   }

--- a/packages/gasket-resolve/test/config.test.js
+++ b/packages/gasket-resolve/test/config.test.js
@@ -69,7 +69,7 @@ describe('config', () => {
     });
 
     it('supports custom config absolute path', async () => {
-      const configFile = path.join(root, 'custom', 'gasket.config.js')
+      const configFile = path.join(root, 'custom', 'gasket.config.js');
       const results = await utils.loadGasketConfigFile('/somewhere', env, commandId, configFile);
       expect(results).toHaveProperty('root', '/somewhere');
       expect(results).toEqual(expect.objectContaining({ custom: true }));

--- a/packages/gasket-resolve/test/fixtures/bad.gasket.config.js
+++ b/packages/gasket-resolve/test/fixtures/bad.gasket.config.js
@@ -1,0 +1,5 @@
+require('some-fake-lib');
+
+module.exports = {
+  mockConfig: true
+}

--- a/packages/gasket-resolve/test/fixtures/custom.gasket.config.js
+++ b/packages/gasket-resolve/test/fixtures/custom.gasket.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  mockConfig: true,
+  custom: true
+}

--- a/packages/gasket-resolve/test/fixtures/custom/gasket.config.js
+++ b/packages/gasket-resolve/test/fixtures/custom/gasket.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  mockConfig: true,
+  custom: true
+}

--- a/packages/gasket-resolve/test/fixtures/gasket.config.js
+++ b/packages/gasket-resolve/test/fixtures/gasket.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  mockConfig: true,
+
+  example: 'base',
+  environments: {
+    'other-env': {
+      example: 'overridden from env'
+    }
+  },
+  commands: {
+    'other-cmd': {
+      example: 'overridden from cmd'
+    }
+  }
+};

--- a/packages/gasket-resolve/test/fixtures/malformed.gasket.config.js
+++ b/packages/gasket-resolve/test/fixtures/malformed.gasket.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  malformed
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Current behavior uses tryRequire which makes it difficult to debug if the gasket.config is actually missing, or if it was a bad require in the gasket.config itself.

When a missing module is required in the gasket.config, we should hard fail the app.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/resolve**
- Hard fail bad requires in gasket.config while preserving missing gasket.config behavior

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- Tested in local app
- Updated unit tests
