### PR TITLE
Avoid env var bleed into bundles

### DIFF
--- a/packages/gasket-plugin-intl/lib/index.js
+++ b/packages/gasket-plugin-intl/lib/index.js
@@ -45,16 +45,16 @@ module.exports = {
         await buildManifest(gasket);
       }
     },
-    webpackConfig(gasket, webpackConfig, { webpack }) {
+    webpackConfig(gasket, webpackConfig, { webpack, isServer }) {
       return {
         ...webpackConfig,
         plugins: [
           ...(webpackConfig.plugins || []),
-          new webpack.EnvironmentPlugin([
+          isServer ? new webpack.EnvironmentPlugin([
             'GASKET_INTL_LOCALES_DIR',
             'GASKET_INTL_MANIFEST_FILE'
-          ])
-        ]
+          ]) : null
+        ].filter(Boolean)
       };
     },
     express: serve,

--- a/packages/gasket-plugin-intl/test/webpack-config.test.js
+++ b/packages/gasket-plugin-intl/test/webpack-config.test.js
@@ -17,7 +17,7 @@ describe('webpackConfig', function () {
   });
 
   it('adds env vars to EnvironmentPlugin', function () {
-    const results = hook(mockGasket, mockConfig, { webpack });
+    const results = hook(mockGasket, mockConfig, { webpack, isServer: true });
     expect(results).toHaveProperty('plugins');
     expect(results.plugins).toHaveLength(1);
     expect(results.plugins[0]).toBeInstanceOf(webpack.EnvironmentPlugin);
@@ -27,13 +27,19 @@ describe('webpackConfig', function () {
     });
   });
 
+  it('does NOT add EnvironmentPlugin for client', function () {
+    const results = hook(mockGasket, mockConfig, { webpack });
+    expect(results).toHaveProperty('plugins');
+    expect(results.plugins).toHaveLength(0);
+  });
+
   it('merges with existing plugins', function () {
     mockConfig.plugins = [
       new webpack.EntryOptionPlugin(),
       new webpack.DynamicEntryPlugin()
     ];
 
-    const results = hook(mockGasket, mockConfig, { webpack });
+    const results = hook(mockGasket, mockConfig, { webpack, isServer: true });
     expect(results).toHaveProperty('plugins');
     expect(results.plugins).toHaveLength(3);
     expect(results.plugins[2]).toBeInstanceOf(webpack.EnvironmentPlugin);
@@ -50,7 +56,7 @@ describe('webpackConfig', function () {
       ])
     ];
 
-    const results = hook(mockGasket, mockConfig, { webpack });
+    const results = hook(mockGasket, mockConfig, { webpack, isServer: true });
     expect(results).toHaveProperty('plugins');
     expect(results.plugins).toHaveLength(2);
     expect(results.plugins[1]).toBeInstanceOf(webpack.EnvironmentPlugin);

--- a/packages/gasket-react-intl/src/next.js
+++ b/packages/gasket-react-intl/src/next.js
@@ -1,5 +1,13 @@
-import { localeUtils, getLocalesParentDir } from './utils';
+import { localeUtils } from './utils';
 import { manifest } from './config';
+
+let localesParentDir;
+export function getLocalesParentDir() {
+  return localesParentDir || (
+    // eslint-disable-next-line no-process-env
+    localesParentDir = require('path').dirname(process.env.GASKET_INTL_LOCALES_DIR)
+  );
+}
 
 /**
  * Load locale file(s) for Next.js static pages

--- a/packages/gasket-react-intl/src/utils.js
+++ b/packages/gasket-react-intl/src/utils.js
@@ -18,11 +18,3 @@ export function getActiveLocale() {
   }
   return manifest.defaultLocale;
 }
-
-let localesParentDir;
-export function getLocalesParentDir() {
-  return localesParentDir || (
-    // eslint-disable-next-line no-process-env
-    localesParentDir = require('path').dirname(process.env.GASKET_INTL_LOCALES_DIR)
-  );
-}

--- a/packages/gasket-react-intl/test/use-locale-required.test.js
+++ b/packages/gasket-react-intl/test/use-locale-required.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { useContext } from 'react';
 import { LocaleStatus } from '../src/utils';
 import useLocaleRequired from '../src/use-locale-required';


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

We uncovered that the `GASKET_INTL_LOCALES_DIR`, intended for server-side operations only, could be webpack bundled into the client chunk.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

@gasket/plugin-intl
- Only config webpack with add env vars for server bundles.

@gasket/react-intl
- Move next-specific utility function to avoid inclusion for browser bundles.

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

Tested in local app

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
