### PR TITLE
[PFX-601] - @gasket/plugin-lint fix

### DIFF
--- a/packages/gasket-plugin-lint/CHANGELOG.md
+++ b/packages/gasket-plugin-lint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `@gasket/plugin-lint`
 
+
+
+- Adjust makeGatherDeps to add devDeps
+
 ### 6.45.2
 
 - Tune `devDeps` ([#670])
@@ -110,3 +114,4 @@
 [#460]: https://github.com/godaddy/gasket/pull/460
 [#482]: https://github.com/godaddy/gasket/pull/482
 [#670]: https://github.com/godaddy/gasket/pull/670
+[#747]: https://github.com/godaddy/gasket/pull/747

--- a/packages/gasket-plugin-lint/lib/utils.js
+++ b/packages/gasket-plugin-lint/lib/utils.js
@@ -33,10 +33,12 @@ function makeGatherDevDeps(context) {
 
     const full = `${parsedName}@${version.trim()}`;
     const peerDeps = (await pkgManager.info([full, 'peerDependencies'])).data;
+    const devDeps = (await pkgManager.info([full, 'devDependencies'])).data;
 
     return {
       [parsedName]: parsedVersion || `^${version}`,
-      ...(peerDeps || {})
+      ...(peerDeps || {}),
+      ...(devDeps || {})
     };
   };
 }


### PR DESCRIPTION


<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

#### Issue

`Invalid option '--ext' - perhaps you meant '-c'?`. Eslint version 9 was making it's way into apps causing this error. The reason is the loose version range that's added to the `devDeps` of the app. The [version is derived from the config](https://github.com/godaddy/javascript/blob/main/packages/eslint-config-godaddy/package.json) and added in the `makeGatherDevDeps` function [here](https://github.com/godaddy/gasket/blob/v7/packages/gasket-plugin-lint/lib/utils.js#L39).

#### Solution

Rather than remove the `peerDep` logic, we just also gather the `devDeps` and spread them last in the return statement. A `peerDep` that is not a `devDep` will still work correctly and as with the case of `eslint` it is [both a peerDep and devDep](https://github.com/godaddy/javascript/blob/main/packages/eslint-config-godaddy/package.json#L29-L37) so the [last spread will win](https://github.com/godaddy/gasket/blob/PFX-601/packages/gasket-plugin-lint/lib/utils.js#L39-L41).
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

- Adjust `makeGatherDeps` to add `devDeps` 
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
- Test case adjusted
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
