### PR TITLE
Workaround for prerelease peer dep issues

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -14,6 +14,7 @@
   "command": {
     "publish": {
       "npmClientArgs": [
+        "--legacy-peer-deps",
         "--access",
         "public"
       ]


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Some of our packages have peers dependencies on each other. Howeve, when using lerna publish with more recent npm clients, because lerna doesn't auto-update the peer dependencies, we have publishes fail due to mismatch prerelease versions.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

- Add `--legacy-peer-deps` for the lerna publish command

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

Successfully canary publish

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
