### PR TITLE
fix circular gasket issue with api routes

### DIFF
--- a/packages/gasket-plugin-express/generator/routes/index.js
+++ b/packages/gasket-plugin-express/generator/routes/index.js
@@ -1,5 +1,5 @@
 export const routes = [
-  (app) => {
+  (gasket, app) => {
     {{#if hasSwaggerPlugin}}
     /**
     * @swagger

--- a/packages/gasket-plugin-express/generator/routes/index.ts
+++ b/packages/gasket-plugin-express/generator/routes/index.ts
@@ -1,8 +1,9 @@
+import type { Gasket } from '@gasket/core';
 import type { AppRoutes } from '@gasket/plugin-express';
 import type { Application, Request, Response } from 'express';
 
 export const routes: AppRoutes = [
-  (app: Application): void => {
+  (gasket: Gasket, app: Application): void => {
     {{#if hasSwaggerPlugin}}
     /**
     * @swagger

--- a/packages/gasket-plugin-express/lib/create-servers.js
+++ b/packages/gasket-plugin-express/lib/create-servers.js
@@ -26,7 +26,7 @@ module.exports = async function createServers(gasket, serverOpts) {
       if (typeof route !== 'function') {
         throw new Error('Route must be a function');
       }
-      await route(app);
+      await route(gasket, app);
     }
   }
 

--- a/packages/gasket-plugin-express/lib/index.d.ts
+++ b/packages/gasket-plugin-express/lib/index.d.ts
@@ -1,4 +1,4 @@
-import type { MaybeAsync, MaybeMultiple, Plugin } from '@gasket/core';
+import type { Gasket, MaybeAsync, MaybeMultiple, Plugin } from '@gasket/core';
 import type { Application, ErrorRequestHandler, Handler } from 'express';
 
 export type AppRoutes = Array<MaybeAsync<(app: Application) => void>>;
@@ -11,7 +11,7 @@ declare module '@gasket/core' {
       /** Filter for which request URLs invoke Gasket middleware */
       middlewareInclusionRegex?: RegExp;
       /** Glob pattern for source files setting up express routes */
-      routes?: Array<MaybeAsync<(app: Application) => void>>;
+      routes?: Array<MaybeAsync<(gasket: Gasket, app: Application) => void>>;
       /** @deprecated */
       excludedRoutesRegex?: RegExp;
       trustProxy?: boolean | string | number | Function;

--- a/packages/gasket-plugin-express/test/plugin.test.js
+++ b/packages/gasket-plugin-express/test/plugin.test.js
@@ -91,13 +91,15 @@ describe('createServers', () => {
     gasket.config.express = { routes: [route] };
     await plugin.hooks.createServers(gasket, {});
     expect(route).toHaveBeenCalled();
+    expect(route).toHaveBeenCalledWith(gasket, app);
   });
 
   it('allows for an array of route functions with async', async function () {
     const route = jest.fn();
-    gasket.config.express = { routes: [async () => route()] };
+    gasket.config.express = { routes: [async (g, a) => route(g, a)] };
     await plugin.hooks.createServers(gasket, {});
     expect(route).toHaveBeenCalled();
+    expect(route).toHaveBeenCalledWith(gasket, app);
   });
 
   it('throws an error if a route is not a function', async function () {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
Edge case found where API routes that are defined in the entry `makeGasket` cannot import `gasket` for use in handlers. The solution was to pass `gasket` to the route definition function.
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
- Fix circular gasket API route issue
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
Tests & types updated
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
