### PR TITLE
Fix error middleware ordering

### DIFF
--- a/packages/gasket-plugin-express/CHANGELOG.md
+++ b/packages/gasket-plugin-express/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `@gasket/plugin-express`
 
+- Fix ordering of error middlewares so they come after API routes
 - Docs on configuring middleware paths ([#613])
 
 ### 6.34.4

--- a/packages/gasket-plugin-express/test/fixtures/mock-api-route.js
+++ b/packages/gasket-plugin-express/test/fixtures/mock-api-route.js
@@ -1,0 +1,5 @@
+module.exports = app => {
+  app.use('/some/route', (req, res, next) => {
+    next(new Error('Not implemented'));
+  });
+};


### PR DESCRIPTION
- Await setup of API routes
- Place error middleware after API routes

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Error middlewares are not currently being injected after API routes. [Support thread for context](https://godaddy.slack.com/archives/CABCTNQ5P/p1695847406758869).

## Changelog

- Fix ordering of error middlewares so they come after API routes

## Test Plan

Added unit test