### PR TITLE
Fix docs for environment variable

### DIFF
--- a/packages/gasket-cli/docs/configuration.md
+++ b/packages/gasket-cli/docs/configuration.md
@@ -102,7 +102,7 @@ configuration is augmented with the `prod` environment settings, then the
 
 The last step is making sure that Gasket is told which environment it is running
 in when starting up. There are three ways of doing this. The first would be to
-set the `NODE_ENV` environment variable. The second would be to pass an `--env`
+set the `GASKET_ENV` environment variable. The second would be to pass an `--env`
 command line argument when running any `gasket` command. The third is to
 programmatically set an `env` property at the top level of your configuration,
 which would enable you to use any arbitrary environment derivation logic.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Document that `GASKET_ENV` is the preferred way to set the environment. Currently the docs say `NODE_ENV` which works (kind of) but is not preferred.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->