### PR TITLE
[PFX-606] - create-gasket-app force env to create

### DIFF
--- a/packages/create-gasket-app/CHANGELOG.md
+++ b/packages/create-gasket-app/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 - Modified global test prompt to ask for unit and integration tests ([#752])
+- Force `GASKET_ENV` to create
 - Add preset lifecycles `presetPrompt` and `presetConfig` ([#736])
 - ESM refactor, package is now type module
 - Gasket apps default to `type: module`

--- a/packages/create-gasket-app/lib/commands/create.js
+++ b/packages/create-gasket-app/lib/commands/create.js
@@ -103,6 +103,7 @@ const createCommand = {
  * @returns {Promise<void>} void
  */
 createCommand.action = async function run(appname, options, command) {
+  process.env.GASKET_ENV = 'create';
   const context = makeCreateContext([appname], options);
   const { rawPresets, localPresets } = context;
 

--- a/packages/create-gasket-app/test/unit/commands/create.test.js
+++ b/packages/create-gasket-app/test/unit/commands/create.test.js
@@ -58,6 +58,11 @@ describe('create', function () {
     jest.clearAllMocks();
   });
 
+  it('should force GASKE_ENV to create', async () => {
+    await cmd.parseAsync(['node', 'gasket', 'create', 'myapp']);
+    expect(process.env.GASKET_ENV).toEqual('create');
+  });
+
   it('should have expected args', () => {
     const args = cmd.commands[0]._args;
     expect(CreateCommand.args.length).toEqual(args.length);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
Force the env to create to prevent the logging in the flow from `getEnvironment`.
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
- Force `GASKET_ENV` to create
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
Test case added.
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
