### PR TITLE
Elastic APM disabled mode bug

### DIFF
--- a/packages/gasket-plugin-elastic-apm/CHANGELOG.md
+++ b/packages/gasket-plugin-elastic-apm/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-elastic-apm`
 
+- Fix bug with express middleware injection when APM is not available
+
 ### 6.46.4
 
 - Fix to handle case when APM is not available ([#697])

--- a/packages/gasket-plugin-elastic-apm/lib/middleware.js
+++ b/packages/gasket-plugin-elastic-apm/lib/middleware.js
@@ -34,7 +34,8 @@ async function customizeTransaction(gasket, req, res) {
 }
 
 module.exports = (gasket) => {
-  return gasket.apm
-    ? [callbackify(async (req, res) => customizeTransaction(gasket, req, res))]
-    : [];
+  return (
+    gasket.apm
+    && [callbackify(async (req, res) => customizeTransaction(gasket, req, res))]
+  );
 };

--- a/packages/gasket-plugin-elastic-apm/test/middleware.test.js
+++ b/packages/gasket-plugin-elastic-apm/test/middleware.test.js
@@ -30,7 +30,7 @@ describe('The middleware hook', () => {
 
     const middleware = middlewareHook(gasket);
 
-    expect(middleware).toHaveLength(0);
+    expect(middleware).toBeFalsy();
   });
 
   describe('middleware', () => {

--- a/packages/gasket-plugin-express/CHANGELOG.md
+++ b/packages/gasket-plugin-express/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-express`
 
+- Support the case of middleware hooks returning empty arrays
+
 ### 6.46.4
 
 - Adjust JSDocs and TS types ([#695])

--- a/packages/gasket-plugin-express/lib/create-servers.js
+++ b/packages/gasket-plugin-express/lib/create-servers.js
@@ -76,7 +76,7 @@ module.exports = async function createServers(gasket, serverOpts) {
   await gasket.execApply('middleware', async (plugin, handler) => {
     const middleware = await handler(app);
 
-    if (middleware) {
+    if (middleware && (!Array.isArray(middleware) || middleware.length)) {
       if (middlewareConfig) {
         const pluginName = plugin && plugin.name ? plugin.name : '';
         const mwConfig = middlewareConfig.find(mw => mw.plugin === pluginName);

--- a/packages/gasket-plugin-express/test/plugin.test.js
+++ b/packages/gasket-plugin-express/test/plugin.test.js
@@ -104,6 +104,14 @@ describe('createServers', () => {
     expect(gasket.exec.mock.calls[0]).toContain('express', app);
   });
 
+  it('does not use empty middleware arrays', async function () {
+    lifecycles.middleware.mockResolvedValue([[]]);
+
+    await plugin.hooks.createServers(gasket, {});
+
+    expect(app.use).not.toHaveBeenCalledWith([]);
+  });
+
   it('executes the `errorMiddleware` lifecycle after the `express` lifecycle', async function () {
     await plugin.hooks.createServers(gasket, {});
     expect(gasket.exec.mock.calls[0]).toContain('express', app);


### PR DESCRIPTION
- Fix `@gasket/plugin-elastic-apm` so it doesn't return a `middleware` result that breaks express
- Also fix `@gasket/plugin-express` so it can handle empty middleware arrays

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

This fixes a bug with `@gasket/plugin-elastic-apm` where its returning of an empty array breaks the express middleware. It also improves the express plugin such that it can handle empty arrays. [Support thread](https://godaddy.slack.com/archives/CABCTNQ5P/p1710975890130339) for context.

## Changelog

Included in PR

## Test Plan

Unit tests included