### PR TITLE
(fix) types for hook method

### DIFF
--- a/packages/gasket-engine/CHANGELOG.md
+++ b/packages/gasket-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/engine`
 
+- Add missing gasket engine `hook` method to types
+
 ### 6.38.5
 
 - Fix to use long name for named app plugins ([#560])

--- a/packages/gasket-engine/lib/engine.d.ts
+++ b/packages/gasket-engine/lib/engine.d.ts
@@ -8,6 +8,13 @@ declare module '@gasket/engine' {
 
   export type HookId = keyof HookExecTypes
 
+  export type HookTimings = {
+    before?: Array<string>;
+    after?: Array<string>;
+    first?: boolean;
+    last?: boolean;
+  };
+
   export type HookHandler<Id extends HookId> = (
     gasket: Gasket,
     ...args: Parameters<HookExecTypes[Id]>
@@ -18,12 +25,7 @@ declare module '@gasket/engine' {
   ) => ReturnType<HookExecTypes[Id]>;
 
   type HookWithTimings<Id extends HookId> = {
-    timing: {
-      before?: Array<string>;
-      after?: Array<string>;
-      first?: boolean;
-      last?: boolean;
-    };
+    timing: HookWithTimings;
     handler: HookHandler<Id>;
   };
 
@@ -49,6 +51,7 @@ declare module '@gasket/engine' {
   export default class GasketEngine {
     constructor(config: GasketConfigFile, context?: { resolveFrom?: string });
     config: GasketConfig;
+  
     exec<Id extends HookId>(
       hook: Id,
       ...args: Parameters<HookExecTypes[Id]>
@@ -73,6 +76,13 @@ declare module '@gasket/engine' {
       hook: Id,
       callback: (plugin: Plugin, handler: ApplyHookHandler<Id>) => Return
     ): Return[];
+
+    hook<Id extends HookId>(opts: {
+      event: Id,
+      pluginName?: string,
+      timing?: HookTimings,
+      handler: HookHandler<Id>
+    }): void;
   }
 
   export interface Gasket extends GasketEngine {}

--- a/packages/gasket-typescript-tests/test/engine.spec.ts
+++ b/packages/gasket-typescript-tests/test/engine.spec.ts
@@ -42,4 +42,36 @@ describe('@gasket/engine', () => {
       }
     };
   });
+
+  it('type checks the hook method', () => {
+    const engine = new Gasket(
+      { root: __dirname, env: 'test' },
+      { resolveFrom: __dirname }
+    );
+
+    // Valid
+    engine.hook({
+      event: 'example',
+      handler(gasket, str, num, bool) {
+        return true;
+      }
+    });
+
+    // Unknown event type
+    engine.hook({
+      // @ts-expect-error
+      event: 'unknown',
+      // @ts-expect-error
+      handler: (gasket) => {}
+    });
+
+    // Invalid return type
+    engine.hook({
+      event: 'example',
+      // @ts-expect-error
+      handler(gasket, str, num, bool) {
+        return 'invalid';
+      }
+    });
+  });
 });

--- a/packages/gasket-typescript-tests/test/plugin-metadata.spec.ts
+++ b/packages/gasket-typescript-tests/test/plugin-metadata.spec.ts
@@ -3,8 +3,11 @@ import type { PluginData } from '@gasket/plugin-metadata';
 import '@gasket/plugin-metadata';
 
 describe('@gasket/plugin-metadata', () => {
-  type SlimGasket = Omit<Gasket, 'config'|'logger'|
-    'exec'|'execSync'|'execWaterfall'|'execWaterfallSync'|'execApply'|'execApplySync'>
+  type SlimGasket = Omit<Gasket,
+    |'config'|'logger'
+    |'exec'|'execSync'|'execWaterfall'|'execWaterfallSync'|'execApply'|'execApplySync'
+    |'hook'
+  >
 
   it('defines a metadata lifecycle', () => {
     const hook: Hook<'metadata'> = (gasket: Gasket, origData: PluginData) => ({


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Add missing types for the `hook` method so that TypeScript code that is using it will compile.

## Changelog

- (fix) document the gasket engine `hook` method

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

Added unit test for type validation