### PR TITLE
Use path instead of url in getNextRoute

### DIFF
--- a/packages/gasket-plugin-nextjs/CHANGELOG.md
+++ b/packages/gasket-plugin-nextjs/CHANGELOG.md
@@ -1,6 +1,5 @@
 # `@gasket/plugin-nextjs`
 
-### 6.45.3
 
 - Use `req.path` instead of `req.url` in path matching in `getNextRoute` ([#679])
 

--- a/packages/gasket-plugin-nextjs/CHANGELOG.md
+++ b/packages/gasket-plugin-nextjs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `@gasket/plugin-nextjs`
 
+### 6.45.3
+
+- Use `req.path` instead of `req.url` in path matching in `getNextRoute` ([#679])
+
 ### 6.45.2
 
 - Add `peerDeps` ([#670])

--- a/packages/gasket-plugin-nextjs/lib/next-route.js
+++ b/packages/gasket-plugin-nextjs/lib/next-route.js
@@ -30,7 +30,7 @@ async function getNextRoute(gasket, req) {
   const routes = await loadRoutes(gasket);
   if (routes) {
     for (const route of iterateRoutes(routes)) {
-      if (route.regex.test(req.url)) {
+      if (route.regex.test(req.path)) {
         result = route;
         break;
       }

--- a/packages/gasket-plugin-nextjs/test/next-route.test.js
+++ b/packages/gasket-plugin-nextjs/test/next-route.test.js
@@ -13,7 +13,7 @@ describe('req.getNextRoute()', () => {
       }
     };
 
-    req = { url: '/' };
+    req = { path: '/', url: '/' };
 
     getNextRoute = require('../lib/next-route');
   });
@@ -36,7 +36,7 @@ describe('req.getNextRoute()', () => {
     });
 
     it('returns null if the URL does not match a route', async () => {
-      req.url = '/does/not/exist';
+      req.path = '/does/not/exist';
 
       const route = await getNextRoute(gasket, req);
 
@@ -44,7 +44,7 @@ describe('req.getNextRoute()', () => {
     });
 
     it('returns a static route if there is a match', async () => {
-      req.url = '/purge-documents';
+      req.path = '/purge-documents';
 
       const route = await getNextRoute(gasket, req);
 
@@ -53,7 +53,18 @@ describe('req.getNextRoute()', () => {
     });
 
     it('returns a dynamic route if there is a match', async () => {
-      req.url = '/plans/cohorts/US%20Only';
+      req.path = '/plans/cohorts/US%20Only';
+
+      const route = await getNextRoute(gasket, req);
+
+      expect(route).not.toBeNull();
+      expect(route.page).toEqual('/plans/cohorts/[cohort]');
+      expect(route.namedRegex.exec(req.url).groups.cohort).toEqual('US%20Only');
+    });
+
+    it('returns valid static route if url has query param', async () => {
+      req.path = '/addons';
+      req.url = '/addons?addon=addon1';
 
       const route = await getNextRoute(gasket, req);
 

--- a/packages/gasket-plugin-nextjs/test/next-route.test.js
+++ b/packages/gasket-plugin-nextjs/test/next-route.test.js
@@ -59,18 +59,18 @@ describe('req.getNextRoute()', () => {
 
       expect(route).not.toBeNull();
       expect(route.page).toEqual('/plans/cohorts/[cohort]');
-      expect(route.namedRegex.exec(req.url).groups.cohort).toEqual('US%20Only');
+      expect(route.namedRegex.exec(req.path).groups.cohort).toEqual('US%20Only');
     });
 
     it('returns valid static route if url has query param', async () => {
-      req.path = '/addons';
-      req.url = '/addons?addon=addon1';
+      req.path = '/plans/cohorts/US%20Only';
+      req.url = '/plans/cohorts/US%20Only?addon=addon1';
 
       const route = await getNextRoute(gasket, req);
 
       expect(route).not.toBeNull();
       expect(route.page).toEqual('/plans/cohorts/[cohort]');
-      expect(route.namedRegex.exec(req.url).groups.cohort).toEqual('US%20Only');
+      expect(route.namedRegex.exec(req.path).groups.cohort).toEqual('US%20Only');
     });
   });
 });


### PR DESCRIPTION
## Summary
`getNextRoute` regex did not work for `req.url`s with query params or anchor tags.

## Changelog
Use `req.path` instead of `req.url` in path matching in `getNextRoute`

## Test Plan
Added unit test
