### PR TITLE
Handle incorrected encoded URL segments

### DIFF
--- a/packages/gasket-plugin-nextjs/CHANGELOG.md
+++ b/packages/gasket-plugin-nextjs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # `@gasket/plugin-nextjs`
 
 - (fix) Handle malformed URL segments in Elastic APM transaction labeling
+- (fix) Omit query parameters when parsing next.js route labels
 
 ### 6.46.4
 

--- a/packages/gasket-plugin-nextjs/CHANGELOG.md
+++ b/packages/gasket-plugin-nextjs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-nextjs`
 
+- (fix) Handle malformed URL segments in Elastic APM transaction labeling
+
 ### 6.46.4
 
 - Adjust JSDocs and TS types ([#695])

--- a/packages/gasket-plugin-nextjs/lib/apm-transaction.js
+++ b/packages/gasket-plugin-nextjs/lib/apm-transaction.js
@@ -6,7 +6,7 @@ module.exports = async (_gasket, transaction, { req }) => {
 
   transaction.name = route.page;
 
-  const match = route.namedRegex.exec(req.url);
+  const match = route.namedRegex.exec(req.url.replace(/\?.*$/, ''));
   const groups = match && match.groups;
   if (!groups) {
     return;

--- a/packages/gasket-plugin-nextjs/lib/apm-transaction.js
+++ b/packages/gasket-plugin-nextjs/lib/apm-transaction.js
@@ -14,7 +14,15 @@ module.exports = async (_gasket, transaction, { req }) => {
 
   transaction.addLabels(
     Object.fromEntries(
-      Object.entries(groups).map(([key, value]) => [key, decodeURIComponent(value)])
+      Object.entries(groups).map(([key, value]) => {
+        let decodedValue = value;
+        try {
+          decodedValue = decodeURIComponent(value);
+        } catch (e) {
+          // ignore
+        }
+        return [key, decodedValue];
+      })
     )
   );
 };

--- a/packages/gasket-plugin-nextjs/test/apm-transaction.test.js
+++ b/packages/gasket-plugin-nextjs/test/apm-transaction.test.js
@@ -53,4 +53,18 @@ describe('The apmTransaction hook', () => {
 
     expect(transaction.addLabels).toHaveBeenCalledWith({ cohortId: 'Rad People' });
   });
+
+  it('handles URL segments that are not properly URL encoded', async () => {
+    const req = {
+      url: '/cohorts/TopTen%',
+      getNextRoute: async () => ({
+        page: '/cohorts/[cohortId]',
+        namedRegex: /^\/cohorts\/(?<cohortId>[^/]+)(?:\/)?$/
+      })
+    };
+
+    await apmTransaction({}, transaction, { req });
+
+    expect(transaction.addLabels).toHaveBeenCalledWith({ cohortId: 'TopTen%' });
+  });
 });

--- a/packages/gasket-plugin-nextjs/test/apm-transaction.test.js
+++ b/packages/gasket-plugin-nextjs/test/apm-transaction.test.js
@@ -21,6 +21,7 @@ describe('The apmTransaction hook', () => {
 
   it('returns the page name if the route is for a page', async () => {
     const req = {
+      url: '/customer/123',
       getNextRoute: async () => ({
         page: '/customer/[id]',
         namedRegex: /^\/customer\/(?<id>[^/]+)(?:\/)?$/
@@ -66,5 +67,19 @@ describe('The apmTransaction hook', () => {
     await apmTransaction({}, transaction, { req });
 
     expect(transaction.addLabels).toHaveBeenCalledWith({ cohortId: 'TopTen%' });
+  });
+
+  it('ignores the query string when parsing the route', async () => {
+    const req = {
+      url: '/cohorts/Rad%20People?utm_source=TDFS_DASLNC&utm_medium=parkedpages&utm_campaign=x_corp_tdfs-daslnc_base&traffic_type=TDFS_DASLNC&traffic_id=daslnc&sayfa=20&act=ul&listurun=12&sublastcat=&subcat=61&marka=&sort=2&catname=Realistik%20Belden%20Ba%F0lamal%FD',
+      getNextRoute: async () => ({
+        page: '/cohorts/[cohortId]',
+        namedRegex: /^\/cohorts\/(?<cohortId>[^/]+)(?:\/)?$/
+      })
+    };
+
+    await apmTransaction({}, transaction, { req });
+
+    expect(transaction.addLabels).toHaveBeenCalledWith({ cohortId: 'Rad People' });
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Somehow, bad URLs are making it through the layers to elastic APM transaction labeling. Ensure that if we cannot URL-decode segments in next.js routes paths they're still usable as labels. We're also not properly omitting query parameters from the regex match which will add unwanted extras to the labels.

[Support thread for context](https://godaddy.slack.com/archives/CABCTNQ5P/p1712599592510309)

## Changelog

- (fix) Handle malformed URL segments in Elastic APM transaction labeling
- (fix) Omit query parameters when parsing next.js route labels

## Test Plan

Added unit test