### PR TITLE
fix(gasket-plugin-command): ESM JSON imports

### DIFF
--- a/packages/gasket-plugin-command/lib/cli.js
+++ b/packages/gasket-plugin-command/lib/cli.js
@@ -1,8 +1,8 @@
 import { Command } from 'commander';
 import { logo } from './utils/index.js';
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-const { version } = require('../package.json');
+
+const { default: pkg } = await import('../package.json', { assert: { type: 'json' } });
+const { version } = pkg;
 const program = new Command();
 
 // Create Gasket CLI

--- a/packages/gasket-plugin-command/lib/create.js
+++ b/packages/gasket-plugin-command/lib/create.js
@@ -1,6 +1,5 @@
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-const { name, version } = require('../package.json');
+const { default: pkg } = await import('../package.json', { assert: { type: 'json' } });
+const { name, version } = pkg
 
 /** @type {import('@gasket/core').HookHandler<'create'>} */
 export default function create(gasket, { pkg, gasketConfig }) {

--- a/packages/gasket-plugin-command/lib/index.js
+++ b/packages/gasket-plugin-command/lib/index.js
@@ -1,9 +1,9 @@
 import create from './create.js';
 import configure from './configure.js';
 import commands from './commands.js';
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-const { name, version, description } = require('../package.json');
+
+const { default: pkg } = await import('../package.json', { assert: { type: 'json' } });
+const { name, version, description } = pkg;
 
 /** @type {import('@gasket/core').Plugin} */
 export default {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
I tried deploying gasket to AWS Lambda using [SST](https://ion.sst.dev/docs/start/aws/nextjs/) and [open-next](https://open-next.js.org/). I got an error with the createRequire import
```
2024-08-15T00:10:17.547Z	fd062990-0d21-4422-ac69-ef5b40275d49	ERROR	 ⨯ Error: Cannot find module '../package.json'
Require stack:
- ...../gasket-serverless/node_modules/@gasket/plugin-command/lib/create.js
```

The import.meta.url is a part of the bundle 

.next/server/chunks before
`(0,a.createRequire)("file:///...../gasket-serverless/node_modules/@gasket/plugin-command/lib/create.js")("../package.json"),{`

.next/server/chunks after
`JSON.parse('{"name":"@gasket/plugin-command","version":"7.0.0-next. ....`

I know import assertions are experimental currently but wanted to get some thoughts on it.

gasket-serverless repo is here https://github.com/aryasaatvik/gasket-serverless. deployed https://d1nb6js3qoug11.cloudfront.net/


<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
