### PR TITLE
Add native Gasket trust proxy support to Express & Fastify

### DIFF
--- a/packages/gasket-plugin-express/README.md
+++ b/packages/gasket-plugin-express/README.md
@@ -42,6 +42,7 @@ All the configurations for the plugin are added under `express` in the config:
 - `excludedRoutesRegex`: (deprecated) renamed to more correct `middlewareInclusionRegex`.
 - `middlewareInclusionRegex`: RegExp filter to apply toward request URLs to determine when Gasket middleware will run. You can use negative lookahead patterns to exclude routes like static resource paths.
 - `routes`: [Glob pattern](https://github.com/isaacs/node-glob#glob-primer) for source files exporting route-defining functions. These functions will be passed the express `app` object, and therein they can attach handlers and middleware.
+- 'trustProxy': Enable trust proxy option, [see Express documentation on Express behind proxies](https://expressjs.com/en/guide/behind-proxies.html)
 
 #### Example configuration
 
@@ -54,6 +55,7 @@ module.exports = {
     compression: false,
     routes: 'api/*.js',
     middlewareInclusionRegex: /^(?!\/_next\/)/,
+    trustProxy: true
   }
 }
 ```

--- a/packages/gasket-plugin-express/lib/index.js
+++ b/packages/gasket-plugin-express/lib/index.js
@@ -98,12 +98,7 @@ module.exports = {
         app.use(compression());
       }
 
-      const middlewares = [
-        (req, res, next) => {
-          req.trustProxy = app.get('trust proxy');
-          next();
-        }
-      ];
+      const middlewares = [];
       await gasket.execApply('middleware', async (plugin, handler) => {
         const middleware = await handler(app);
 

--- a/packages/gasket-plugin-express/lib/index.js
+++ b/packages/gasket-plugin-express/lib/index.js
@@ -99,11 +99,9 @@ module.exports = {
       }
 
       const middlewares = [
-        () => {
-          return (req, res, next) => {
-            req.trustProxy = app.get('trust proxy');
-            next();
-          };
+        (req, res, next) => {
+          req.trustProxy = app.get('trust proxy');
+          next();
         }
       ];
       await gasket.execApply('middleware', async (plugin, handler) => {

--- a/packages/gasket-plugin-express/lib/index.js
+++ b/packages/gasket-plugin-express/lib/index.js
@@ -51,7 +51,8 @@ module.exports = {
           routes,
           excludedRoutesRegex,
           middlewareInclusionRegex,
-          compression: compressionConfig = true
+          compression: compressionConfig = true,
+          trustProxy = false
         } = {},
         http2,
         middleware: middlewareConfig
@@ -64,6 +65,10 @@ module.exports = {
       }
 
       const app = http2 ? require('http2-express-bridge')(express) : express();
+
+      if (trustProxy) {
+        app.set('trust proxy', trustProxy);
+      }
 
       if (http2) {
         app.use(
@@ -93,7 +98,14 @@ module.exports = {
         app.use(compression());
       }
 
-      const middlewares = [];
+      const middlewares = [
+        () => {
+          return (req, res, next) => {
+            req.trustProxy = app.get('trust proxy');
+            next();
+          };
+        }
+      ];
       await gasket.execApply('middleware', async (plugin, handler) => {
         const middleware = await handler(app);
 

--- a/packages/gasket-plugin-express/test/plugin.test.js
+++ b/packages/gasket-plugin-express/test/plugin.test.js
@@ -237,13 +237,13 @@ describe('createServers', () => {
 
   it('adds middleware from lifecycle (ignores falsy)', async () => {
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(3);
+    expect(app.use).toHaveBeenCalledTimes(2);
 
     app.use.mockClear();
     mockMwPlugins = [{ name: 'middlware-1' }, null];
 
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(4);
+    expect(app.use).toHaveBeenCalledTimes(3);
   });
 
   it('supports async middleware hooks', async () => {
@@ -279,16 +279,16 @@ describe('createServers', () => {
     mockMwPlugins = [{ name: 'middlware-1' }];
     await plugin.hooks.createServers(gasket, {});
 
-    expect(app.use.mock.calls[3]).toContain(paths);
+    expect(app.use.mock.calls[2]).toContain(paths);
   });
 
   it('adds errorMiddleware from lifecycle (ignores falsy)', async () => {
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(3);
+    expect(app.use).toHaveBeenCalledTimes(2);
     lifecycles.errorMiddleware.mockResolvedValue([() => {}, null]);
     app.use.mockClear();
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(4);
+    expect(app.use).toHaveBeenCalledTimes(3);
   });
 
   it('does not enable trust proxy by default', async () => {

--- a/packages/gasket-plugin-express/test/plugin.test.js
+++ b/packages/gasket-plugin-express/test/plugin.test.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { setTimeout } = require('timers/promises');
 const GasketEngine = require('@gasket/engine');
-const app = { use: jest.fn(), post: jest.fn() };
+const app = { use: jest.fn(), post: jest.fn(), set: jest.fn() };
 const mockExpress = jest.fn().mockReturnValue(app);
 const bridgedApp = { use: jest.fn() };
 const mockExpressBridge = jest.fn().mockReturnValue(bridgedApp);
@@ -237,13 +237,13 @@ describe('createServers', () => {
 
   it('adds middleware from lifecycle (ignores falsy)', async () => {
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(2);
+    expect(app.use).toHaveBeenCalledTimes(3);
 
     app.use.mockClear();
     mockMwPlugins = [{ name: 'middlware-1' }, null];
 
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(3);
+    expect(app.use).toHaveBeenCalledTimes(4);
   });
 
   it('supports async middleware hooks', async () => {
@@ -279,16 +279,36 @@ describe('createServers', () => {
     mockMwPlugins = [{ name: 'middlware-1' }];
     await plugin.hooks.createServers(gasket, {});
 
-    expect(app.use.mock.calls[2]).toContain(paths);
+    expect(app.use.mock.calls[3]).toContain(paths);
   });
 
   it('adds errorMiddleware from lifecycle (ignores falsy)', async () => {
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(2);
+    expect(app.use).toHaveBeenCalledTimes(3);
     lifecycles.errorMiddleware.mockResolvedValue([() => {}, null]);
     app.use.mockClear();
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(3);
+    expect(app.use).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not enable trust proxy by default', async () => {
+    await plugin.hooks.createServers(gasket, {});
+
+    expect(app.set).not.toHaveBeenCalled();
+  });
+
+  it('does enable trust proxy by if set to true', async () => {
+    gasket.config.express = { trustProxy: true };
+    await plugin.hooks.createServers(gasket, {});
+
+    expect(app.set).toHaveBeenCalledWith('trust proxy', true);
+  });
+
+  it('does enable trust proxy by if set to string', async () => {
+    gasket.config.express = { trustProxy: '127.0.0.1' };
+    await plugin.hooks.createServers(gasket, {});
+
+    expect(app.set).toHaveBeenCalledWith('trust proxy', '127.0.0.1');
   });
 
   function findCall(aSpy, aPredicate) {

--- a/packages/gasket-plugin-fastify/README.md
+++ b/packages/gasket-plugin-fastify/README.md
@@ -35,6 +35,7 @@ All the configurations for the plugin are added under `fastify` in the config:
 - `compression`: true by default. Can be set to false if applying compression
   differently.
 - `excludedRoutesRegex`: Routes to be excluded based on a regex
+- `trustProxy`: Enable trust proxy option, [see Fastify documentation for possible values](https://fastify.dev/docs/latest/Reference/Server/#trustproxy)
 
 #### Example configuration
 
@@ -45,7 +46,8 @@ module.exports = {
   },
   fastify: {
     compression: false,
-    excludedRoutesRegex: /^(?!\/_next\/)/
+    excludedRoutesRegex: /^(?!\/_next\/)/,
+    trustProxy: true
   }
 }
 ```

--- a/packages/gasket-plugin-fastify/lib/index.js
+++ b/packages/gasket-plugin-fastify/lib/index.js
@@ -70,12 +70,7 @@ module.exports = {
         app.use(compression());
       }
 
-      const middlewares = [
-        (req, res, next) => {
-          req.trustProxy = trustProxy;
-          next();
-        }
-      ];
+      const middlewares = [];
       await gasket.execApply('middleware', async (plugin, handler) => {
         const middleware = await handler(app);
         if (middleware) {

--- a/packages/gasket-plugin-fastify/lib/index.js
+++ b/packages/gasket-plugin-fastify/lib/index.js
@@ -71,11 +71,9 @@ module.exports = {
       }
 
       const middlewares = [
-        () => {
-          return (req, res, next) => {
-            req.trustProxy = trustProxy;
-            next();
-          };
+        (req, res, next) => {
+          req.trustProxy = trustProxy;
+          next();
         }
       ];
       await gasket.execApply('middleware', async (plugin, handler) => {

--- a/packages/gasket-plugin-fastify/test/plugin.test.js
+++ b/packages/gasket-plugin-fastify/test/plugin.test.js
@@ -92,7 +92,7 @@ describe('createServers', () => {
   it('adds log plugin as logger to fastify', async function () {
     await plugin.hooks.createServers(gasket, {});
 
-    expect(mockFastify).toHaveBeenCalledWith({ logger: gasket.logger });
+    expect(mockFastify).toHaveBeenCalledWith({ logger: gasket.logger, trustProxy: false });
   });
 
   it('executes the `middleware` lifecycle', async function () {
@@ -209,7 +209,7 @@ describe('createServers', () => {
 
   it('adds middleware from lifecycle (ignores falsy)', async () => {
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(3);
+    expect(app.use).toHaveBeenCalledTimes(4);
 
     app.use.mockClear();
     mockMwPlugins = [
@@ -218,7 +218,7 @@ describe('createServers', () => {
     ];
 
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(4);
+    expect(app.use).toHaveBeenCalledTimes(5);
   });
 
   it('supports async middleware hooks', async () => {
@@ -258,13 +258,36 @@ describe('createServers', () => {
 
   it('adds errorMiddleware from lifecycle (ignores falsy)', async () => {
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(3);
+    expect(app.use).toHaveBeenCalledTimes(4);
 
     app.use.mockClear();
     lifecycles.errorMiddleware.mockResolvedValue([() => {}, null]);
 
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(4);
+    expect(app.use).toHaveBeenCalledTimes(5);
+  });
+
+  it('does not enable trust proxy by default', async () => {
+    await plugin.hooks.createServers(gasket, {});
+
+    expect(mockFastify).toHaveBeenCalledWith({ logger: gasket.logger, trustProxy: false });
+  });
+
+  it('does enable trust proxy by if set to true', async () => {
+    gasket.config.fastify = { trustProxy: true };
+    await plugin.hooks.createServers(gasket, {});
+
+    expect(mockFastify).toHaveBeenCalledWith({ logger: gasket.logger, trustProxy: true });
+  });
+
+  it('does enable trust proxy by if set to string', async () => {
+    gasket.config.fastify = { trustProxy: '127.0.0.1' };
+    await plugin.hooks.createServers(gasket, {});
+
+    expect(mockFastify).toHaveBeenCalledWith({
+      logger: gasket.logger,
+      trustProxy: '127.0.0.1'
+    });
   });
 
   function findCall(aSpy, aPredicate) {

--- a/packages/gasket-plugin-fastify/test/plugin.test.js
+++ b/packages/gasket-plugin-fastify/test/plugin.test.js
@@ -209,7 +209,7 @@ describe('createServers', () => {
 
   it('adds middleware from lifecycle (ignores falsy)', async () => {
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(4);
+    expect(app.use).toHaveBeenCalledTimes(3);
 
     app.use.mockClear();
     mockMwPlugins = [
@@ -218,7 +218,7 @@ describe('createServers', () => {
     ];
 
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(5);
+    expect(app.use).toHaveBeenCalledTimes(4);
   });
 
   it('supports async middleware hooks', async () => {
@@ -258,13 +258,13 @@ describe('createServers', () => {
 
   it('adds errorMiddleware from lifecycle (ignores falsy)', async () => {
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(4);
+    expect(app.use).toHaveBeenCalledTimes(3);
 
     app.use.mockClear();
     lifecycles.errorMiddleware.mockResolvedValue([() => {}, null]);
 
     await plugin.hooks.createServers(gasket, {});
-    expect(app.use).toHaveBeenCalledTimes(5);
+    expect(app.use).toHaveBeenCalledTimes(4);
   });
 
   it('does not enable trust proxy by default', async () => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Both the Express and Fastify plugins do not support trust proxy natively in Gasket, this leads to custom patching in lifecycles and middlewares.

This change begins the support for the trust proxy option in both Express & Fastify. This PR adds native support for passing this option and enabling trust proxy in both frameworks via Gasket configuration.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

All commits adhere to conventional commits and can be used in the changelog.

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

I have added unit tests and tested this change locally.

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
