### PR TITLE
Default gasket env to local and adjust npm scripts

### DIFF
--- a/packages/gasket-core/lib/index.js
+++ b/packages/gasket-core/lib/index.js
@@ -5,38 +5,17 @@ import { applyConfigOverrides } from '@gasket/utils';
 
 /**
  * Get the environment to use for the gasket instance.
- * Defaults to `development`.
+ * Defaults to `local`.
  * @returns {string} env
  */
-function getEnvironment(
-  // flags, commandId, warn
-) {
-  // TODO: enable if cli commands and flags are to be used with v7
-  // if (flags.env) {
-  //   debug('Environment was passed through command line flags', flags.env);
-  //   return flags.env;
-  // }
-
+function getEnvironment() {
   const { GASKET_ENV } = process.env;
   if (GASKET_ENV) {
     return GASKET_ENV;
   }
 
-  // TODO: enable if cli commands and flags are to be used with v7
-  // // special snowflake case to match up `local` env with command unless set
-  // if (commandId === 'local') {
-  //   debug('Environment defaulting to `local` due to `local` command');
-  //   return 'local';
-  // }
-
-  const { NODE_ENV } = process.env;
-  if (NODE_ENV) {
-    console.warn(`No GASKET_ENV specified, falling back to NODE_ENV: "${NODE_ENV}".`);
-    return NODE_ENV;
-  }
-
-  console.warn('No GASKET_ENV specified, falling back to "development".');
-  return 'development';
+  console.warn(`No GASKET_ENV env variable set; defaulting to "local".`);
+  return 'local';
 }
 /* eslint-enable no-console, no-process-env */
 

--- a/packages/gasket-core/test/index.test.js
+++ b/packages/gasket-core/test/index.test.js
@@ -75,6 +75,19 @@ describe('makeGasket', () => {
     expect(gasket).toBeInstanceOf(GasketEngine);
   });
 
+  it('defaults env to local', () => {
+    const gasket = makeGasket({ plugins: [mockPlugin] });
+    expect(gasket.config.env).toEqual('local');
+    expect(console.warn).toHaveBeenCalledWith('No GASKET_ENV env variable set; defaulting to "local".');
+  });
+
+  it('sets env GASKET_ENV', () => {
+    process.env.GASKET_ENV = 'production';
+    const gasket = makeGasket({ plugins: [mockPlugin] });
+    expect(gasket.config.env).toEqual('production');
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
   it('prunes nullish and/or empty plugins', () => {
     const nullishPlugin = null;
     const emptyPlugin = {};
@@ -208,8 +221,8 @@ describe('makeGasket', () => {
       const gasket = makeGasket(inputConfig);
       const { doSomething, doAnotherThing } = gasket.actions;
 
-      expect(doSomething()).toEqual('the environment is test');
-      expect(doAnotherThing()).toEqual('the environment is test');
+      expect(doSomething()).toEqual('the environment is local');
+      expect(doAnotherThing()).toEqual('the environment is local');
     });
 
     it('warns on duplicate action names', () => {

--- a/packages/gasket-plugin-nextjs/lib/index.d.ts
+++ b/packages/gasket-plugin-nextjs/lib/index.d.ts
@@ -74,7 +74,7 @@ declare module 'http' {
 declare module 'create-gasket-app' {
   export interface CreateContext {
     addSitemap?: boolean;
-    nextServerType: 'defaultServer' | 'customServer';
+    nextServerType: 'appRouter' | 'pageRouter' | 'customServer';
     nextDevProxy: boolean;
     typescript: boolean;
     useRedux: boolean;

--- a/packages/gasket-plugin-nextjs/lib/prompt.js
+++ b/packages/gasket-plugin-nextjs/lib/prompt.js
@@ -1,39 +1,28 @@
 /// <reference types="@gasket/core" />
 
-/** @type {import('./index').promptAppRouter} */
-async function promptAppRouter(context, prompt) {
-  if ('useAppRouter' in context) return;
-  const { useAppRouter } = await prompt([
-    {
-      name: 'useAppRouter',
-      message: 'Do you want to use the App Router? (experimental)',
-      type: 'confirm',
-      default: false
-    }
-  ]);
-
-  const ctx = useAppRouter ? { useAppRouter, nextServerType: 'defaultServer' } : { useAppRouter };
-  Object.assign(context, ctx);
-}
-
 /** @type {import('./index').promptNextServerType} */
 async function promptNextServerType(context, prompt) {
-  if ('nextServerType' in context) return;
-  const { useAppRouter } = context;
-  if (useAppRouter) return;
-  const { nextServerType } = await prompt([
-    {
-      name: 'nextServerType',
-      message: 'Which server type would you like to use?',
-      type: 'list',
-      choices: [
-        { name: 'Next Server(CLI)', value: 'defaultServer' },
-        { name: 'Custom Next Server', value: 'customServer' }
-      ]
-    }
-  ]);
+  if (!('nextServerType' in context)) {
+    const { nextServerType } = await prompt([
+      {
+        name: 'nextServerType',
+        message: 'Which server type would you like to use?',
+        type: 'list',
+        choices: [
+          { name: 'App Router', value: 'appRouter' },
+          { name: 'Page Router', value: 'pageRouter' },
+          { name: 'Page Router w/ Custom Server', value: 'customServer' }
+        ]
+      }
+    ]);
 
-  Object.assign(context, { nextServerType });
+    Object.assign(context, { nextServerType });
+  }
+
+  if (context.nextServerType === 'appRouter') {
+    // used for templating
+    Object.assign(context, { useAppRouter: true });
+  }
 }
 
 /** @type {import('./index').promptNextDevProxy} */
@@ -70,7 +59,6 @@ async function promptSitemap(context, prompt) {
 
 /** @type {import('@gasket/core').HookHandler<'prompt'>} */
 async function promptAll(gasket, context, { prompt }) {
-  await promptAppRouter(context, prompt);
   await promptNextServerType(context, prompt);
   await promptNextDevProxy(context, prompt);
   await promptSitemap(context, prompt);
@@ -80,7 +68,6 @@ async function promptAll(gasket, context, { prompt }) {
 
 module.exports = {
   prompt: promptAll,
-  promptAppRouter,
   promptNextServerType,
   promptNextDevProxy,
   promptSitemap

--- a/packages/gasket-plugin-nextjs/test/create.test.js
+++ b/packages/gasket-plugin-nextjs/test/create.test.js
@@ -166,38 +166,39 @@ describe('create hook', () => {
     );
   });
 
-  it('adds the appropriate npm scripts for next cli', async function () {
-    mockContext.nextServerType = 'defaultServer';
+  it('adds the appropriate npm scripts for Next.js default server', async function () {
+    mockContext.nextServerType = 'appRouter';
     await plugin.hooks.create.handler({}, mockContext);
 
     expect(mockContext.pkg.add).toHaveBeenCalledWith('scripts', {
       build: 'next build',
       start: 'next start',
-      local: 'next dev'
+      local: 'next dev',
+      preview: 'npm run build && npm run start'
     });
   });
 
-  it('adds start:local script for next cli w/devProxy', async function () {
-    mockContext.nextServerType = 'defaultServer';
+  it('adds start:local script for Next.js default server w/devProxy', async function () {
+    mockContext.nextServerType = 'appRouter';
     mockContext.nextDevProxy = true;
     await plugin.hooks.create.handler({}, mockContext);
 
     expect(mockContext.pkg.add).toHaveBeenCalledWith('scripts',
       expect.objectContaining({
-        'start:local': 'next start & GASKET_ENV=local node server.js'
+        'start:local': 'next start & node server.js'
       })
     );
   });
 
-  it('adds the appropriate npm scripts for next custom server', async function () {
+  it('adds the appropriate npm scripts for custom server', async function () {
     mockContext.nextServerType = 'customServer';
     await plugin.hooks.create.handler({}, mockContext);
 
     expect(mockContext.pkg.add).toHaveBeenCalledWith('scripts', {
-      'build': 'next build',
-      'start': 'next build && node server.js',
-      'start:local': 'next build && GASKET_ENV=local node server.js',
-      'local': 'GASKET_DEV=1 GASKET_ENV=local nodemon server.js'
+      build: 'next build',
+      start: 'node server.js',
+      preview: 'npm run build && npm run start',
+      local: 'GASKET_DEV=1 nodemon server.js'
     });
   });
 });

--- a/packages/gasket-plugin-nextjs/test/prompt.test.js
+++ b/packages/gasket-plugin-nextjs/test/prompt.test.js
@@ -1,6 +1,5 @@
 const {
   prompt,
-  promptAppRouter,
   promptNextServerType,
   promptNextDevProxy,
   promptSitemap
@@ -28,22 +27,18 @@ describe('prompt hook', () => {
 
   it('serves the expected prompt question', async () => {
     await promptHook(gasket, context, { prompt: mockPrompt });
-    const first = mockPrompt.mock.calls[0][0][0];
-    const second = mockPrompt.mock.calls[1][0][0];
-    const third = mockPrompt.mock.calls[2][0][0];
-    const fourth = mockPrompt.mock.calls[3][0][0];
-    expect(first.name).toEqual('useAppRouter');
-    expect(first.message).toEqual('Do you want to use the App Router? (experimental)');
-    expect(first.type).toEqual('confirm');
-    expect(second.name).toEqual('nextServerType');
-    expect(second.message).toEqual('Which server type would you like to use?');
-    expect(second.type).toEqual('list');
-    expect(third.name).toEqual('nextDevProxy');
-    expect(third.message).toEqual('Do you want to add a proxy for the Next.js dev server?');
-    expect(third.type).toEqual('confirm');
-    expect(fourth.name).toEqual('addSitemap');
-    expect(fourth.message).toEqual('Do you want to add a sitemap?');
-    expect(fourth.type).toEqual('confirm');
+    const askNextServer = mockPrompt.mock.calls[0][0][0];
+    const askDevServer = mockPrompt.mock.calls[1][0][0];
+    const askSitemap = mockPrompt.mock.calls[2][0][0];
+    expect(askNextServer.name).toEqual('nextServerType');
+    expect(askNextServer.message).toEqual('Which server type would you like to use?');
+    expect(askNextServer.type).toEqual('list');
+    expect(askDevServer.name).toEqual('nextDevProxy');
+    expect(askDevServer.message).toEqual('Do you want to add a proxy for the Next.js dev server?');
+    expect(askDevServer.type).toEqual('confirm');
+    expect(askSitemap.name).toEqual('addSitemap');
+    expect(askSitemap.message).toEqual('Do you want to add a sitemap?');
+    expect(askSitemap.type).toEqual('confirm');
   });
 
   it('sets nextServerType to next-cli', async () => {
@@ -51,10 +46,10 @@ describe('prompt hook', () => {
     expect(result.nextServerType).toEqual('next-cli');
   });
 
-  it('sets nextServerType to next-custom', async () => {
-    mockAnswers = { nextServerType: 'next-custom' };
+  it('sets nextServerType to customServer', async () => {
+    mockAnswers = { nextServerType: 'customServer' };
     const result = await promptHook(gasket, context, { prompt: mockPrompt });
-    expect(result.nextServerType).toEqual('next-custom');
+    expect(result.nextServerType).toEqual('customServer');
   });
 
   it('sets addSitemap to true', async () => {
@@ -69,7 +64,7 @@ describe('prompt hook', () => {
   });
 
   it('sets useAppRouter to true', async () => {
-    mockAnswers = { useAppRouter: true };
+    mockAnswers = { nextServerType: 'appRouter' };
     const result = await promptHook(gasket, context, { prompt: mockPrompt });
     expect(result.useAppRouter).toEqual(true);
   });
@@ -85,15 +80,6 @@ describe('prompt hook', () => {
   });
 
   describe('prompt exports', () => {
-    it('promptAppRouter', async () => {
-      await promptAppRouter(context, mockPrompt);
-      expect(mockPrompt).toHaveBeenCalledWith([{
-        name: 'useAppRouter',
-        message: 'Do you want to use the App Router? (experimental)',
-        type: 'confirm',
-        default: false
-      }]);
-    });
 
     it('promptNextServerType', async () => {
       await promptNextServerType(context, mockPrompt);
@@ -103,8 +89,9 @@ describe('prompt hook', () => {
           message: 'Which server type would you like to use?',
           type: 'list',
           choices: [
-            { name: 'Next Server(CLI)', value: 'defaultServer' },
-            { name: 'Custom Next Server', value: 'customServer' }
+            { name: 'App Router', value: 'appRouter' },
+            { name: 'Page Router', value: 'pageRouter' },
+            { name: 'Page Router w/ Custom Server', value: 'customServer' }
           ]
         }
       ]);

--- a/packages/gasket-preset-nextjs/lib/preset-prompt.js
+++ b/packages/gasket-preset-nextjs/lib/preset-prompt.js
@@ -10,7 +10,6 @@ import typescriptPrompts from '@gasket/plugin-typescript/prompts';
  */
 export default async function presetPrompt(gasket, context, { prompt }) {
   await typescriptPrompts.promptTypescript(context, prompt);
-  await nextJsPrompts.promptAppRouter(context, prompt);
   await nextJsPrompts.promptNextServerType(context, prompt);
   await nextJsPrompts.promptNextDevProxy(context, prompt);
 
@@ -18,7 +17,7 @@ export default async function presetPrompt(gasket, context, { prompt }) {
     const { server } = await prompt([
       {
         name: 'server',
-        message: 'Which server framework would you like to use?',
+        message: 'Which custom server framework would you like to use?',
         type: 'list',
         choices: [
           { name: 'Express', value: 'express' },

--- a/packages/gasket-preset-nextjs/test/preset-prompt.test.js
+++ b/packages/gasket-preset-nextjs/test/preset-prompt.test.js
@@ -1,6 +1,5 @@
 import { jest } from '@jest/globals';
 
-const mockAppRouterPrompt = jest.fn();
 const mockNextServerTypePrompt = jest.fn();
 const mockNextDevProxyPrompt = jest.fn();
 const mockTypescriptPrompt = jest.fn();
@@ -8,10 +7,6 @@ const mockTypescriptPrompt = jest.fn();
 jest.mock('@gasket/plugin-nextjs/prompts', () => {
   const mod = jest.requireActual('@gasket/plugin-nextjs/prompts');
   return {
-    promptAppRouter: async (context, prompt) => {
-      mod.promptAppRouter(context, prompt);
-      mockAppRouterPrompt(context, prompt);
-    },
     promptNextServerType: async (context, prompt) => {
       mod.promptNextServerType(context, prompt);
       mockNextServerTypePrompt(context, prompt);
@@ -56,12 +51,6 @@ describe('presetPrompt', () => {
     expect(mockPrompt.prompt).toHaveBeenCalled();
   });
 
-  it('prompts for app router', async () => {
-    await presetPrompt({}, mockContext, mockPrompt);
-    expect(mockAppRouterPrompt).toHaveBeenCalled();
-    expect(mockPrompt.prompt).toHaveBeenCalled();
-  });
-
   it('prompts for next server type', async () => {
     await presetPrompt({}, mockContext, mockPrompt);
     expect(mockNextServerTypePrompt).toHaveBeenCalled();
@@ -80,7 +69,7 @@ describe('presetPrompt', () => {
     expect(mockPrompt.prompt).toHaveBeenCalledWith([
       {
         name: 'server',
-        message: 'Which server framework would you like to use?',
+        message: 'Which custom server framework would you like to use?',
         type: 'list',
         choices: [
           { name: 'Express', value: 'express' },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Streamline app development startup for freshly created apps. Defaulting the gasket env to `local` when GASKET_ENV environment variable has not been set. Also, adjusted how the Next server type is prompted.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/core**
- Default gasket env to local

**@gasket/plugin-nextjs**, **@gasket/preset-nextjs**
- Streamline prompts and created scripts



<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

locally tested with create-gasket-app using --preset-path