### PR TITLE
[PFX-550]: Fix lint script failure warning after creating app with api preset

### DIFF
--- a/packages/gasket-plugin-express/generator/routes/index.js
+++ b/packages/gasket-plugin-express/generator/routes/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 module.exports = (app) => {
   {{#if hasSwaggerPlugin}}
   /**
@@ -16,7 +15,7 @@ module.exports = (app) => {
   *           application/json
   */
   {{/if}}
-  app.get('/default', async (req, res, next) => {
+  app.get('/default', async (req, res) => {
     res.status(200).json({
       message: 'Welcome to your default route...'
     });

--- a/packages/gasket-plugin-express/generator/routes/index.js
+++ b/packages/gasket-plugin-express/generator/routes/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 module.exports = (app) => {
   {{#if hasSwaggerPlugin}}
   /**


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

- Ticket: [PFX-550](https://godaddy-corp.atlassian.net/browse/PFX-550)

This error: `Errors encountered running script: 'lint:fix'` is displayed when creating a gasket app with the `@godaddy/gasket-preset-api` and `@gasket/preset-api` presets. The error is due to `next` not being defined in the generated file for the express routes. 

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->
- Add eslint disable 

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
- All tests pass
- The error is no longer 
<img width="1171" alt="Screenshot 2024-04-04 at 11 15 17 AM" src="https://github.com/godaddy/gasket/assets/104379885/4bd5c39b-6b0c-4f75-97e8-8a7dc1eb87b2">
occurring when creating a gasket app with the presets


