### PR TITLE
[PFX-548] - Update runShellCommand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41459,8 +41459,6 @@
       "version": "6.45.2",
       "license": "MIT",
       "dependencies": {
-        "concat-stream": "^2.0.0",
-        "cross-spawn": "^7.0.3",
         "diagnostics": "^2.0.2",
         "lodash.defaultsdeep": "^4.6.1"
       },
@@ -46783,9 +46781,7 @@
         "@gasket/engine": "^6.45.2",
         "@godaddy/dmd": "^1.0.4",
         "abort-controller": "^3.0.0",
-        "concat-stream": "^2.0.0",
         "cross-env": "^7.0.3",
-        "cross-spawn": "^7.0.3",
         "diagnostics": "^2.0.2",
         "eslint": "^8.56.0",
         "eslint-config-godaddy": "^7.0.2",

--- a/packages/gasket-utils/lib/run-shell-command.js
+++ b/packages/gasket-utils/lib/run-shell-command.js
@@ -1,5 +1,4 @@
-const concat = require('concat-stream');
-const spawn = require('cross-spawn');
+const { spawn } = require('child_process');
 
 /**
  * Promise friendly wrapper to running a shell command (eg: git, npm, ls)
@@ -51,13 +50,13 @@ function runShellCommand(cmd, argv, options = {}, debug = false) {
     let stderr;
     let stdout;
 
-    child.stderr.pipe(concat({ encoding: 'string' }, lines => {
-      stderr = lines;
-    }));
+    child.stderr.on('data', lines => {
+      stderr = lines.toString();
+    });
 
-    child.stdout.pipe(concat({ encoding: 'string' }, lines => {
-      stdout = lines;
-    }));
+    child.stdout.on('data', lines => {
+      stdout = lines.toString();
+    });
 
     if (debug) {
       child.stderr.pipe(process.stderr);

--- a/packages/gasket-utils/lib/run-shell-command.js
+++ b/packages/gasket-utils/lib/run-shell-command.js
@@ -1,4 +1,15 @@
 const { spawn } = require('child_process');
+const { Writable } = require('stream');
+const stderr = new Writable();
+const stdout = new Writable();
+const write = function (chunk, encoding, next) {
+  if (!this.data) this.data = '';
+  this.data += chunk;
+  next();
+};
+
+stdout._write = write;
+stderr._write = write;
 
 /**
  * Promise friendly wrapper to running a shell command (eg: git, npm, ls)
@@ -41,21 +52,18 @@ function runShellCommand(cmd, argv, options = {}, debug = false) {
   const { signal, ...opts } = options;
 
   if (signal && signal.aborted) {
-    return Promise.reject(Object.assign(new Error(`${ cmd } was aborted before spawn`), { argv, aborted: true }));
+    return Promise.reject(Object.assign(new Error(`${cmd} was aborted before spawn`), { argv, aborted: true }));
   }
 
   return new Promise((resolve, reject) => {
     const child = spawn(cmd, argv, opts);
 
-    let stderr;
-    let stdout;
-
     child.stderr.on('data', lines => {
-      stderr = lines.toString();
+      stderr.write(lines);
     });
 
     child.stdout.on('data', lines => {
-      stdout = lines.toString();
+      stdout.write(lines);
     });
 
     if (debug) {
@@ -73,16 +81,16 @@ function runShellCommand(cmd, argv, options = {}, debug = false) {
 
     child.on('close', code => {
       if (code !== 0) {
-        return reject(Object.assign(new Error(`${ cmd } exited with non-zero code`), {
+        return reject(Object.assign(new Error(`${cmd} exited with non-zero code`), {
           argv,
-          stdout,
-          stderr,
+          stdout: stdout.data,
+          stderr: stderr.data,
           aborted,
           code
         }));
       }
 
-      resolve({ stdout });
+      resolve({ stdout: stdout.data });
     });
   });
 }

--- a/packages/gasket-utils/package.json
+++ b/packages/gasket-utils/package.json
@@ -38,8 +38,6 @@
   },
   "homepage": "https://github.com/godaddy/gasket/tree/main/packages/gasket-utils",
   "dependencies": {
-    "concat-stream": "^2.0.0",
-    "cross-spawn": "^7.0.3",
     "diagnostics": "^2.0.2",
     "lodash.defaultsdeep": "^4.6.1"
   },

--- a/packages/gasket-utils/test/require-with-install.test.js
+++ b/packages/gasket-utils/test/require-with-install.test.js
@@ -149,7 +149,12 @@ describe('requireWithInstall', function () {
 
       expect(Array.isArray(pkgList)).toEqual(true);
       expect(pkgList.length).toEqual(2);
-      expect(mockPackageManagerExecStub).toHaveBeenCalledWith('add', expect.arrayContaining(['my-package', '@scoped/package', '--dev']));
+      expect(mockPackageManagerExecStub).toHaveBeenCalledWith(
+        'add',
+        expect.arrayContaining(
+          ['my-package', '@scoped/package', '--dev']
+        )
+      );
     });
   });
 });

--- a/packages/gasket-utils/test/run-shell-command.test.js
+++ b/packages/gasket-utils/test/run-shell-command.test.js
@@ -29,6 +29,7 @@ describe('runShellCommand', function () {
   });
 
   it('rejects with details object', async function () {
+
     try {
       await runShellCommand('node', ['./fixtures/test-script.js', failMode], { cwd });
     } catch (err) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
Updated `runShellCommand` to use the current libs from node. By doing this we can remove two outdated(4 and 5 years since last publish) packages that were used. Investigated Windows support and it should NOT be an issue. Issues would arise if this utility was used to run `.bat` scripts for example. There are options that can be passed to the `spawn` function that will resolve the issues. The options object from `runShellCommand` is passed directly to `spawn` so these Windows specific options are available but again there's really not a use case for it.
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
- Update runShellCommand
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
- Updated tests
- Tested `gasket create` & other use cases of `runShellCommand`
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
