### PR TITLE
Fix locale files loading multiple times

### DIFF
--- a/packages/gasket-react-intl/src/context.js
+++ b/packages/gasket-react-intl/src/context.js
@@ -4,7 +4,7 @@ import { manifest } from './config';
 /** @type {import('./index').GasketIntlContext} */
 const defaultContext = {
   locale: manifest.defaultLocale,
-  status: {},
+  status: {}
 };
 
 export const GasketIntlContext = React.createContext(defaultContext);

--- a/packages/gasket-react-intl/src/context.js
+++ b/packages/gasket-react-intl/src/context.js
@@ -3,7 +3,8 @@ import { manifest } from './config';
 
 /** @type {import('./index').GasketIntlContext} */
 const defaultContext = {
-  locale: manifest.defaultLocale
+  locale: manifest.defaultLocale,
+  status: {},
 };
 
 export const GasketIntlContext = React.createContext(defaultContext);

--- a/packages/gasket-react-intl/src/index.d.ts
+++ b/packages/gasket-react-intl/src/index.d.ts
@@ -3,7 +3,8 @@ import {
   LocalePathPartOrThunk,
   LocaleStatus,
   LocalesProps,
-  LocalesState
+  LocalesState,
+  LocalePath
 } from '@gasket/helper-intl';
 import type { GasketData } from '@gasket/data';
 import type { IncomingMessage, ServerResponse } from 'http';
@@ -119,7 +120,7 @@ declare module '@gasket/data' {
 
 export interface GasketIntlContext {
   locale: string;
-  status?: LocaleStatus;
+  status?: Record<LocalePath, LocaleStatus>;
   dispatch?: React.Dispatch<{
     type: string;
     payload: {};

--- a/packages/gasket-react-intl/src/with-intl-provider.js
+++ b/packages/gasket-react-intl/src/with-intl-provider.js
@@ -12,7 +12,7 @@ import { getActiveLocale, LocaleStatus } from './utils';
  * @type {import('./index').init}
  */
 export function init(localesProps) {
-  const { messages = {}, status } = localesProps;
+  const { messages = {}, status = {} } = localesProps;
 
   if (isBrowser) {
     // merge any data set on window with what comes from SSR or static page

--- a/packages/gasket-react-intl/test/use-locale-required.test.js
+++ b/packages/gasket-react-intl/test/use-locale-required.test.js
@@ -50,6 +50,7 @@ describe('useLocaleRequired', function () {
     const results = useLocaleRequired('/locales');
     expect(results).toEqual(LOADING);
     expect(fetch).toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith('/locales/en.json');
   });
 
@@ -121,6 +122,7 @@ describe('useLocaleRequired', function () {
       const results = useLocaleRequired(['/locales', '/custom/locales', 'modules/module/locales']);
       expect(results).toEqual(LOADING);
       expect(fetch).toHaveBeenCalled();
+      expect(fetch).toHaveBeenCalledTimes(3);
       expect(fetch).toHaveBeenCalledWith('/locales/en.json');
       expect(fetch).toHaveBeenCalledWith('/custom/locales/en.json');
       expect(fetch).toHaveBeenCalledWith('/modules/module/locales/en.json');

--- a/packages/gasket-react-intl/test/with-intl-provider.test.js
+++ b/packages/gasket-react-intl/test/with-intl-provider.test.js
@@ -105,7 +105,8 @@ describe('withIntlProvider', function () {
     it('initializes state with empty objects', function () {
       const result = init({});
       expect(result).toEqual({
-        messages: {}
+        messages: {},
+        status: {}
       });
     });
 


### PR DESCRIPTION
## Summary

With the v6.46.1 release, a bug was introduced where locale files were loaded multiple times when using the `withLocaleRequired` high-order component. This was due to the removal of a default value for the `status` property in the `init` function for the `withIntlProvider` hook.

## Changelog

Provide a default value for the status value used in the GasketIntlContext component.

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
