### PR TITLE
Fix for missing manifest paths

### DIFF
--- a/packages/gasket-helper-intl/lib/index.js
+++ b/packages/gasket-helper-intl/lib/index.js
@@ -121,7 +121,7 @@ const trim = localePath => localePath.replace(reLeadingSlash, '');
 function LocaleUtils(config) {
   const { manifest, debug = () => {} } = config;
   const { basePath = manifest.basePath } = config;
-  const { defaultLocale = 'en', localesMap, paths, locales } = manifest;
+  const { defaultLocale = 'en', localesMap, paths = {}, locales } = manifest;
   const defaultLang = defaultLocale.split('-')[0];
 
   /**

--- a/packages/gasket-helper-intl/test/server.test.js
+++ b/packages/gasket-helper-intl/test/server.test.js
@@ -43,14 +43,14 @@ describe('LocaleUtils (Server)', function () {
     });
 
     it('returns localesProps with error for missing path', async function () {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       const results = utils.serverLoadData('/locales/missing', 'en-US', localesParentDir);
       expect(results).toEqual({
         locale: 'en-US',
         messages: { 'en-US': {} },
         status: { '/locales/missing/en-US.json': 'error' }
       });
-      // eslint-disable-next-line no-console
-      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Cannot find module'));
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Cannot find module'));
     });
 
     it('returns localesProps for default if locale missing', async function () {

--- a/packages/gasket-helper-intl/test/shared.js
+++ b/packages/gasket-helper-intl/test/shared.js
@@ -3,7 +3,6 @@ module.exports = function sharedTests(UtilClass) {
   let utils, mockConfig;
 
   beforeEach(function () {
-    jest.spyOn(console, 'error');
     mockConfig = {
       manifest: require('./fixtures/mock-manifest.json')
     };
@@ -12,6 +11,7 @@ module.exports = function sharedTests(UtilClass) {
 
   afterEach(function () {
     jest.resetModules();
+    jest.restoreAllMocks();
   });
 
   describe('.formatLocalePath', function () {
@@ -161,6 +161,16 @@ module.exports = function sharedTests(UtilClass) {
       const results = utils.getLocalePath(mockThunk, 'en-US', mockContext);
       expect(results).toEqual('/bogus/locales/en-US.json');
       expect(mockThunk).toHaveBeenCalled();
+    });
+
+    it('handles missing manifest paths', function () {
+      utils = new UtilClass({
+        manifest: {
+          defaultLocale: 'fake'
+        }
+      });
+      const results = utils.getLocalePath('/locales', 'da-DK');
+      expect(results).toEqual('/locales/da-DK.json');
     });
   });
 };

--- a/packages/gasket-plugin-intl/lib/configure.js
+++ b/packages/gasket-plugin-intl/lib/configure.js
@@ -74,10 +74,14 @@ module.exports = function configureHook(gasket, config) {
     modules = modules === true ? moduleDefaults : { ...moduleDefaults, ...modules };
   }
 
-  // This allows packages (@gasket/react-intl) to reference certain configs
   /* eslint-disable no-process-env */
+
+  // Allows @gasket/react-intl/next to perform server side loading
   process.env.GASKET_INTL_LOCALES_DIR = fullLocalesDir;
+
+  // Allows @gasket/react-intl to access manifest, and is bundled for browser
   process.env.GASKET_INTL_MANIFEST_FILE = path.join(fullLocalesDir, manifestFilename);
+
   /* eslint-enable no-process-env */
 
   const normalizedIntlConfig = {

--- a/packages/gasket-plugin-intl/lib/index.js
+++ b/packages/gasket-plugin-intl/lib/index.js
@@ -50,10 +50,10 @@ module.exports = {
         ...webpackConfig,
         plugins: [
           ...(webpackConfig.plugins || []),
-          isServer ? new webpack.EnvironmentPlugin([
-            'GASKET_INTL_LOCALES_DIR',
+          new webpack.EnvironmentPlugin([
+            isServer ? 'GASKET_INTL_LOCALES_DIR' : null,
             'GASKET_INTL_MANIFEST_FILE'
-          ]) : null
+          ].filter(Boolean))
         ].filter(Boolean)
       };
     },

--- a/packages/gasket-plugin-intl/test/webpack-config.test.js
+++ b/packages/gasket-plugin-intl/test/webpack-config.test.js
@@ -27,10 +27,15 @@ describe('webpackConfig', function () {
     });
   });
 
-  it('does NOT add EnvironmentPlugin for client', function () {
+  it('does NOT add GASKET_INTL_LOCALES_DIR for client', function () {
     const results = hook(mockGasket, mockConfig, { webpack });
     expect(results).toHaveProperty('plugins');
-    expect(results.plugins).toHaveLength(0);
+    expect(results.plugins).toHaveLength(1);
+    expect(results.plugins[0]).toBeInstanceOf(webpack.EnvironmentPlugin);
+    expect(results.plugins[0]).toEqual({
+      keys: ['GASKET_INTL_MANIFEST_FILE'],
+      defaultValues: {}
+    });
   });
 
   it('merges with existing plugins', function () {
@@ -59,6 +64,13 @@ describe('webpackConfig', function () {
     const results = hook(mockGasket, mockConfig, { webpack, isServer: true });
     expect(results).toHaveProperty('plugins');
     expect(results.plugins).toHaveLength(2);
+
+    expect(results.plugins[0]).toBeInstanceOf(webpack.EnvironmentPlugin);
+    expect(results.plugins[0]).toEqual({
+      keys: ['GASKET_BOGUS'],
+      defaultValues: {}
+    });
+
     expect(results.plugins[1]).toBeInstanceOf(webpack.EnvironmentPlugin);
     expect(results.plugins[1]).toEqual({
       keys: ['GASKET_INTL_LOCALES_DIR', 'GASKET_INTL_MANIFEST_FILE'],


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Fix for locales manifest not being bundled for client, introduced as an over correction in https://github.com/godaddy/gasket/pull/696 to avoid full dir paths being bundled. The manifest file env var is necessary for client bundles.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/helper-intl**
- handle missing manifest paths

**@gasket/plugin-intl**
- Set `GASKET_INTL_MANIFEST_FILE` for all webpack configs

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

- Updated unit tests
- locally tested in app

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
