### PR TITLE
Fix docsify plugin create

### DIFF
--- a/packages/gasket-plugin-docsify/CHANGELOG.md
+++ b/packages/gasket-plugin-docsify/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-docsify`
 
+- Fix create command failing to find docsify ([#663])
+
 ### 6.44.2
 
 - Deprecate Docsify ([#648])
@@ -61,5 +63,6 @@
 [#460]: https://github.com/godaddy/gasket/pull/460
 [#643]: https://github.com/godaddy/gasket/pull/643
 [#648]: https://github.com/godaddy/gasket/pull/648
+[#663]: https://github.com/godaddy/gasket/pull/663
 
 [mermaid]:https://mermaid-js.github.io/

--- a/packages/gasket-plugin-docsify/lib/create.js
+++ b/packages/gasket-plugin-docsify/lib/create.js
@@ -1,6 +1,6 @@
 module.exports = function create(_gasket, { pkg }) {
   // Workaround for https://github.com/docsifyjs/docsify/issues/2345
-  pkg.add('dependencies', {
-    'strip-indent': require('docsify/package.json').dependencies['strip-indent']
+  pkg.add('devDependencies', {
+    'strip-indent': '^3.0.0'
   });
 };

--- a/packages/gasket-plugin-docsify/test/create.test.js
+++ b/packages/gasket-plugin-docsify/test/create.test.js
@@ -8,7 +8,8 @@ describe('The create hook', () => {
     create({}, context);
 
     expect(context.pkg.add).toHaveBeenCalledWith(
-      'dependencies',
+      'devDependencies',
+      // expect the hard-coded version to match the dep
       { 'strip-indent': docsifyPackage.dependencies['strip-indent'] }
     );
   });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

The `docsify` package has not been installed to lookup the dep version in its package.json during the `create` lifecycle.

```
    Error: Cannot find module 'docsify/package.json'
    Require stack:
    - /path/to/new-app/node_modules/@gasket/plugin-docsify/lib/create.js
```

As such, we need to hard code the `strip-indent` version to address the workaround.

We will still continue to lazy install `docsify-cli` per https://github.com/godaddy/gasket/pull/495, which avoids package lock scan vulnerability alerts and is only needed during development when running the `gasket docs` command.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog



<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
