### PR TITLE
Fix: cmd options not being destructured correctly

### DIFF
--- a/packages/gasket-cli/lib/scaffold/create-context.js
+++ b/packages/gasket-cli/lib/scaffold/create-context.js
@@ -61,7 +61,7 @@ function flatten(acc, values) {
  *
  * @type {CreateContext}
  *
- * -- Added by command args and flags
+ * -- Added by command args and options
  *
  * @property {String} appName - Short name of the app
  * @property {String} cwd - Current work directory
@@ -70,7 +70,7 @@ function flatten(acc, values) {
  * @property {Boolean} extant - Whether or not target directory already exists
  * @property {[String]} localPresets - paths to the local presets packages
  * @property {PresetDesc[]} rawPresets - Raw preset desc from args. Can include version constraint. Added by load-preset if using localPresets.
- * @property {PluginDesc[]} rawPlugins - Raw plugin desc from flags, prompts, etc. Can include constraints.
+ * @property {PluginDesc[]} rawPlugins - Raw plugin desc from options, prompts, etc. Can include constraints.
  * @property {PluginName[]} plugins - Short names of plugins
  * @property {String[]} pkgLinks - Local packages that should be linked
  * @property {String[]} messages - non-error/warning messages to report
@@ -126,21 +126,21 @@ class CreateContext {
  * Makes the initial context used through the create command flow.
  *
  * @param {String[]} argv - Commands args
- * @param {Object} flags - Command flags
+ * @param {Object} options - Command options
  * @returns {CreateContext} context
  */
-module.exports = function makeCreateContext(argv = [], flags = {}) {
+module.exports = function makeCreateContext(argv = [], options = {}) {
   const appName = argv[0] || 'templated-app';
   const {
     plugins = [],
     presets = [],
-    'npm-link': npmLink = [],
-    'preset-path': presetPath = [],
-    'package-manager': packageManager,
+    npmLink = [],
+    presetPath = [],
+    packageManager,
     prompts,
     config,
     'config-file': configFile
-  } = flags;
+  } = options;
 
   // Flatten the array of array created by the plugins flag – it
   // supports both multiple instances as well as comma-separated lists.

--- a/packages/gasket-cli/lib/utils/warn-if-outdated.js
+++ b/packages/gasket-cli/lib/utils/warn-if-outdated.js
@@ -28,7 +28,11 @@ function isOlderThanSevenDays(currentTime, latestVersionUpdateTime) {
  * @returns {string} - latest version of the package
  */
 async function getLatestVersion(pkgName, currentTime, cache) {
-  if (!cache[LATEST_VERSION_UPDATE_TIME] || !cache[LATEST_VERSION] || isOlderThanSevenDays(currentTime, cache[LATEST_VERSION_UPDATE_TIME])) {
+  if (
+    !cache[LATEST_VERSION_UPDATE_TIME] ||
+    !cache[LATEST_VERSION] ||
+    isOlderThanSevenDays(currentTime, cache[LATEST_VERSION_UPDATE_TIME])
+  ) {
     try {
       const cmdResult = await runShellCommand('npm', ['view', pkgName, 'version'], {});
       if (cmdResult?.stdout) {

--- a/packages/gasket-cli/test/unit/scaffold/create-context.test.js
+++ b/packages/gasket-cli/test/unit/scaffold/create-context.test.js
@@ -170,17 +170,17 @@ describe('makeCreateContext', () => {
   });
 
   it('sets rawPresets to empty array if not defined', () => {
-    results = makeCreateContext(argv, { 'preset-path': ['../bogus/path'] });
+    results = makeCreateContext(argv, { presetPath: ['../bogus/path'] });
     expect(results.rawPresets).toEqual([]);
   });
 
   it('sets localPresets from flags', () => {
-    results = makeCreateContext(argv, { 'preset-path': ['../bogus/path'] });
+    results = makeCreateContext(argv, { presetPath: ['../bogus/path'] });
     expect(results.localPresets).toEqual(['../bogus/path']);
   });
 
   it('sets localPresets from flags with multiple entries', () => {
-    results = makeCreateContext(argv, { 'preset-path': ['../bogus/path', '../test/path'] });
+    results = makeCreateContext(argv, { presetPath: ['../bogus/path', '../test/path'] });
     expect(results.localPresets).toEqual(['../bogus/path', '../test/path']);
   });
 
@@ -205,7 +205,7 @@ describe('makeCreateContext', () => {
   });
 
   it('sets pkgLinks from flags', () => {
-    results = makeCreateContext(argv, { 'npm-link': ['@gasket/jest', 'gasket-plugin-some-user'], 'presets': ['godady'] });
+    results = makeCreateContext(argv, { npmLink: ['@gasket/jest', 'gasket-plugin-some-user'], presets: ['godady'] });
     expect(results.pkgLinks).toEqual(['@gasket/jest', 'gasket-plugin-some-user']);
   });
 
@@ -264,7 +264,7 @@ describe('makeCreateContext', () => {
   it('doesnt throw if preset path found', () => {
     let error;
     try {
-      results = makeCreateContext(argv, { 'preset-path': ['somePath'] });
+      results = makeCreateContext(argv, { presetPath: ['somePath'] });
     } catch (err) {
       error = err;
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
This problem was highlighted after working on some other investigations. Basically the destructure assumed that the cmd options would be in the original format but instead they are camelCased. Example `preset-path` option becomes `presetPath`.
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
- cmd options not being destructured correctly
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
- Updated tests
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
