### PR TITLE
Tracing bug with nullish values

### DIFF
--- a/packages/gasket-engine/CHANGELOG.md
+++ b/packages/gasket-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/engine`
 
+- Fix bug with `execWaterfallSync` not supporting nullish return values
+
 ### 6.38.5
 
 - Fix to use long name for named app plugins ([#560])

--- a/packages/gasket-engine/lib/engine.js
+++ b/packages/gasket-engine/lib/engine.js
@@ -425,7 +425,7 @@ class PluginEngine {
       plansByType[type] = prepare(hookConfig, trace)
     );
     const result = exec(plan);
-    if (result.finally) {
+    if (typeof result?.finally === 'function') {
       return result.finally(() => this._traceDepth--);
     }
 

--- a/packages/gasket-engine/test/exec-waterfall-sync.test.js
+++ b/packages/gasket-engine/test/exec-waterfall-sync.test.js
@@ -11,7 +11,8 @@ describe('The execWaterfallSync method', () => {
       hooks: {
         eventA: jest.fn((gasket, value) => {
           return value * 7;
-        })
+        }),
+        eventB: () => null
       }
     };
 
@@ -20,7 +21,8 @@ describe('The execWaterfallSync method', () => {
       hooks: {
         eventA: jest.fn((gasket, value) => {
           return value + 4;
-        })
+        }),
+        eventB: () => null
       }
     };
 
@@ -64,5 +66,13 @@ describe('The execWaterfallSync method', () => {
     const result = execWaterfallSync('eventA', 5);
 
     expect(result).toEqual(39);
+  });
+
+  it('handles the return of nullish values', () => {
+    const { execWaterfallSync } = engine;
+
+    const result = execWaterfallSync('eventB', null);
+
+    expect(result).toEqual(null);
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

I encountered an error with an `execSyncWaterfall` hook when the returned value was `undefined` because the tracing output logic's check for a `Promise` causes a `TypeError`.

## Changelog

- Fix bug that occurs if execWaterfallSync returns nullish values

## Test Plan

Unit test