### PR TITLE
Ensure gasket/core is not bundled to allow GASKET_ENV

### DIFF
--- a/packages/gasket-plugin-nextjs/lib/index.js
+++ b/packages/gasket-plugin-nextjs/lib/index.js
@@ -3,6 +3,7 @@ const url = require('url');
 const { name } = require('../package');
 const { createConfig } = require('./config');
 const create = require('./create');
+const { webpackConfig } = require('./webpack-config');
 const prompt = require('./prompt');
 const { setupNextApp, setupNextHandling } = require('./setup-next-app');
 const getNextRoute = require('./next-route');
@@ -17,6 +18,7 @@ module.exports = {
   name,
   hooks: {
     configure,
+    webpackConfig,
     actions(gasket) {
       return {
         getNextConfig(nextConfig) {

--- a/packages/gasket-plugin-nextjs/lib/webpack-config.js
+++ b/packages/gasket-plugin-nextjs/lib/webpack-config.js
@@ -1,5 +1,13 @@
 const isGasketCore = /@gasket[/\\](core)/;
 
+/**
+ * Function to validate that '@gasket/core' is not used in browser code.
+ * If '@gasket/core' is found in the module request, an error is thrown.
+ *
+ * @param {Object} ctx - The context object containing the request string.
+ * @param {Function} callback - The externals callback.
+ * @returns {void}
+ */
 function validateNoGasketCore(ctx, callback) {
   if (isGasketCore.test(ctx.request)) {
     return callback(new Error('@gasket/core should not be used in browser code.'));
@@ -12,9 +20,9 @@ function validateNoGasketCore(ctx, callback) {
  * We do this to enable GASKET_ENV to be picked up and passed to the plugins.
  * Otherwise, unique builds per environment would be required.
  *
- * @param ctx
- * @param callback
- * @returns {*}
+ * @param {Object} ctx - The context object containing the request string.
+ * @param {Function} callback - The externals callback.
+ * @returns {void|*}
  */
 function externalizeGasketCore(ctx, callback) {
   if (isGasketCore.test(ctx.request)) {

--- a/packages/gasket-plugin-nextjs/lib/webpack-config.js
+++ b/packages/gasket-plugin-nextjs/lib/webpack-config.js
@@ -1,0 +1,57 @@
+const isGasketCore = /@gasket[/\\](core)/;
+
+function validateNoGasketCore(ctx, callback) {
+  if (isGasketCore.test(ctx.request)) {
+    return callback(new Error('@gasket/core should not be used in browser code.'));
+  }
+  return callback();
+}
+
+/**
+ * Externalize @gasket/core in the server build.
+ * We do this to enable GASKET_ENV to be picked up and passed to the plugins.
+ * Otherwise, unique builds per environment would be required.
+ *
+ * @param ctx
+ * @param callback
+ * @returns {*}
+ */
+function externalizeGasketCore(ctx, callback) {
+  if (isGasketCore.test(ctx.request)) {
+    const externalsType = ctx.dependencyType === 'esm' ? 'module' : 'commonjs';
+    return callback(null, [externalsType, ctx.request].join(' '));
+  }
+  return callback();
+}
+
+/**
+ * Configure Next.js Webpack for @gasket/core
+ *
+ * @param {Object} gasket - The gasket API.
+ * @param {Object} webpackConfig - Initial Next.js webpack config
+ * @returns {Object} Partial webpack config with UXCore2 support.
+ * @public
+ */
+function webpackConfigHook(gasket, webpackConfig) {
+  if (webpackConfig.name === 'client') {
+    webpackConfig.externals.unshift(validateNoGasketCore);
+  } else {
+    webpackConfig.externals.unshift(externalizeGasketCore);
+
+    // TODO: If we find a reason NOT to externalized the core package,
+    //  then we must set the GASKET_ENV which requires builds per environment.
+    // webpackConfig.plugins.push(
+    //   new webpack.EnvironmentPlugin({
+    //     GASKET_ENV: gasket.config.env
+    //   })
+    // );
+  }
+
+  return webpackConfig;
+}
+
+module.exports = {
+  validateNoGasketCore,
+  externalizeGasketCore,
+  webpackConfig: webpackConfigHook
+};

--- a/packages/gasket-plugin-nextjs/lib/webpack-config.js
+++ b/packages/gasket-plugin-nextjs/lib/webpack-config.js
@@ -1,4 +1,4 @@
-const isGasketCore = /@gasket[/\\](core)/;
+const isGasketCore = /@gasket[/\\]core$/;
 
 /**
  * Function to validate that '@gasket/core' is not used in browser code.
@@ -37,11 +37,13 @@ function externalizeGasketCore(ctx, callback) {
  *
  * @param {Object} gasket - The gasket API.
  * @param {Object} webpackConfig - Initial Next.js webpack config
+ * @param {Object} context - Next.js build options
+ * @param {Object} context.isServer - Is this a server build?
  * @returns {Object} Partial webpack config with UXCore2 support.
  * @public
  */
-function webpackConfigHook(gasket, webpackConfig) {
-  if (webpackConfig.name === 'client') {
+function webpackConfigHook(gasket, webpackConfig, { isServer }) {
+  if (!isServer) {
     webpackConfig.externals.unshift(validateNoGasketCore);
   } else {
     webpackConfig.externals.unshift(externalizeGasketCore);

--- a/packages/gasket-plugin-nextjs/test/index.test.js
+++ b/packages/gasket-plugin-nextjs/test/index.test.js
@@ -55,6 +55,7 @@ describe('Plugin', function () {
       'metadata',
       'middleware',
       'prompt',
+      'webpackConfig',
       'workbox'
     ];
 

--- a/packages/gasket-plugin-nextjs/test/webpack-config.test.js
+++ b/packages/gasket-plugin-nextjs/test/webpack-config.test.js
@@ -1,7 +1,7 @@
 const { webpackConfig, validateNoGasketCore, externalizeGasketCore } = require('../lib/webpack-config.js');
 
 describe('webpackConfigHook', () => {
-  let mockGasket, mockWebpackConfig;
+  let mockGasket, mockWebpackConfig, mockContext;
 
   beforeEach(() => {
     mockGasket = {};
@@ -9,17 +9,17 @@ describe('webpackConfigHook', () => {
       name: '',
       externals: []
     };
+    mockContext = {};
   });
 
   it('adds validateNoGasketCore to externals for client', () => {
-    mockWebpackConfig.name = 'client';
-    const result = webpackConfig(mockGasket, mockWebpackConfig);
+    const result = webpackConfig(mockGasket, mockWebpackConfig, mockContext);
     expect(result.externals[0]).toBe(validateNoGasketCore);
   });
 
   it('adds externalizeGasketCore to externals for server', () => {
-    mockWebpackConfig.name = 'server';
-    const result = webpackConfig(mockGasket, mockWebpackConfig);
+    mockContext.isServer = true;
+    const result = webpackConfig(mockGasket, mockWebpackConfig, mockContext);
     expect(result.externals[0]).toBe(externalizeGasketCore);
   });
 });
@@ -53,6 +53,14 @@ describe('externalizeGasketCore', () => {
     mockCtx.request = 'other-package';
     externalizeGasketCore(mockCtx, mockCallback);
     expect(mockCallback).toHaveBeenCalledWith();
+  });
+
+  it('avoids closely name packages', () => {
+    mockCtx.request = '@gasket/core-utils';
+    mockCtx.dependencyType = 'esm';
+    externalizeGasketCore(mockCtx, mockCallback);
+    expect(mockCallback).toHaveBeenCalledWith();
+    expect(mockCallback).not.toHaveBeenCalledWith(null, 'module @gasket/core-utils');
   });
 });
 

--- a/packages/gasket-plugin-nextjs/test/webpack-config.test.js
+++ b/packages/gasket-plugin-nextjs/test/webpack-config.test.js
@@ -1,0 +1,80 @@
+const { webpackConfig, validateNoGasketCore, externalizeGasketCore } = require('../lib/webpack-config.js');
+
+describe('webpackConfigHook', () => {
+  let mockGasket, mockWebpackConfig;
+
+  beforeEach(() => {
+    mockGasket = {};
+    mockWebpackConfig = {
+      name: '',
+      externals: []
+    };
+  });
+
+  it('adds validateNoGasketCore to externals for client', () => {
+    mockWebpackConfig.name = 'client';
+    const result = webpackConfig(mockGasket, mockWebpackConfig);
+    expect(result.externals[0]).toBe(validateNoGasketCore);
+  });
+
+  it('adds externalizeGasketCore to externals for server', () => {
+    mockWebpackConfig.name = 'server';
+    const result = webpackConfig(mockGasket, mockWebpackConfig);
+    expect(result.externals[0]).toBe(externalizeGasketCore);
+  });
+});
+
+describe('externalizeGasketCore', () => {
+  let mockCtx, mockCallback;
+
+  beforeEach(() => {
+    mockCtx = {
+      request: '',
+      dependencyType: ''
+    };
+    mockCallback = jest.fn();
+  });
+
+  it('returns module type for esm dependency when request matches gasket core', () => {
+    mockCtx.request = '@gasket/core';
+    mockCtx.dependencyType = 'esm';
+    externalizeGasketCore(mockCtx, mockCallback);
+    expect(mockCallback).toHaveBeenCalledWith(null, 'module @gasket/core');
+  });
+
+  it('returns commonjs type for non-esm dependency when request matches gasket core', () => {
+    mockCtx.request = '@gasket/core';
+    mockCtx.dependencyType = 'commonjs';
+    externalizeGasketCore(mockCtx, mockCallback);
+    expect(mockCallback).toHaveBeenCalledWith(null, 'commonjs @gasket/core');
+  });
+
+  it('returns undefined when request does not match gasket core', () => {
+    mockCtx.request = 'other-package';
+    externalizeGasketCore(mockCtx, mockCallback);
+    expect(mockCallback).toHaveBeenCalledWith();
+  });
+});
+
+describe('validateNoGasketCore', () => {
+  let mockCtx, mockCallback;
+
+  beforeEach(() => {
+    mockCtx = {
+      request: ''
+    };
+    mockCallback = jest.fn();
+  });
+
+  it('throws error when request matches gasket core', () => {
+    mockCtx.request = '@gasket/core';
+    validateNoGasketCore(mockCtx, mockCallback);
+    expect(mockCallback).toHaveBeenCalledWith(new Error('@gasket/core should not be used in browser code.'));
+  });
+
+  it('does not throw error when request does not match gasket core', () => {
+    mockCtx.request = 'other-package';
+    validateNoGasketCore(mockCtx, mockCallback);
+    expect(mockCallback).toHaveBeenCalledWith();
+  });
+});


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

With gasket files, being imported into app code, `@gasket/core` was being bundled. When this happens, any process.env vars are not captured, including `GASKET_ENV` which is necessary for configuring gaskets to be run in different environments.

Without this change, it would be necessary to `next build` uniquely for each environment.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/plugin-nextjs**
- Add Webpack externals for `@gasket/core` in Next.js apps.

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

N/A

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
