### PR TITLE
makeGasket lifecycles and order

### DIFF
--- a/packages/gasket-core/README.md
+++ b/packages/gasket-core/README.md
@@ -149,5 +149,8 @@ In this example, we register an action `getDoodads` that will only execute if th
 It will then execute the `doodads` lifecycle, allowing any registered plugin to
 provide doodads.
 
+[init]: #init 
+[actions]: #actions 
+[configure]: #configure 
 [registered plugins]: #registered-plugins
 [Plugins Guide]:/packages/gasket-cli/docs/plugins.md

--- a/packages/gasket-core/lib/index.d.ts
+++ b/packages/gasket-core/lib/index.d.ts
@@ -12,8 +12,9 @@ declare module '@gasket/engine' {
   }
 
   export interface HookExecTypes {
-    configure(config: GasketConfig): GasketConfig
+    init(): void
     actions(): GasketActions
+    configure(config: GasketConfig): GasketConfig
   }
 }
 

--- a/packages/gasket-core/lib/index.js
+++ b/packages/gasket-core/lib/index.js
@@ -74,13 +74,18 @@ class Gasket extends GasketEngine {
     config.env = env;
     config.root ??= process.cwd();
 
+    // start the engine
     super(config.plugins);
+
+    this.config = config;
     this.command = null;
-    this.config = this.execWaterfallSync('configure', config);
+    this.execSync('init');
     this.actions = registerActions(this);
+    this.config = this.execWaterfallSync('configure', config);
   }
 }
 
+// TODO: Add JSDoc types
 export function makeGasket(gasketConfigDefinition) {
   return new Gasket(gasketConfigDefinition);
 }

--- a/packages/gasket-plugin-logger/README.md
+++ b/packages/gasket-plugin-logger/README.md
@@ -11,8 +11,8 @@ custom logger: `@gasket/plugin-winston`.
 
 ### createLogger
 
-To implement a custom logger, hook the `createLogger` lifecycle. Your hook,
-which may be asynchronous, must return an object with this shape:
+To implement a custom logger, hook the `createLogger` lifecycle.
+Your hook must be synchronous and return an object with this shape:
 
 ```typescript
 type Logger = {

--- a/packages/gasket-plugin-logger/lib/index.d.ts
+++ b/packages/gasket-plugin-logger/lib/index.d.ts
@@ -16,6 +16,6 @@ declare module '@gasket/engine' {
   }
 
   export interface HookExecTypes {
-    createLogger(): MaybeAsync<Logger>
+    createLogger(): Logger
   }
 }

--- a/packages/gasket-plugin-logger/lib/index.js
+++ b/packages/gasket-plugin-logger/lib/index.js
@@ -52,7 +52,7 @@ module.exports = {
         lifecycles: [
           {
             name: 'createLogger',
-            method: 'exec',
+            method: 'execSync',
             description: 'Custom logger creation',
             link: 'README.md#createLogger',
             parent: 'init'

--- a/packages/gasket-plugin-logger/lib/index.js
+++ b/packages/gasket-plugin-logger/lib/index.js
@@ -23,8 +23,9 @@ function verifyLoggerLevels(logger) {
 module.exports = {
   name,
   hooks: {
-    async init(gasket) {
-      const loggers = await gasket.exec('createLogger');
+    init(gasket) {
+      // eslint-disable-next-line no-sync
+      const loggers = gasket.execSync('createLogger');
       if (!loggers || loggers.length === 0) {
         gasket.logger = {
           debug: console.debug,

--- a/packages/gasket-plugin-logger/test/index.test.js
+++ b/packages/gasket-plugin-logger/test/index.test.js
@@ -108,7 +108,7 @@ describe('@gasket/plugin-logger', () => {
             lifecycles: expect.arrayContaining([
               expect.objectContaining({
                 name: 'createLogger',
-                method: 'exec',
+                method: 'execSync',
                 description: 'Custom logger creation',
                 link: 'README.md#createLogger',
                 parent: 'init'

--- a/packages/gasket-plugin-logger/test/index.test.js
+++ b/packages/gasket-plugin-logger/test/index.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, no-sync */
 const { name, hooks } = require('../lib'); // Update the path accordingly
 
 // Mock console methods
@@ -29,7 +29,7 @@ describe('@gasket/plugin-logger', () => {
 
     beforeEach(() => {
       gasket = {
-        exec: jest.fn(),
+        execSync: jest.fn(),
         logger: null
       };
     });
@@ -37,17 +37,17 @@ describe('@gasket/plugin-logger', () => {
     describe('init', () => {
       it('should set logger from the first plugin if only one logger is hooked', async () => {
         const fakeLogger = { ...mockLogger };
-        gasket.exec.mockResolvedValue([fakeLogger]);
+        gasket.execSync.mockReturnValue([fakeLogger]);
 
-        await hooks.init(gasket);
+        hooks.init(gasket);
 
         expect(gasket.logger).toEqual(fakeLogger);
       });
 
       it('should set logger to default if no loggers are hooked', async () => {
-        gasket.exec.mockResolvedValue([]);
+        gasket.execSync.mockReturnValue([]);
 
-        await hooks.init(gasket);
+        hooks.init(gasket);
 
         // Check default logger behavior
         const childLogger = gasket.logger.child({ key: 'value' });
@@ -75,9 +75,10 @@ describe('@gasket/plugin-logger', () => {
       it('should throw an error if multiple loggers are hooked', async () => {
         const fakeLogger1 = { error: jest.fn() };
         const fakeLogger2 = { error: jest.fn() };
-        gasket.exec.mockResolvedValue([fakeLogger1, fakeLogger2]);
+        gasket.execSync.mockReturnValue([fakeLogger1, fakeLogger2]);
 
-        await expect(hooks.init(gasket)).rejects.toThrow(
+        // eslint-disable-next-line max-nested-callbacks
+        expect(() => hooks.init(gasket)).toThrow(
           'Multiple plugins are hooking createLogger. Only one logger is supported.'
         );
       });

--- a/packages/gasket-plugin-metadata/lib/index.js
+++ b/packages/gasket-plugin-metadata/lib/index.js
@@ -12,6 +12,7 @@ const {
 module.exports = {
   name: require('../package').name,
   hooks: {
+    // TODO: convert to a getMetadata action
     async init(gasket) {
       const { loader, config } = gasket;
       const { root = process.cwd() } = config;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

To allow an earlier entry into gasket instance setup, we'll bring back the `init` hook as a synchronous lifecycle. Also ordering `actions` lifecycle to execute before `configure` to make Actions available during that lifecycle.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/core**
- Add `init` lifecycle with `actions` before `configure`

**@gasket/plugin-logger**
- Update `init` hook to be sync and execute `createLoggers` as sync

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

- Updated unit tests

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
