### PR TITLE
FIX: fix weird behavior with camelCase anchors in markdown

### DIFF
--- a/scripts/generate-docs-index/plugins/site-docs-plugin.js
+++ b/scripts/generate-docs-index/plugins/site-docs-plugin.js
@@ -17,7 +17,8 @@ const txFixLinks = {
       .replace(/(\.\.\/)+plugin-/g, '/docs/plugins/plugin-')
       .replace(/(\.\.\/)+preset-/g, '/docs/presets/preset-')
       .replace(/packages\/gasket-plugin/g, '/docs/plugins/plugin')
-      .replace(/\/@gasket\//g, '/');
+      .replace(/\/@gasket\//g, '/')
+      .replace(/#([a-z]+[A-Z].*)/g, (_, match) => '#' + match.toLowerCase());
 
     return content;
   }

--- a/scripts/generate-docs-index/utils/transform-links.js
+++ b/scripts/generate-docs-index/utils/transform-links.js
@@ -11,6 +11,7 @@ module.exports = function transformLinks(content) {
     .replace('/docs/generated-docs/', '/docs/')
     .replace('./LICENSE.md', '/docs/LICENSE.md')
     .replace('/packages/create-gasket-app/README.md', '/docs/create-gasket-app')
-    .replace('./SECURITY.md', '/docs/SECURITY');
+    .replace('./SECURITY.md', '/docs/SECURITY')
+    .replace(/#([a-z]+[A-Z].*)/g, (_, match) => '#' + match.toLowerCase());
   return content;
 };


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
Quick PR to fix some weird behavior where anchor links were camel case and the slug format is lower case. This makes `/docs/some/link#lifecyleHook` to `/docs/some/link#lifecylehook` which corrects the location of the anchor to the correct place in the markdown file.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
- fix weird behavior with camelCase anchors in markdown
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
- Tested locally
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
