### PR TITLE
Webpack fixes for Next App Router

### DIFF
--- a/packages/gasket-plugin-nextjs/lib/actions.js
+++ b/packages/gasket-plugin-nextjs/lib/actions.js
@@ -12,7 +12,7 @@ module.exports = function actions(gasket) {
         } else {
           baseConfig = nextConfig ?? {};
         }
-        return createConfig(gasket, phase === 'phase-production-build', baseConfig);
+        return createConfig(gasket, baseConfig);
       };
     },
     async getNextRoute(req) {

--- a/packages/gasket-plugin-nextjs/lib/prompt.js
+++ b/packages/gasket-plugin-nextjs/lib/prompt.js
@@ -14,7 +14,7 @@ async function promptAppRouter(context, prompt) {
 
   const ctx = useAppRouter ? { useAppRouter, nextServerType: 'defaultServer' } : { useAppRouter };
   Object.assign(context, ctx);
-};
+}
 
 /** @type {import('./index').promptNextServerType} */
 async function promptNextServerType(context, prompt) {
@@ -34,7 +34,7 @@ async function promptNextServerType(context, prompt) {
   ]);
 
   Object.assign(context, { nextServerType });
-};
+}
 
 /** @type {import('./index').promptNextDevProxy} */
 async function promptNextDevProxy(context, prompt) {
@@ -51,7 +51,7 @@ async function promptNextDevProxy(context, prompt) {
   ]);
 
   Object.assign(context, { nextDevProxy });
-};
+}
 
 /** @type {import('./index').promptSitemap} */
 async function promptSitemap(context, prompt) {
@@ -66,20 +66,20 @@ async function promptSitemap(context, prompt) {
   ]);
 
   Object.assign(context, { addSitemap });
-};
+}
 
 /** @type {import('@gasket/core').HookHandler<'prompt'>} */
-async function prompt(gasket, context, { prompt }) {
+async function promptAll(gasket, context, { prompt }) {
   await promptAppRouter(context, prompt);
   await promptNextServerType(context, prompt);
   await promptNextDevProxy(context, prompt);
   await promptSitemap(context, prompt);
 
   return context;
-};
+}
 
 module.exports = {
-  prompt,
+  prompt: promptAll,
   promptAppRouter,
   promptNextServerType,
   promptNextDevProxy,

--- a/packages/gasket-plugin-nextjs/lib/utils/config.js
+++ b/packages/gasket-plugin-nextjs/lib/utils/config.js
@@ -3,7 +3,7 @@
 
 /**
  * Bring forward configuration from intl plugin to config for next.
- * @param {import("@gasket/core").Gasket} gasket - The gasket API
+ * @param {import('@gasket/core').Gasket} gasket - The gasket API
  * @param {object} config - Configuration to pass to Nextjs
  * @private
  */
@@ -41,13 +41,12 @@ function forwardIntlConfig(gasket, config) {
 /**
  * Small helper function that creates nextjs configuration from the gasket
  * configuration.
- * @param {import("@gasket/core").Gasket}  gasket The gasket API.
- * @param {boolean} includeWebpackConfig `true` to generate webpack config
+ * @param {import('@gasket/core').Gasket}  gasket The gasket API.
  * @param   {object} [nextConfig]           Initial next config
  * @returns {Promise<object>} The configuration data for Nextjs
  * @private
  */
-function createConfig(gasket, includeWebpackConfig = true, nextConfig = {}) {
+function createConfig(gasket, nextConfig = {}) {
   const config = {
     poweredByHeader: false,
     ...(gasket.config?.nextConfig || {}),
@@ -56,17 +55,15 @@ function createConfig(gasket, includeWebpackConfig = true, nextConfig = {}) {
 
   forwardIntlConfig(gasket, config);
 
-  if (includeWebpackConfig) {
-    const { webpack: existingWebpack } = config;
+  const { webpack: existingWebpack } = config;
 
-    // Add webpack property to nextConfig and wrap existing
-    config.webpack = function webpack(webpackConfig, data) {
-      if (typeof existingWebpack === 'function') {
-        webpackConfig = existingWebpack(webpackConfig, data);
-      }
-      return gasket.actions.getWebpackConfig(webpackConfig, data);
-    };
-  }
+  // Add webpack property to nextConfig and wrap existing
+  config.webpack = function webpack(webpackConfig, data) {
+    if (typeof existingWebpack === 'function') {
+      webpackConfig = existingWebpack(webpackConfig, data);
+    }
+    return gasket.actions.getWebpackConfig(webpackConfig, data);
+  };
 
   // eslint-disable-next-line no-sync
   return gasket.execWaterfallSync('nextConfig', config);

--- a/packages/gasket-plugin-nextjs/lib/webpack-config.js
+++ b/packages/gasket-plugin-nextjs/lib/webpack-config.js
@@ -33,7 +33,7 @@ function externalizeGasketCore(ctx, callback) {
 }
 
 /** @type {import('@gasket/core').HookHandler<'webpackConfig'>} */
-function webpackConfigHook(gasket, webpackConfig, { isServer }) {
+function webpackConfigHook(gasket, webpackConfig, { webpack, isServer }) {
   if (Array.isArray(webpackConfig.externals)) {
     if (!isServer) {
       if ('filename' in gasket.config) {
@@ -45,20 +45,16 @@ function webpackConfigHook(gasket, webpackConfig, { isServer }) {
       }
 
       webpackConfig.externals.unshift(validateNoGasketCore);
-    } else {
-      webpackConfig.externals.unshift(externalizeGasketCore);
-
-      // TODO: If we find a reason NOT to externalized the core package,
-      //  then we must set the GASKET_ENV which requires builds per environment.
-      // webpackConfig.plugins.push(
-      //   new webpack.EnvironmentPlugin({
-      //     GASKET_ENV: gasket.config.env
-      //   })
-      // );
     }
   } else {
     throw new Error('Expected webpackConfig.externals to be an array');
   }
+
+  webpackConfig.plugins.push(
+    new webpack.EnvironmentPlugin({
+      GASKET_ENV: gasket.config.env
+    })
+  );
 
   return webpackConfig;
 }

--- a/packages/gasket-plugin-nextjs/test/config.test.js
+++ b/packages/gasket-plugin-nextjs/test/config.test.js
@@ -56,7 +56,7 @@ describe('createConfig', () => {
     const custom = {
       customConfig: 'from arguments'
     };
-    result = await createConfig(gasket, false, custom);
+    result = await createConfig(gasket, custom);
     expect(result).toHaveProperty('customConfig', 'from arguments');
   });
 
@@ -76,7 +76,7 @@ describe('createConfig', () => {
     const custom = {
       poweredByHeader: 'from arguments'
     };
-    result = await createConfig(gasket, false, custom);
+    result = await createConfig(gasket, custom);
     expect(result).toHaveProperty('poweredByHeader', 'from arguments');
   });
 

--- a/packages/gasket-plugin-nextjs/test/prompt.test.js
+++ b/packages/gasket-plugin-nextjs/test/prompt.test.js
@@ -8,7 +8,7 @@ const {
 
 describe('prompt hook', () => {
   let gasket, context, mockPrompt, mockAnswers;
-  const promptHook = prompt
+  const promptHook = prompt;
 
   beforeEach(() => {
     gasket = {};
@@ -133,5 +133,5 @@ describe('prompt hook', () => {
         }
       ]);
     });
-  })
+  });
 });

--- a/packages/gasket-plugin-nextjs/test/webpack-config.test.js
+++ b/packages/gasket-plugin-nextjs/test/webpack-config.test.js
@@ -1,4 +1,5 @@
 const { webpackConfig, validateNoGasketCore, externalizeGasketCore } = require('../lib/webpack-config.js');
+const webpack = require('webpack');
 
 const mockFilename = '/path/to/gasket.js';
 
@@ -16,9 +17,16 @@ describe('webpackConfigHook', () => {
     };
     mockWebpackConfig = {
       name: '',
-      externals: []
+      externals: [],
+      plugins: []
     };
-    mockContext = {};
+    mockContext = {
+      webpack
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('throws if externals is not an array', () => {
@@ -44,10 +52,16 @@ describe('webpackConfigHook', () => {
     expect(result.externals[0]).toBe(validateNoGasketCore);
   });
 
-  it('adds externalizeGasketCore to externals for server', () => {
+  it('adds GASKET_ENV env plugin', () => {
     mockContext.isServer = true;
+    mockGasket.config.env = 'fake-env';
+
     const result = webpackConfig(mockGasket, mockWebpackConfig, mockContext);
-    expect(result.externals[0]).toBe(externalizeGasketCore);
+    const plugin = result.plugins[0];
+    expect(plugin).toBeInstanceOf(webpack.EnvironmentPlugin);
+    expect(plugin).toEqual(expect.objectContaining({
+      defaultValues: { GASKET_ENV: 'fake-env' }
+    }));
   });
 });
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary



Error with `npm run build` for App Router when `gasket` imported to a client component:
> Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined.

Fix by NOT externalizing gasket/core, and instead bundling with `GASKET_ENV` env var defined.


Error with `npm run local` for App Router when `gasket` imported to a client component:
> Module not found: Can't resolve 'fs'

Fixed by adding Webpack config for `phase-development-server`. 

The Gasket action will only fire when Next.js executes the `nextConfig.webpack` hook, so we do not need to limit setting configuration based on phase. 

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

@gasket/plugin-nextjs
- Always add Webpack config regardless of Next phases
- Define Webpack GASKET_ENV env var instead of externalizing core package.

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

- Tested locally in App Router app
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
