### PR TITLE
Docsify bug workaround

### DIFF
--- a/packages/gasket-plugin-docsify/CHANGELOG.md
+++ b/packages/gasket-plugin-docsify/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-docsify`
 
+- Workaround to fix `gasket docs` command caused by a [docsify bug](https://github.com/docsifyjs/docsify/issues/2345)
+
 ### 6.34.4
 
 - Upgrade eslint-plugin-unicorn v43 ([#436])

--- a/packages/gasket-plugin-docsify/lib/create.js
+++ b/packages/gasket-plugin-docsify/lib/create.js
@@ -1,0 +1,6 @@
+module.exports = function create(_gasket, { pkg }) {
+  // Workaround for https://github.com/docsifyjs/docsify/issues/2345
+  pkg.add('dependencies', {
+    'strip-indent': require('docsify/package.json').dependencies['strip-indent']
+  });
+};

--- a/packages/gasket-plugin-docsify/lib/index.js
+++ b/packages/gasket-plugin-docsify/lib/index.js
@@ -1,8 +1,10 @@
+const create = require('./create');
 const docsView = require('./docs-view');
 
 module.exports = {
   name: require('../package').name,
   hooks: {
+    create,
     docsView,
     metadata(gasket, meta) {
       return {

--- a/packages/gasket-plugin-docsify/test/create.test.js
+++ b/packages/gasket-plugin-docsify/test/create.test.js
@@ -1,0 +1,15 @@
+const { hooks: { create } } = require('../lib');
+const docsifyPackage = require('docsify/package.json');
+
+describe('The create hook', () => {
+  it('adds a strip-indent dependency to work around a docsify bug', function () {
+    const context = { pkg: { add: jest.fn() } };
+
+    create({}, context);
+
+    expect(context.pkg.add).toHaveBeenCalledWith(
+      'dependencies',
+      { 'strip-indent': docsifyPackage.dependencies['strip-indent'] }
+    );
+  });
+});

--- a/packages/gasket-plugin-docsify/test/index.test.js
+++ b/packages/gasket-plugin-docsify/test/index.test.js
@@ -12,6 +12,7 @@ describe('Plugin', function () {
 
   it('has expected hooks', () => {
     const expected = [
+      'create',
       'docsView',
       'metadata'
     ];


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Ensure that `strip-indent@3` is floated to the top of `node_modules` to fix a [bug](https://github.com/docsifyjs/docsify/issues/2345) where `docsify-server-renderer` can require that package (which it doesn't have as a declared dependency) and receive version 4 instead, which is an ESM module.

## Changelog

Included in PR

## Test Plan

In a project where this bug was occuring, I was able to fix the issue by manually installing `strip-indent@3.0.0` as a dependency so that `strip-indent@4` was no-longer the module that was found by `docsify-server-renderer`.