### PR TITLE
Exclude gaskets from client bundling

### DIFF
--- a/packages/create-gasket-app/CHANGELOG.md
+++ b/packages/create-gasket-app/CHANGELOG.md
@@ -1,6 +1,6 @@
 # `create-gasket-app`
 
-
+- Exclude gaskets from client bundling ([#806])
 - Modified global test prompt to ask for unit and integration tests ([#752])
 - Force `GASKET_ENV` to create
 - Add preset lifecycles `presetPrompt` and `presetConfig` ([#736])
@@ -62,3 +62,4 @@
 [#712]: https://github.com/godaddy/gasket/pull/712
 [#736]: https://github.com/godaddy/gasket/pull/736
 [#752]: https://github.com/godaddy/gasket/pull/752
+[#806]: https://github.com/godaddy/gasket/pull/806

--- a/packages/create-gasket-app/lib/scaffold/actions/write-gasket-config.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/write-gasket-config.js
@@ -96,6 +96,7 @@ async function writeGasketConfig({ context }) {
   const assignments = gasketConfig.fields.injectionAssignments || null;
   const expressions = gasketConfig.fields.expressions || null;
   gasketConfig.fields.plugins = 'PLUGIN_REPLACE';
+  gasketConfig.fields.filename = 'FILENAME_REPLACE';
 
   let contents = '';
   contents += `import { makeGasket } from '@gasket/core';\n`;
@@ -107,6 +108,7 @@ async function writeGasketConfig({ context }) {
 
   const pluginImports = `[\n${writePluginImports(plugins)}\n\t]`;
   contents += `\nexport default makeGasket(${JSON5.stringify(gasketConfig.fields, null, 2)});\n`;
+  contents = contents.replace('\'FILENAME_REPLACE\'', 'import.meta.filename');
   contents = contents.replace('\'PLUGIN_REPLACE\'', pluginImports);
   contents = replaceInjectionAssignments(contents, assignments);
 

--- a/packages/create-gasket-app/test/unit/scaffold/actions/write-gasket-config.test.js
+++ b/packages/create-gasket-app/test/unit/scaffold/actions/write-gasket-config.test.js
@@ -61,6 +61,12 @@ describe('write-gasket-config', () => {
     expect(output).toContain('plugins:');
   });
 
+  it('writes filename', async () => {
+    await writeGasketConfig({ context: mockContext });
+    const output = mockWriteStub.mock.calls[0][1];
+    expect(output).toContain('filename: import.meta.filename');
+  });
+
   it('outputs keys without quotes, strings with single-quotes', async () => {
     mockContext.gasketConfig.add("bogus", "double"); // eslint-disable-line quotes
     await writeGasketConfig({ context: mockContext });

--- a/packages/gasket-core/lib/index.d.ts
+++ b/packages/gasket-core/lib/index.d.ts
@@ -50,10 +50,11 @@ declare module '@gasket/core' {
 
   // This is the config
   export interface GasketConfig {
-    filename?: string;
     plugins: Array<Plugin>;
     root: string;
     env: string;
+    /** Path to the gasket instance file. Can be set to `import.meta.filename` **/
+    filename?: string;
   }
 
   export class GasketEngine {

--- a/packages/gasket-core/lib/index.d.ts
+++ b/packages/gasket-core/lib/index.d.ts
@@ -40,8 +40,8 @@ declare module '@gasket/core' {
 
   export type Plugin = {
     name: string;
-    version: string;
-    description: string;
+    version?: string;
+    description?: string;
     dependencies?: Array<string>;
     hooks: {
       [K in HookId]?: Hook<K>;
@@ -50,6 +50,7 @@ declare module '@gasket/core' {
 
   // This is the config
   export interface GasketConfig {
+    filename?: string;
     plugins: Array<Plugin>;
     root: string;
     env: string;

--- a/packages/gasket-core/lib/index.js
+++ b/packages/gasket-core/lib/index.js
@@ -31,11 +31,11 @@ function getEnvironment(
 
   const { NODE_ENV } = process.env;
   if (NODE_ENV) {
-    console.warn(`No env specified, falling back to NODE_ENV: "${NODE_ENV}".`);
+    console.warn(`No GASKET_ENV specified, falling back to NODE_ENV: "${NODE_ENV}".`);
     return NODE_ENV;
   }
 
-  console.warn('No env specified, falling back to "development".');
+  console.warn('No GASKET_ENV specified, falling back to "development".');
   return 'development';
 }
 /* eslint-enable no-console, no-process-env */

--- a/packages/gasket-plugin-nextjs/CHANGELOG.md
+++ b/packages/gasket-plugin-nextjs/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `@gasket/plugin-nextjs`
 
+- Exclude gaskets from client bundling ([#806])
 - Convert cjs sitemap config to esm ([#798])
 - Added useAppRouter optional flag ([#777])
 - Convert store.js to esm ([#799])
@@ -292,4 +293,5 @@
 [#778]: https://github.com/godaddy/gasket/pull/778
 [#798]: https://github.com/godaddy/gasket/pull/798
 [#799]: https://github.com/godaddy/gasket/pull/799
+[#806]: https://github.com/godaddy/gasket/pull/806
 

--- a/packages/gasket-plugin-nextjs/lib/webpack-config.js
+++ b/packages/gasket-plugin-nextjs/lib/webpack-config.js
@@ -36,6 +36,14 @@ function externalizeGasketCore(ctx, callback) {
 function webpackConfigHook(gasket, webpackConfig, { isServer }) {
   if (Array.isArray(webpackConfig.externals)) {
     if (!isServer) {
+      if ('filename' in gasket.config) {
+        webpackConfig.resolve ??= {};
+        webpackConfig.resolve.alias ??= {};
+        webpackConfig.resolve.alias[gasket.config.filename] = false;
+      } else {
+        gasket.logger.warn('Gasket `filename` was not configured in makeGasket');
+      }
+
       webpackConfig.externals.unshift(validateNoGasketCore);
     } else {
       webpackConfig.externals.unshift(externalizeGasketCore);
@@ -48,7 +56,8 @@ function webpackConfigHook(gasket, webpackConfig, { isServer }) {
       //   })
       // );
     }
-    // TODO: throw or something if externals is NOT an array
+  } else {
+    throw new Error('Expected webpackConfig.externals to be an array');
   }
 
   return webpackConfig;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

In order to allow gaskets to be imported for server-side `getInitialProps` usage cases, we need to ensure they are not attempted to be bundled for the browser.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**create-gasket-app**
- Default generate gaskets with filename configured

**@gasket/plugin-nextjs**
- Add false alias for gasket filenames for client bundling

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

Locally tested by calling `/path/to/gasket/packages/create-gasket-app/lib/index.js`