### PR TITLE
[PFX-117] - Fix Yarn validation

### DIFF
--- a/packages/create-gasket-app/lib/scaffold/actions/load-preset.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/load-preset.js
@@ -20,7 +20,7 @@ async function loadPresets({ context }) {
     packageManager: context.packageManager,
     dest: tmpDir
   });
-  const pkgVerb = pkgManager.isYarn ? 'add' : 'install';
+  const pkgVerb = pkgManager.manager ? 'add' : 'install';
 
   const remotePresets = context.rawPresets.map(async preset => {
     const parts = hasVersion.test(preset) && preset.split('@').filter(Boolean);

--- a/packages/create-gasket-app/lib/scaffold/actions/load-preset.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/load-preset.js
@@ -20,7 +20,7 @@ async function loadPresets({ context }) {
     packageManager: context.packageManager,
     dest: tmpDir
   });
-  const pkgVerb = pkgManager.manager ? 'add' : 'install';
+  const pkgVerb = pkgManager.manager === 'yarn' ? 'add' : 'install';
 
   const remotePresets = context.rawPresets.map(async preset => {
     const parts = hasVersion.test(preset) && preset.split('@').filter(Boolean);

--- a/packages/create-gasket-app/test/unit/scaffold/actions/load-preset.test.js
+++ b/packages/create-gasket-app/test/unit/scaffold/actions/load-preset.test.js
@@ -10,9 +10,8 @@ jest.mock('@gasket/utils', () => {
   return {
     PackageManager: class MockPackageManager {
       constructor({ packageManager, dest }) {
-        this.packageManager = packageManager;
+        this.manager = packageManager;
         this.dest = dest;
-        this.isYarn = packageManager === 'yarn';
         mockConstructorStub(...arguments);
       }
       async exec() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
Load preset was referencing a non-existent property of the package manager. Update to reference the correct property to toggle the package manager. Private registry support is available with `yarn` via the `YARN_REGISTRY` CLI arg. There's issues with support for multiple registries that should be handled in another ticket. Yarn finds the internal packages but throws errors about not finding packages from the `npm` registry.

- [Follow-up ticket](https://godaddy-corp.atlassian.net/browse/PFX-634)
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
![Screenshot 2024-05-23 at 1 46 43 PM](https://github.com/godaddy/gasket/assets/105235096/cbf3ca9f-9bbc-4373-88f5-1a08896b0ec6)

## Changelog
- Fix property to derive the correct package manager
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
Update tests
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
