### PR TITLE
[FOSS-633]: @gasket/plugin-elastic-apm 

### DIFF
--- a/packages/gasket-plugin-elastic-apm/lib/index.d.ts
+++ b/packages/gasket-plugin-elastic-apm/lib/index.d.ts
@@ -1,11 +1,17 @@
 import type { IncomingMessage, ServerResponse } from 'http';
-import type { AgentConfigOptions, Transaction } from 'elastic-apm-node';
+import type { Agent, AgentConfigOptions, Transaction } from 'elastic-apm-node';
+import type Log from '@gasket/log';
 
 declare module '@gasket/engine' {
   export interface GasketConfig {
     elasticAPM?: AgentConfigOptions & {
       sensitiveCookies?: Array<string>
     },
+  }
+
+  export interface Gasket {
+    apm: Agent;
+    logger: Log;
   }
 
   export interface HookExecTypes {

--- a/packages/gasket-plugin-elastic-apm/lib/index.js
+++ b/packages/gasket-plugin-elastic-apm/lib/index.js
@@ -69,6 +69,8 @@ module.exports = {
         }
 
         apm.addFilter(filterSensitiveCookies(config));
+
+        gasket.apm = apm;
       }
     },
     create: {

--- a/packages/gasket-plugin-elastic-apm/lib/middleware.js
+++ b/packages/gasket-plugin-elastic-apm/lib/middleware.js
@@ -10,7 +10,6 @@
  */
 
 const { callbackify } = require('util');
-const apm = require('elastic-apm-node');
 
 /**
  * Middleware for customizing transactions
@@ -20,6 +19,13 @@ const apm = require('elastic-apm-node');
  * @param {Response}  res     The server response
  */
 async function customizeTransaction(gasket, req, res) {
+  const apm = gasket.apm;
+
+  if (!apm.isStarted()) {
+    gasket.logger.warning('Elastic APM has not been started properly.');
+    return;
+  }
+
   const transaction = apm.currentTransaction;
   if (!transaction) {
     return;

--- a/packages/gasket-plugin-elastic-apm/test/index.test.js
+++ b/packages/gasket-plugin-elastic-apm/test/index.test.js
@@ -103,6 +103,11 @@ describe('Plugin', () => {
     );
   });
 
+  it('sets gasket.apm', async function () {
+    await plugin.hooks.preboot.handler(mockGasket);
+    expect(mockGasket.apm).toEqual(apm);
+  });
+
   it('warns if using deprecated gasket.config', async function () {
     mockGasket.config = await plugin.hooks.configure.handler(mockGasket, {
       ...mockGasket.config,

--- a/packages/gasket-plugin-elastic-apm/test/middleware.test.js
+++ b/packages/gasket-plugin-elastic-apm/test/middleware.test.js
@@ -1,25 +1,38 @@
 const { promisify } = require('util');
-const apm = require('elastic-apm-node');
+// const apm = require('elastic-apm-node');
 const middlewareHook = require('../lib/middleware');
 
-jest.mock('elastic-apm-node', () => ({
-  currentTransaction: {
-    name: 'transaction name',
-    addLabels: jest.fn()
-  }
-}));
+// jest.mock('elastic-apm-node', () => ({
+//   currentTransaction: {
+//     name: 'transaction name',
+//     addLabels: jest.fn()
+//   }
+// }));
 
 describe('The middleware hook', () => {
   let gasket, req, res;
+  const loggerMock = { warning: jest.fn() };
 
   beforeEach(() => {
     gasket = {
-      exec: jest.fn(() => Promise.resolve())
+      exec: jest.fn(() => Promise.resolve()),
+      logger: loggerMock,
+      apm: {
+        isStarted: jest.fn().mockReturnValue(true),
+        currentTransaction: {
+          name: 'transaction name',
+          addLabels: jest.fn()
+        }
+      }
     };
     req = {
       url: '/cohorts/Rad%20Dudes'
     };
     res = {};
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   describe('middleware', () => {
@@ -35,9 +48,26 @@ describe('The middleware hook', () => {
 
       expect(gasket.exec).toHaveBeenCalledWith(
         'apmTransaction',
-        apm.currentTransaction,
+        gasket.apm.currentTransaction,
         { req, res }
       );
+      expect(gasket.logger.warning).not.toHaveBeenCalled();
+    });
+
+    it('logs a warning if apm is not started', async () => {
+      gasket.apm.isStarted = jest.fn().mockReturnValue(false);
+
+      await middleware(req, res);
+
+      expect(gasket.logger.warning).toHaveBeenCalledWith('Elastic APM has not been started properly.');
+      expect(gasket.exec).not.toHaveBeenCalled();
+    });
+
+    it('returns if currentTransaction is not defined', async () => {
+      gasket.apm.currentTransaction = null;
+      await middleware(req, res);
+      expect(gasket.logger.warning).not.toHaveBeenCalled();
+      expect(gasket.exec).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

The currentTransaction was always null in the middleware hook.  I found that when calling `apm.isStarted()`, it returned undefined. As a result, the currentTransaction was undefined meaning that the `apmTransaction` lifecycle was never executed. To work around this, I added the `apm` property to the Gasket object allowing the initial instance to be accessed in the middleware object and the lifecycle to be executed.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

- Add `apm` to Gasket properties

## Test Plan

<img width="947" alt="Screenshot 2024-02-27 at 10 28 37 AM" src="https://github.com/godaddy/gasket/assets/104379885/0d0f1d82-68f0-4961-8922-47da52f8419a">


<img width="971" alt="Screenshot 2024-02-27 at 10 29 24 AM" src="https://github.com/godaddy/gasket/assets/104379885/72499abd-acda-48f6-854c-1c26dff4f62d">

- Added some additional tests to the middleware hook to verify that the lifecycle is only executed when both the apm instance is started and the transaction is defined