### PR TITLE
Tweak README for gasket data

### DIFF
--- a/packages/gasket-data/README.md
+++ b/packages/gasket-data/README.md
@@ -27,17 +27,14 @@ import gasketData from '@gasket/data';
 console.log(gasketData.something); // interesting
 ```
 
-### Adding SSR Data
+### Adding Data
 
-To make data available for server-side rendering options, plugins should add to
-the `res.locals.gasketData` object.
-
-For example when using the [middleware lifecycle] in a plugin:
+To add to the data exposed in `@gasket/data`, you can write to the HTTP response object's `locals.gasketData` property. For example when using the [middleware lifecycle] in a plugin:
 
 ```js
 module.exports = {
   hooks: {
-    middleware() {
+    middleware(gasket) {
       return (req, res, next) => {
         res.locals.gasketData = res.locals.gasketData || {};
         res.locals.gasketData.example = { fake: 'data' }; 
@@ -48,8 +45,18 @@ module.exports = {
 };
 ```
 
-The results of `res.locals.gasketData` should then be rendering in a script as
-described above.
+The results of `res.locals.gasketData` should then be rendering in a script as described above. Similarly, this can be done in an application lifecycle script:
+
+```js
+// /lifecycles/middleware.js
+
+module.exports = gasket => [
+  (req, res, next) => {
+    res.locals.gasketData ??= {};
+    res.locals.gasketData.example = gasket.config.somethingWeWantToExpose;
+  }
+];
+```
 
 ## License
 


### PR DESCRIPTION


<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

The section header for `@gasket/data` isn't super clear; the primary purpose of writing to `res.locals.gasketData` is to expose data in the client, not on the server.

## Changelog

N/A

## Test Plan

N/A
