### PR TITLE
fix(create-gasket-app): allow specifying tags for presets

### DIFF
--- a/packages/create-gasket-app/lib/scaffold/actions/load-preset.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/load-preset.js
@@ -5,7 +5,7 @@ import { default as gasketUtils } from '@gasket/utils';
 import { mkdtemp } from 'fs/promises';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const hasVersion = /@(\^[0-9]\.|[0-9]).+/;
+const hasVersionOrTag = /@([\^~]?\d+\.\d+\.\d+(?:-[\d\w.-]+)?|[\^~]?\d+\.\d+\.\d+|[a-zA-Z]+)$/;
 
 /**
  * loadPresets - Load presets to temp directory
@@ -23,7 +23,7 @@ async function loadPresets({ context }) {
   const pkgVerb = pkgManager.manager === 'yarn' ? 'add' : 'install';
 
   const remotePresets = context.rawPresets.map(async preset => {
-    const parts = hasVersion.test(preset) && preset.split('@').filter(Boolean);
+    const parts = hasVersionOrTag.test(preset) && preset.split('@').filter(Boolean);
     const name = parts ? `@${parts[0]}` : preset;
     const version = parts ? `@${parts[1]}` : '@latest';
 

--- a/packages/create-gasket-app/test/unit/scaffold/actions/load-preset.test.js
+++ b/packages/create-gasket-app/test/unit/scaffold/actions/load-preset.test.js
@@ -221,4 +221,15 @@ describe('loadPreset', () => {
     ]);
     expect(mockContext.presets).toHaveLength(2);
   });
+
+  it('support preset with tags', async () => {
+    mockContext.rawPresets = ['@gasket/preset-bogus@canary', '@gasket/preset-all-i-ever-wanted@next'];
+
+    await loadPreset({ context: mockContext });
+    expect(mockContext).toHaveProperty('presets', [
+      expect.objectContaining(presetBogus),
+      expect.objectContaining(presetAllIEverWanted)
+    ]);
+    expect(mockContext.presets).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
`create-gasket-app api --presets @gasket/preset-api@next` was failing

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
modify regex to also match tags

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
- updated tests
- verified `create-gasket-app api --presets @gasket/preset-api@next` works now

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
