### PR TITLE
fix: adjust path on tryRequire to handle dep check

### DIFF
--- a/packages/gasket-plugin-docusaurus/lib/docs-view.js
+++ b/packages/gasket-plugin-docusaurus/lib/docs-view.js
@@ -12,7 +12,7 @@ const defaultConfig = {
 
 function checkDevDependencies() {
   const preset = tryRequire('@docusaurus/preset-classic');
-  const core = tryRequire('@docusaurus/core');
+  const core = tryRequire('@docusaurus/core/lib');
   if (!preset || !core) {
     throw new Error('Missing devDependencies. Please run `npm i -D @docusaurus/core @docusaurus/preset-classic`');
   }

--- a/packages/gasket-plugin-docusaurus/lib/docs-view.js
+++ b/packages/gasket-plugin-docusaurus/lib/docs-view.js
@@ -12,7 +12,7 @@ const defaultConfig = {
 
 function checkDevDependencies() {
   const preset = tryRequire('@docusaurus/preset-classic');
-  const core = tryRequire('@docusaurus/core/lib');
+  const core = tryRequire('@docusaurus/core/package.json');
   if (!preset || !core) {
     throw new Error('Missing devDependencies. Please run `npm i -D @docusaurus/core @docusaurus/preset-classic`');
   }

--- a/packages/gasket-plugin-docusaurus/test/docs-view.test.js
+++ b/packages/gasket-plugin-docusaurus/test/docs-view.test.js
@@ -83,7 +83,7 @@ describe('docsView', () => {
   it('throw on missing devDependencies', async function () {
     mockTryRequireStub.mockReturnValue(false);
     expect(mockTryRequireStub).toHaveBeenCalledWith('@docusaurus/preset-classic');
-    expect(mockTryRequireStub).toHaveBeenCalledWith('@docusaurus/core');
+    expect(mockTryRequireStub).toHaveBeenCalledWith('@docusaurus/core/lib');
     await expect(async () => await docsView(mockGasket)).rejects.toThrow();
   });
 });

--- a/packages/gasket-plugin-docusaurus/test/docs-view.test.js
+++ b/packages/gasket-plugin-docusaurus/test/docs-view.test.js
@@ -83,7 +83,7 @@ describe('docsView', () => {
   it('throw on missing devDependencies', async function () {
     mockTryRequireStub.mockReturnValue(false);
     expect(mockTryRequireStub).toHaveBeenCalledWith('@docusaurus/preset-classic');
-    expect(mockTryRequireStub).toHaveBeenCalledWith('@docusaurus/core/lib');
+    expect(mockTryRequireStub).toHaveBeenCalledWith('@docusaurus/core/package.json');
     await expect(async () => await docsView(mockGasket)).rejects.toThrow();
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
- **Why**: The `checkDevDependencies` function wasn't behaving properly due to the path used in the `tryRequire`. A require on `@docusaurus/core` will always return `null`. Opt for a `tryRequire` on the `package.json` of that file.
- **What**: Adjust path on the `tryRequire`
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
- adjust path on tryRequire to handle dep check
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
- Update test case with the new path
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
