### PR TITLE
Use cjs extension for gasket-data

### DIFF
--- a/packages/gasket-data/package.json
+++ b/packages/gasket-data/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "import": "./lib/index.js",
-      "require": "./cjs/index.js",
+      "require": "./cjs/index.cjs",
       "types": "./lib/index.d.ts"
     }
   },
@@ -24,7 +24,7 @@
     "posttest": "npm run lint && npm run typecheck",
     "typecheck": "tsc",
     "typecheck:watch": "tsc --watch",
-    "build": "swc lib -d cjs --delete-dir-on-start --strip-leading-paths",
+    "build": "swc lib -d cjs --delete-dir-on-start --strip-leading-paths --out-file-extension cjs",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/packages/gasket-data/tsconfig.json
+++ b/packages/gasket-data/tsconfig.json
@@ -16,6 +16,7 @@
   },
   "exclude": [
     "test",
-    "coverage"
+    "coverage",
+    "cjs",
   ]
 }

--- a/packages/gasket-react-intl/package.json
+++ b/packages/gasket-react-intl/package.json
@@ -3,8 +3,6 @@
   "version": "7.0.0-next.32",
   "description": "React component library to enable localization for gasket apps.",
   "main": "lib",
-  "browser": "lib",
-  "module": "src",
   "types": "src/index.d.ts",
   "files": [
     "lib",

--- a/packages/gasket-redux/package.json
+++ b/packages/gasket-redux/package.json
@@ -3,8 +3,6 @@
   "version": "7.0.0-next.32",
   "description": "Gasket Redux Configuration",
   "main": "lib",
-  "browser": "lib",
-  "module": "src",
   "types": "src/index.d.ts",
   "files": [
     "lib",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Work-around for importing commonjs packages, that require `@gasket/data`. Seems to only be an issue with Jest tests where the package is `type: module`.

Also cleaning up legacy `module:src` package fields.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/data**
- Transpile with .cjs extension

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

N/A

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
