### PR TITLE
windows support

### DIFF
--- a/packages/gasket-resolve/lib/resolver.js
+++ b/packages/gasket-resolve/lib/resolver.js
@@ -57,7 +57,7 @@ class Resolver {
       return this.resolve(moduleName);
     } catch (err) {
       debug('try-resolve error', err.message);
-      if (err.code === 'MODULE_NOT_FOUND' && err.message.includes(moduleName) ||
+      if (err.code === 'MODULE_NOT_FOUND' && err.message.replace(/\\/g, '/').includes(moduleName) ||
         err.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED'
       ) return null;
 


### PR DESCRIPTION
This allows errors on windows like `Cannot find module 'C:\github\caas-api\node_modules\openai\package.json.js'` to be properly caught by this logic, since it's looking for `openai/package.json`