### PR TITLE
Allow plugins to exclude themselves from webpack scenarios

### DIFF
--- a/packages/gasket-core/lib/index.js
+++ b/packages/gasket-core/lib/index.js
@@ -77,6 +77,11 @@ class Gasket extends GasketEngine {
     config.env = env;
     config.root ??= process.cwd();
 
+    // prune nullish and/or empty plugins
+    config.plugins = config.plugins
+      .filter(Boolean)
+      .filter(plugin => Boolean(plugin.name) || Boolean(plugin.hooks));
+
     // start the engine
     super(config.plugins);
 

--- a/packages/gasket-core/test/index.test.js
+++ b/packages/gasket-core/test/index.test.js
@@ -75,6 +75,35 @@ describe('makeGasket', () => {
     expect(gasket).toBeInstanceOf(GasketEngine);
   });
 
+  it('prunes nullish and/or empty plugins', () => {
+    const nullishPlugin = null;
+    const emptyPlugin = {};
+    const dummyPlugin = { name: 'dummy', hooks: {} };
+
+    const initConfig = {
+      plugins: [mockPlugin, nullishPlugin, emptyPlugin, dummyPlugin]
+    };
+
+    const gasket = makeGasket(initConfig);
+
+    expect(gasket.config.plugins).toHaveLength(2);
+    expect(gasket.config.plugins[0]).toHaveProperty('name', 'mockPlugin');
+    expect(gasket.config.plugins[1]).toHaveProperty('name', 'dummy');
+  });
+
+  it('does not otherwise prune faulty plugins', () => {
+    const nullishPlugin = null;
+    const emptyPlugin = {};
+    const dummyPlugin = { name: 'dummy', hooks: {} };
+    const faultyPlugin = { name: 'faulty' };
+
+    const initConfig = {
+      plugins: [mockPlugin, nullishPlugin, emptyPlugin, dummyPlugin, faultyPlugin]
+    };
+
+    expect(() => makeGasket(initConfig)).toThrow(/must have a hooks/);
+  });
+
   describe('config lifecycle', () => {
 
     it('applies env overrides', () => {

--- a/packages/gasket-plugin-docs/lib/create.js
+++ b/packages/gasket-plugin-docs/lib/create.js
@@ -1,5 +1,6 @@
-/// <reference types="@gasket/core" />
+/// <reference types="create-gasket-app"/>
 /// <reference types="@gasket/plugin-git" />
+
 const { name, version } = require('../package.json');
 
 const { DEFAULT_CONFIG } = require('./utils/constants');

--- a/packages/gasket-plugin-docs/lib/index.js
+++ b/packages/gasket-plugin-docs/lib/index.js
@@ -1,10 +1,9 @@
-/// <reference types="create-gasket-app"/>
-
 const create = require('./create');
 const configure = require('./configure');
 const commands = require('./commands');
 const metadata = require('./metadata');
 const docsSetup = require('./docs-setup');
+const webpackConfig = require('./webpack-config');
 const { name, version, description } = require('../package.json');
 
 /** @type {import('@gasket/core').Plugin} */
@@ -17,7 +16,8 @@ const plugin = {
     create,
     commands,
     metadata,
-    docsSetup
+    docsSetup,
+    webpackConfig
   }
 };
 

--- a/packages/gasket-plugin-docs/lib/webpack-config.js
+++ b/packages/gasket-plugin-docs/lib/webpack-config.js
@@ -1,0 +1,9 @@
+/// <reference types="@gasket/plugin-webpack" />
+
+const { name } = require('../package.json');
+
+/** @type {import('@gasket/core').HookHandler<'webpackConfig'>} */
+module.exports = function webpackConfigHook(gasket, webpackConfig) {
+  webpackConfig.resolve.alias[name] = false;
+  return webpackConfig;
+};

--- a/packages/gasket-plugin-docs/test/index.test.js
+++ b/packages/gasket-plugin-docs/test/index.test.js
@@ -18,7 +18,8 @@ describe('Plugin', function () {
       'create',
       'commands',
       'metadata',
-      'docsSetup'
+      'docsSetup',
+      'webpackConfig'
     ];
 
     expect(plugin).toHaveProperty('hooks');

--- a/packages/gasket-plugin-docs/test/webpack-config.test.js
+++ b/packages/gasket-plugin-docs/test/webpack-config.test.js
@@ -1,0 +1,27 @@
+const webpackConfigHook = require('../lib/webpack-config');
+const { name } = require('../package');
+
+describe('webpackConfig', function () {
+  let mockGasket, mockWebpackConfig;
+
+  beforeEach(() => {
+    mockGasket = {
+      config: {
+        root: '/path/to/root'
+      }
+    };
+    mockWebpackConfig = {
+      resolve: {
+        alias: {}
+      },
+      plugins: []
+    };
+  });
+
+  it('add alias for plugin', () => {
+    const results = webpackConfigHook(mockGasket, mockWebpackConfig);
+    expect(results.resolve.alias).toEqual(expect.objectContaining({
+      [name]: false
+    }));
+  });
+});

--- a/packages/gasket-plugin-docusaurus/lib/index.js
+++ b/packages/gasket-plugin-docusaurus/lib/index.js
@@ -1,6 +1,7 @@
 const create = require('./create');
 const docsView = require('./docs-view');
 const configure = require('./configure');
+const webpackConfig = require('./webpack-config');
 
 const { name, version, description } = require('../package.json');
 
@@ -13,6 +14,7 @@ const plugin = {
     create,
     configure,
     docsView,
+    webpackConfig,
     metadata(gasket, meta) {
       return {
         ...meta,

--- a/packages/gasket-plugin-docusaurus/lib/webpack-config.js
+++ b/packages/gasket-plugin-docusaurus/lib/webpack-config.js
@@ -1,0 +1,9 @@
+/// <reference types="@gasket/plugin-webpack" />
+
+const { name } = require('../package.json');
+
+/** @type {import('@gasket/core').HookHandler<'webpackConfig'>} */
+module.exports = function webpackConfigHook(gasket, webpackConfig) {
+  webpackConfig.resolve.alias[name] = false;
+  return webpackConfig;
+};

--- a/packages/gasket-plugin-docusaurus/test/index.test.js
+++ b/packages/gasket-plugin-docusaurus/test/index.test.js
@@ -18,6 +18,7 @@ describe('Plugin', () => {
       'create',
       'configure',
       'docsView',
+      'webpackConfig',
       'metadata'
     ];
     expect(Object.keys(plugin.hooks)).toEqual(expected);

--- a/packages/gasket-plugin-docusaurus/test/webpack-config.test.js
+++ b/packages/gasket-plugin-docusaurus/test/webpack-config.test.js
@@ -1,0 +1,27 @@
+const webpackConfigHook = require('../lib/webpack-config');
+const { name } = require('../package');
+
+describe('webpackConfig', function () {
+  let mockGasket, mockWebpackConfig;
+
+  beforeEach(() => {
+    mockGasket = {
+      config: {
+        root: '/path/to/root'
+      }
+    };
+    mockWebpackConfig = {
+      resolve: {
+        alias: {}
+      },
+      plugins: []
+    };
+  });
+
+  it('add alias for plugin', () => {
+    const results = webpackConfigHook(mockGasket, mockWebpackConfig);
+    expect(results.resolve.alias).toEqual(expect.objectContaining({
+      [name]: false
+    }));
+  });
+});

--- a/packages/gasket-plugin-metadata/lib/index.js
+++ b/packages/gasket-plugin-metadata/lib/index.js
@@ -1,5 +1,6 @@
 const create = require('./create');
 const actions = require('./actions');
+const webpackConfig = require('./webpack-config');
 const { name, version, description } = require('../package.json');
 
 /** @type {import('@gasket/core').Plugin} */
@@ -10,6 +11,7 @@ module.exports = {
   hooks: {
     create,
     actions,
+    webpackConfig,
     metadata(gasket, meta) {
       const mod = require('@gasket/core/package.json');
       return {

--- a/packages/gasket-plugin-metadata/lib/webpack-config.js
+++ b/packages/gasket-plugin-metadata/lib/webpack-config.js
@@ -1,0 +1,9 @@
+/// <reference types="@gasket/plugin-webpack" />
+
+const { name } = require('../package.json');
+
+/** @type {import('@gasket/core').HookHandler<'webpackConfig'>} */
+module.exports = function webpackConfigHook(gasket, webpackConfig) {
+  webpackConfig.resolve.alias[name] = false;
+  return webpackConfig;
+};

--- a/packages/gasket-plugin-metadata/test/index.test.js
+++ b/packages/gasket-plugin-metadata/test/index.test.js
@@ -27,6 +27,7 @@ describe('Plugin', function () {
     const expected = [
       'create',
       'actions',
+      'webpackConfig',
       'metadata'
     ];
 

--- a/packages/gasket-plugin-metadata/test/webpack-config.test.js
+++ b/packages/gasket-plugin-metadata/test/webpack-config.test.js
@@ -1,0 +1,27 @@
+const webpackConfigHook = require('../lib/webpack-config');
+const { name } = require('../package');
+
+describe('webpackConfig', function () {
+  let mockGasket, mockWebpackConfig;
+
+  beforeEach(() => {
+    mockGasket = {
+      config: {
+        root: '/path/to/root'
+      }
+    };
+    mockWebpackConfig = {
+      resolve: {
+        alias: {}
+      },
+      plugins: []
+    };
+  });
+
+  it('add alias for plugin', () => {
+    const results = webpackConfigHook(mockGasket, mockWebpackConfig);
+    expect(results.resolve.alias).toEqual(expect.objectContaining({
+      [name]: false
+    }));
+  });
+});

--- a/packages/gasket-plugin-webpack/lib/init-webpack.js
+++ b/packages/gasket-plugin-webpack/lib/init-webpack.js
@@ -30,6 +30,8 @@ module.exports = function initWebpack(gasket, initConfig, context) {
 
   baseConfig.resolve ??= {};
   baseConfig.resolve.alias ??= {};
+  // @ts-ignore -- ensure webpack does not bundle itself
+  baseConfig.resolve.alias.webpack = false;
 
   // eslint-disable-next-line no-sync
   return gasket.execWaterfallSync('webpackConfig', baseConfig, setupContext(context));

--- a/packages/gasket-plugin-webpack/lib/init-webpack.js
+++ b/packages/gasket-plugin-webpack/lib/init-webpack.js
@@ -28,6 +28,9 @@ module.exports = function initWebpack(gasket, initConfig, context) {
     ].filter(Boolean)
   };
 
+  baseConfig.resolve ??= {};
+  baseConfig.resolve.alias ??= {};
+
   // eslint-disable-next-line no-sync
   return gasket.execWaterfallSync('webpackConfig', baseConfig, setupContext(context));
 };

--- a/packages/gasket-plugin-webpack/test/init-webpack.test.js
+++ b/packages/gasket-plugin-webpack/test/init-webpack.test.js
@@ -32,6 +32,14 @@ describe('init webpack', function () {
     expect(results.plugins[0].constructor.name).toBe('WebpackMetricsPlugin');
   });
 
+  it('aliases out webpack', function () {
+    const results = initWebpack(mockGasket, mockConfig, mockContext);
+    expect(results).toHaveProperty('resolve.alias');
+    expect(results.resolve.alias).toEqual({
+      webpack: false
+    });
+  });
+
   it('executes webpackConfig lifecycle', function () {
     initWebpack(mockGasket, mockConfig, mockContext);
     expect(mockGasket.execWaterfallSync).toHaveBeenCalledWith(


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Some plugins, such as docs, are not used in webapp runtimes and thus should not be bundled.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/core**
- Prune nullish and empty plugins

**@gasket/plugin-docs**
- Exclude from webpack

**@gasket/plugin-docsusaurus**
- Exclude from webpack

**@gasket/plugin-metadata**
- Exclude from webpack

**@gasket/plugin-webpack**
- Ensure `webpack` does not get bundled

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

Tested in local app

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
