### PR TITLE
Ignore range prefixes for prerelease versions

### DIFF
--- a/packages/create-gasket-app/lib/scaffold/config-builder.js
+++ b/packages/create-gasket-app/lib/scaffold/config-builder.js
@@ -376,9 +376,12 @@ export class ConfigBuilder {
         return;
       }
 
+      // If a prerelease version, strip the range prefix
+      const version = ver.includes('-') ? ver.replace(/^[\^~]/, '') : ver;
+
       const blameId = `${key}.${dep}`;
       if (!prev) {
-        existing[dep] = ver;
+        existing[dep] = version;
         setBlame(blameId);
         return;
       }
@@ -386,7 +389,7 @@ export class ConfigBuilder {
       const blamed = this.blame.get(blameId);
       const forced = this.force.has(blameId);
 
-      if (prev === ver) {
+      if (prev === version) {
         if (forced) return;
         if (force) {
           setBlame(blameId);
@@ -398,21 +401,21 @@ export class ConfigBuilder {
 
       const prevName = blamed.join(', ');
       if (!forced) {
-        const newer = force ? ver : this.tryGetNewerRange(prev, ver);
-        const overridden = newer === ver;
+        const newer = force ? version : this.tryGetNewerRange(prev, version);
+        const overridden = newer === version;
         if (overridden) {
-          existing[dep] = ver;
+          existing[dep] = version;
           setBlame(blameId);
         }
       }
 
-      if (!semver.validRange(prev) || !semver.validRange(ver) || !semver.intersects(prev, ver)) {
+      if (!semver.validRange(prev) || !semver.validRange(version) || !semver.intersects(prev, version)) {
         let forceMsg = force ? '(forced)' : '';
         forceMsg = forced && force ? '(cannot be forced)' : forceMsg;
         this.warn(`
   Conflicting versions for ${dep} in "${key}":
     - ${prev} provided by ${prevName} ${forced && '(forced)' || ''}
-    - ${ver} provided by ${name} ${forceMsg}
+    - ${version} provided by ${name} ${forceMsg}
     Using ${existing[dep]}, but this may cause unexpected behavior.
 `);
       }

--- a/packages/create-gasket-app/test/unit/scaffold/config-builder.test.js
+++ b/packages/create-gasket-app/test/unit/scaffold/config-builder.test.js
@@ -217,6 +217,21 @@ describe('ConfigBuilder', () => {
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Using ^2.0.0, but'));
     });
 
+    it('[semver] strips range prefix from prerelease versions', () => {
+      pkg.add('dependencies', {
+        'patch-pkg': '~2.0.0',
+        'minor-pkg': '^2.0.0',
+        'beta-pkg': '^2.0.0-beta.1',
+        'canary-pkg': '~2.0.0-canary.0'
+      });
+      expect(pkg.fields.dependencies).toEqual({
+        'patch-pkg': '~2.0.0',
+        'minor-pkg': '^2.0.0',
+        'beta-pkg': '2.0.0-beta.1',
+        'canary-pkg': '2.0.0-canary.0'
+      });
+    });
+
     it('[array] adds new fields', () => {
       pkg.add('keys', ['some-key']);
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

When adding dependency version for packages during create, we need to ignore any range prefixes for prerelease versions as this has been seen to trip up npm when installing dependencies.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**create-gasket-app**
- ignore range prefixes for prerelease versions

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

Tested locally by creating an app while invoke `/path/to/gasket/packages/create-gasket-app/lib/index.js`

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
