### PR TITLE
Fix and improve intl modules

### DIFF
--- a/packages/gasket-plugin-intl/README.md
+++ b/packages/gasket-plugin-intl/README.md
@@ -53,7 +53,7 @@ required. However, these options exist to customize an app's setup.
   If set to `true`, the app will use the `defaultPath` as the static endpoint
   path. This option can also be set to a string, to be used as the static
   endpoint path.
-- `modules` - (boolean|object) Enable locale files collation from node modules.
+- `modules` - (boolean|object|string[]) Enable locale files collation from node modules.
   Disabled by default, enable by setting to an object with options below, or set
   to `true` to use the default options. See [Module Locales] section.
   - `localesDir` - (string) Lookup dir for module files (default: `locales`)
@@ -378,6 +378,51 @@ Because the `modules` directory is generated with each build, you may want to
 configure your SCM to ignore committing this file, such as with a `.gitignore`
 entry.
 
+## Module Files Examples
+
+Finds all node_modules with a `./locales` subdirectory.
+
+```js
+// gasket.config.js
+
+module.exports = {
+  intl: {
+    modules: true
+  }
+}
+```
+
+Find all node_modules with a `./i18n` subdirectory, excluding `my-shared-pkg`.
+
+```js
+// gasket.config.js
+
+module.exports = {
+  intl: {
+    modules: {
+        localesDir: 'i18n',
+        excludes: ['my-shared-pkg']
+    }
+  }
+}
+```
+
+Find all packages listed and their `./locales` dir or specified subdirectory.
+
+```js
+// gasket.config.js
+
+module.exports = {
+  intl: {
+    modules: [
+      'my-shared-pkg',
+      '@site/my-shared-pkg',
+      'my-other-shared-pkg/with/custom/locales-dir'
+    ]
+  }
+}
+```
+
 ## Debugging
 
 If you are experiencing difficulties seeing with locale files not working as expected, it can be helpful to enable debug logging for your gasket server via the `DEBUG` environment variable under the namespace `gasket`:
@@ -397,7 +442,7 @@ Once enabled, look for messages under the namespace `gasket:plugin:intl` and `ga
 [locales path]:#locales-path
 [locales map]:#locales-map
 [locales manifest]:#locales-manifest
-[module locales]:#locales-manifest
+[module locales]:#module-files
 [Gasket data]:#gasket-data
 [intlLocale lifecycle]:#intllocale
 [Next.js Routing]:#nextjs-routing

--- a/packages/gasket-plugin-intl/lib/build-modules.js
+++ b/packages/gasket-plugin-intl/lib/build-modules.js
@@ -185,14 +185,14 @@ class BuildModules {
       const promises = this._lookupModuleDirs.map(async lookupDir => {
 
         const match = lookupDir.match(rePkgParts);
-        if (!match?.groups?.name) {
+        const pkgName = match?.groups?.name;
+
+        if (!pkgName) {
           this._logger.warning(`build:locales: malformed module name: ${lookupDir}`);
           return;
         }
 
-        const pkgName = match.groups.name;
         const subDir = (match.groups.dir ?? '/locales').substring(1);
-
         const buildDir = path.join(
           this._nodeModulesDir,
           ...pkgName.split('/'),

--- a/packages/gasket-plugin-intl/lib/build-modules.js
+++ b/packages/gasket-plugin-intl/lib/build-modules.js
@@ -136,8 +136,7 @@ class BuildModules {
    * @param {SrcPkgDir[]} srcPkgDirs - list of dirs to process
    */
   async processDirs(srcPkgDirs) {
-    for (const srcPkgDir of srcPkgDirs) {
-      const [pkgName, srcDir] = srcPkgDir;
+    for (const [pkgName, srcDir] of srcPkgDirs) {
       const tgtDir = path.join(this._outputDir, pkgName);
 
       this._logger.log(`build:locales: Updating locale files for: ${pkgName}`);

--- a/packages/gasket-plugin-intl/lib/build-modules.js
+++ b/packages/gasket-plugin-intl/lib/build-modules.js
@@ -185,7 +185,6 @@ class BuildModules {
   async gatherModuleDirs() {
     if (this._lookupModuleDirs) {
       const promises = this._lookupModuleDirs.map(async lookupDir => {
-        let results;
 
         const match = lookupDir.match(rePkgParts);
         if (!match?.groups?.name) {
@@ -205,16 +204,13 @@ class BuildModules {
         try {
           const stat = await fs.lstat(buildDir);
           if (stat.isDirectory()) {
-            results = [pkgName, buildDir];
+            return [pkgName, buildDir];
           }
         } catch (e) {
           // skip
         }
 
-        if (!results) {
-          this._logger.warning(`build:locales: locales directory not found for: ${lookupDir}`);
-        }
-        return results;
+        this._logger.warning(`build:locales: locales directory not found for: ${lookupDir}`);
       });
 
       const results = await Promise.all(promises);

--- a/packages/gasket-plugin-intl/lib/configure.js
+++ b/packages/gasket-plugin-intl/lib/configure.js
@@ -70,7 +70,7 @@ module.exports = function configureHook(gasket, config) {
     config.basePath, ''].find(isDefined);
 
   let { modules = false } = intlConfig;
-  if (modules) {
+  if (modules && !Array.isArray(modules)) {
     modules = modules === true ? moduleDefaults : { ...moduleDefaults, ...modules };
   }
 

--- a/packages/gasket-plugin-intl/lib/fs-utils.js
+++ b/packages/gasket-plugin-intl/lib/fs-utils.js
@@ -36,7 +36,7 @@ async function *getPackageDirs(parentDir, dirList = []) {
     if ((await fs.stat(filePath)).isDirectory()) {
       const pkgName = await packageName(filePath);
       if (pkgName) {
-        yield await [pkgName, filePath];
+        yield [pkgName, filePath];
       } else {
         yield* getPackageDirs(path.join(filePath, '/'), dirList);
       }

--- a/packages/gasket-plugin-intl/lib/fs-utils.js
+++ b/packages/gasket-plugin-intl/lib/fs-utils.js
@@ -8,60 +8,57 @@ const path = require('path');
  */
 
 /**
- * Utility class for file system operations
+ * Check if path has package.json file and return the name.
+ *
+ * @param {string} targetDir - File path
+ * @returns {string|undefined} result
  */
-class FsUtils {
-
-  /**
-   * Check if path has package.json file and return the name.
-   *
-   * @param {string} targetDir - File path
-   * @returns {string|undefined} result
-   */
-  async packageName(targetDir) {
-    try {
-      const pkg = await fs.readJson(path.join(targetDir, 'package.json'));
-      return pkg.name;
-    } catch (e) {
-      // skip;
-    }
-  }
-
-  /**
-   * Find all directories under target dir, recursively
-   *
-   * @param {string} parentDir - Path to parent directory
-   * @param {SrcPkgDir[]} dirList - List of full paths
-   * @returns {SrcPkgDir[]} directories - List of full paths
-   */
-  async getPackageDirs(parentDir, dirList = []) {
-    const files = await fs.readdir(parentDir);
-    for (const file of files) {
-      const filePath = path.join(parentDir, file);
-      if ((await fs.stat(filePath)).isDirectory()) {
-        const pkgName = await this.packageName(filePath);
-        if (pkgName) {
-          dirList.push([pkgName, filePath]);
-        } else {
-          dirList.concat(await this.getPackageDirs(path.join(filePath, '/'), dirList));
-        }
-      }
-    }
-    return dirList;
-  }
-
-  /**
-     * Saves a json file to disk
-     *
-     * @param {string} filePath - Path to the target file
-     * @param {object} json - JSON to write out
-     * @returns {Promise} promise
-     */
-  async saveJsonFile(filePath, json) {
-    return await fs.writeFile(filePath, JSON.stringify(json, null, 2), 'utf-8');
+async function packageName(targetDir) {
+  try {
+    const pkg = await fs.readJson(path.join(targetDir, 'package.json'));
+    return pkg.name;
+  } catch (e) {
+    // skip;
   }
 }
 
-const fsUtils = new FsUtils();
+/**
+ * Find all directories under target dir, recursively
+ *
+ * @param {string} parentDir - Path to parent directory
+ * @param {SrcPkgDir[]} dirList - List of full paths
+ * @returns {AsyncGenerator<SrcPkgDir>} source package directories
+ */
+async function *getPackageDirs(parentDir, dirList = []) {
+  const files = await fs.readdir(parentDir);
+  for (const file of files) {
+    const filePath = path.join(parentDir, file);
+    if ((await fs.stat(filePath)).isDirectory()) {
+      const pkgName = await packageName(filePath);
+      if (pkgName) {
+        yield await Promise.resolve([pkgName, filePath]);
+      } else {
+        for await (const srcPkgDir of getPackageDirs(path.join(filePath, '/'), dirList)) {
+          yield await Promise.resolve(srcPkgDir);
+        }
+      }
+    }
+  }
+}
 
-module.exports = fsUtils;
+/**
+ * Saves a json file to disk
+ *
+ * @param {string} filePath - Path to the target file
+ * @param {object} json - JSON to write out
+ * @returns {Promise} promise
+ */
+async function saveJsonFile(filePath, json) {
+  return await fs.writeFile(filePath, JSON.stringify(json, null, 2), 'utf-8');
+}
+
+module.exports = {
+  getPackageDirs,
+  packageName,
+  saveJsonFile
+};

--- a/packages/gasket-plugin-intl/lib/fs-utils.js
+++ b/packages/gasket-plugin-intl/lib/fs-utils.js
@@ -36,11 +36,9 @@ async function *getPackageDirs(parentDir, dirList = []) {
     if ((await fs.stat(filePath)).isDirectory()) {
       const pkgName = await packageName(filePath);
       if (pkgName) {
-        yield await Promise.resolve([pkgName, filePath]);
+        yield await [pkgName, filePath];
       } else {
-        for await (const srcPkgDir of getPackageDirs(path.join(filePath, '/'), dirList)) {
-          yield await Promise.resolve(srcPkgDir);
-        }
+        yield* getPackageDirs(path.join(filePath, '/'), dirList);
       }
     }
   }

--- a/packages/gasket-plugin-intl/lib/index.d.ts
+++ b/packages/gasket-plugin-intl/lib/index.d.ts
@@ -13,10 +13,16 @@ declare module '@gasket/engine' {
       localesDir?: string,
       manifestFilename?: string,
       serveStatic?: boolean | string,
-      modules?: boolean | {
-        localesDir?: string,
-        excludes?: Array<string>
-      },
+      modules?:
+        /* default scan settings */
+        boolean |
+        /* custom scan settings */
+        {
+          localesDir?: string,
+          excludes?: Array<string>
+        } |
+        /* specific packages w/ optional subdirectories */
+        string[],
       nextRouting?: boolean
     }
   }

--- a/packages/gasket-plugin-intl/test/build-modules.test.js
+++ b/packages/gasket-plugin-intl/test/build-modules.test.js
@@ -1,7 +1,9 @@
 /* eslint-disable max-nested-callbacks */
 const fs = require('fs-extra');
-const fsUtils = require('../lib/fs-utils');
+const { getPackageDirs, saveJsonFile } = require('../lib/fs-utils');
 const { BuildModules } = require('../lib/build-modules');
+
+jest.mock('../lib/fs-utils');
 
 describe('buildModules', function () {
   const testSrcFilePath = '/path/to/src/myh-fake/locale/en-US.json';
@@ -54,7 +56,7 @@ describe('buildModules', function () {
       it('calls saveJsonFile for correct data', async function () {
         jest.spyOn(fs, 'mkdirp').mockResolvedValue();
         jest.spyOn(fs, 'readdir').mockResolvedValue(['test/folder/name.json']);
-        jest.spyOn(fsUtils, 'saveJsonFile').mockResolvedValue();
+        saveJsonFile.mockResolvedValue();
         jest.spyOn(fs, 'readFile').mockResolvedValue('{ "key-1": "value-1" }');
         await builder.copyFolder(testSrcFilePath, testTgtFilePath);
         expect(fs.mkdirp).toHaveBeenCalledTimes(1);
@@ -140,7 +142,7 @@ describe('buildModules', function () {
         jest.spyOn(fs, 'mkdirp').mockResolvedValue();
         jest.spyOn(fs, 'readdir').mockResolvedValue(['test/folder/name.json']);
         jest.spyOn(fs, 'readJson').mockResolvedValue({ name: 'bogus-package' });
-        jest.spyOn(fsUtils, 'saveJsonFile').mockResolvedValue();
+        saveJsonFile.mockResolvedValue();
         jest.spyOn(builder, 'processFiles');
       });
 
@@ -158,7 +160,11 @@ describe('buildModules', function () {
           ['myh-fake2', '/path/to/module/myh-fake2'],
           ['myh-fake3', '/path/to/module/myh-fake3']
         ];
-        jest.spyOn(fsUtils, 'getPackageDirs').mockResolvedValue(discoveredDirs);
+        getPackageDirs.mockImplementation(async function *mockGen() {
+          for (const pair of discoveredDirs) {
+            yield pair;
+          }
+        });
       });
 
       it('returns a list of all locale paths', async function () {

--- a/packages/gasket-plugin-intl/test/fs-utils.test.js
+++ b/packages/gasket-plugin-intl/test/fs-utils.test.js
@@ -9,30 +9,32 @@ describe('fsUtils', function () {
     results = null;
   });
 
-  describe('#isModule', function () {
-    it('returns true if it finds package.json', async function () {
-      jest.spyOn(fs, 'stat').mockResolvedValue(true);
-      results = await fsUtils.isModule('some-test-path');
-      expect(results).toEqual(true);
+  describe('#packageName', function () {
+    it('returns name if package.json', async function () {
+      jest.spyOn(fs, 'readJson').mockImplementation(() => ({ name: 'test-package' }));
+      results = await fsUtils.packageName('/some/test/path');
+      expect(results).toEqual('test-package');
     });
 
-    it('returns false if it does not find package.json', async function () {
-      jest.spyOn(fs, 'stat').mockResolvedValue(false);
-      results = await fsUtils.isModule('some-test-path');
-      expect(results).toEqual(false);
+    it('returns undefined if no package.json', async function () {
+      jest.spyOn(fs, 'readJson').mockImplementation(() => {
+        throw new Error('Bad things mans');
+      });
+      results = await fsUtils.packageName('/some/test/path');
+      expect(results).toBeUndefined();
     });
   });
 
-  describe('#getDirectories', function () {
+  describe('#getPackageDirs', function () {
     it('returns a list of directory paths', async function () {
       jest.spyOn(fs, 'readdir').mockResolvedValue(['file-1', 'dir-1', 'dir-2', 'file-2', 'dir-3']);
-      jest.spyOn(fsUtils, 'isModule').mockImplementation(testPath => testPath.indexOf('dir-') >= 0);
+      jest.spyOn(fs, 'readJson').mockImplementation(testPath => testPath.indexOf('dir-') >= 0 && { name: testPath });
       jest.spyOn(fs, 'stat').mockImplementation(testPath => {
         return Promise.resolve({ isDirectory: () => testPath.indexOf('dir-') >= 0 });
       });
-      results = await fsUtils.getDirectories(path.join(__dirname, '..', '..'));
-      expect(results.some(f => f.includes('dir-'))).toEqual(true);
-      expect(results.some(f => f.includes('file-'))).toEqual(false);
+      results = await fsUtils.getPackageDirs(path.join(__dirname, '..', '..'));
+      expect(results.some(([name, f]) => name.includes('dir') && f.includes('dir-'))).toEqual(true);
+      expect(results.some(([, f]) => f.includes('file-'))).toEqual(false);
       expect(results).toHaveLength(3);
     });
   });
@@ -41,7 +43,8 @@ describe('fsUtils', function () {
     it('saves json data to file', function () {
       const mockFilePath = '/tmp/file/path';
       const mockJson = { some: 'data' };
-      jest.spyOn(fs, 'writeFile').mockImplementation(() => {});
+      jest.spyOn(fs, 'writeFile').mockImplementation(() => {
+      });
       fsUtils.saveJsonFile(mockFilePath, mockJson);
       expect(fs.writeFile).toHaveBeenCalledWith(mockFilePath, JSON.stringify(mockJson, null, 2), 'utf-8');
     });

--- a/packages/gasket-plugin-intl/test/fs-utils.test.js
+++ b/packages/gasket-plugin-intl/test/fs-utils.test.js
@@ -1,6 +1,10 @@
 const fs = require('fs-extra');
 const path = require('path');
-const fsUtils = require('../lib/fs-utils');
+const { packageName, getPackageDirs, saveJsonFile } = require('../lib/fs-utils');
+
+const GeneratorFunction = Object.getPrototypeOf(
+  async function *() {}
+).constructor;
 
 describe('fsUtils', function () {
   let results;
@@ -12,7 +16,7 @@ describe('fsUtils', function () {
   describe('#packageName', function () {
     it('returns name if package.json', async function () {
       jest.spyOn(fs, 'readJson').mockImplementation(() => ({ name: 'test-package' }));
-      results = await fsUtils.packageName('/some/test/path');
+      results = await packageName('/some/test/path');
       expect(results).toEqual('test-package');
     });
 
@@ -20,19 +24,29 @@ describe('fsUtils', function () {
       jest.spyOn(fs, 'readJson').mockImplementation(() => {
         throw new Error('Bad things mans');
       });
-      results = await fsUtils.packageName('/some/test/path');
+      results = await packageName('/some/test/path');
       expect(results).toBeUndefined();
     });
   });
 
   describe('#getPackageDirs', function () {
+    it('is an async generator function', () => {
+      expect(getPackageDirs.constructor).toBe(GeneratorFunction);
+    });
+
     it('returns a list of directory paths', async function () {
       jest.spyOn(fs, 'readdir').mockResolvedValue(['file-1', 'dir-1', 'dir-2', 'file-2', 'dir-3']);
       jest.spyOn(fs, 'readJson').mockImplementation(testPath => testPath.indexOf('dir-') >= 0 && { name: testPath });
       jest.spyOn(fs, 'stat').mockImplementation(testPath => {
         return Promise.resolve({ isDirectory: () => testPath.indexOf('dir-') >= 0 });
       });
-      results = await fsUtils.getPackageDirs(path.join(__dirname, '..', '..'));
+      const generator = getPackageDirs(path.join(__dirname, '..', '..'));
+
+      results = [];
+      for await (const result of generator) {
+        results.push(result);
+      }
+
       expect(results.some(([name, f]) => name.includes('dir') && f.includes('dir-'))).toEqual(true);
       expect(results.some(([, f]) => f.includes('file-'))).toEqual(false);
       expect(results).toHaveLength(3);
@@ -45,7 +59,7 @@ describe('fsUtils', function () {
       const mockJson = { some: 'data' };
       jest.spyOn(fs, 'writeFile').mockImplementation(() => {
       });
-      fsUtils.saveJsonFile(mockFilePath, mockJson);
+      saveJsonFile(mockFilePath, mockJson);
       expect(fs.writeFile).toHaveBeenCalledWith(mockFilePath, JSON.stringify(mockJson, null, 2), 'utf-8');
     });
   });

--- a/packages/gasket-typescript-tests/test/plugin-intl.spec.ts
+++ b/packages/gasket-typescript-tests/test/plugin-intl.spec.ts
@@ -16,6 +16,39 @@ describe('@gasket/plugin-intl', () => {
     };
   });
 
+  it('module configurations', () => {
+    const config: GasketConfigFile = {
+      intl: {
+        modules: true
+      }
+    };
+
+    const config2: GasketConfigFile = {
+      intl: {
+        modules: {
+          localesDir: 'locales',
+          excludes: ['test']
+        }
+      }
+    };
+
+    const config3: GasketConfigFile = {
+      intl: {
+        modules: [
+          '@site/shared-pkg',
+          '@site/other-pkg/i18n'
+        ]
+      }
+    };
+
+    const badConfig: GasketConfigFile = {
+      intl: {
+        // @ts-expect-error
+        modules: 12345
+      }
+    };
+  });
+
   it('adds an intlLocale lifecycle', () => {
     const hook: Hook<'intlLocale'> = (
       gasket: Gasket,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

We had a bug where using nested `intl.modules.localesDir` was not resolving the correct package name when copying files to the public/locales dir. This PR fixes that and adds a new feature.

To allow apps to copy over varying nested locale subdirectories in packages, we now also allow a specific list of packages with optional subdirectories to be listed.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/plugin-intl**
- Fix for nested localesDir scanning
- Feature to allow listing specific packages with locale subdirs

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

Tested in local app
![Screenshot 2024-02-09 at 3 29 13 PM](https://github.com/godaddy/gasket/assets/63810935/7003054e-d046-41fa-8a62-bceccb51ab00)

![Screenshot 2024-02-09 at 3 00 38 PM](https://github.com/godaddy/gasket/assets/63810935/8790efb8-e189-4f40-a06c-ac56e3e2a7f4)


<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
