### PR TITLE
Simplify default webpack exclusions for Gasket files

### DIFF
--- a/packages/create-gasket-app/lib/scaffold/actions/write-gasket-config.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/write-gasket-config.js
@@ -96,7 +96,6 @@ async function writeGasketConfig({ context }) {
   const assignments = gasketConfig.fields.injectionAssignments || null;
   const expressions = gasketConfig.fields.expressions || null;
   gasketConfig.fields.plugins = 'PLUGIN_REPLACE';
-  gasketConfig.fields.filename = 'FILENAME_REPLACE';
 
   let contents = '';
   if (typescript) contents += `import type { GasketConfigDefinition } from '@gasket/core';\n`;
@@ -110,7 +109,6 @@ async function writeGasketConfig({ context }) {
   const pluginImports = `[\n${writePluginImports(plugins)}\n  ]`;
   const typeCoercion = typescript ? ' as GasketConfigDefinition' : '';
   contents += `\nexport default makeGasket(${JSON5.stringify(gasketConfig.fields, null, 2)}${typeCoercion});\n`;
-  contents = contents.replace('\'FILENAME_REPLACE\'', 'import.meta.filename');
   contents = contents.replace('\'PLUGIN_REPLACE\'', pluginImports);
   contents = replaceInjectionAssignments(contents, assignments);
 

--- a/packages/create-gasket-app/test/unit/scaffold/actions/write-gasket-config.test.js
+++ b/packages/create-gasket-app/test/unit/scaffold/actions/write-gasket-config.test.js
@@ -81,12 +81,6 @@ describe('write-gasket-config', () => {
     expect(output).toContain('plugins:');
   });
 
-  it('writes filename', async () => {
-    await writeGasketConfig({ context: mockContext });
-    const output = mockWriteStub.mock.calls[0][1];
-    expect(output).toContain('filename: import.meta.filename');
-  });
-
   it('outputs keys without quotes, strings with single-quotes', async () => {
     mockContext.gasketConfig.add("bogus", "double"); // eslint-disable-line quotes
     await writeGasketConfig({ context: mockContext });

--- a/packages/gasket-core/lib/index.d.ts
+++ b/packages/gasket-core/lib/index.d.ts
@@ -64,8 +64,6 @@ declare module '@gasket/core' {
     plugins: Array<Plugin>;
     root: string;
     env: string;
-    /** Path to the gasket instance file. Can be set to `import.meta.filename` **/
-    filename?: string;
   }
 
   export class GasketEngine {

--- a/packages/gasket-plugin-nextjs/lib/utils/try-resolve.js
+++ b/packages/gasket-plugin-nextjs/lib/utils/try-resolve.js
@@ -1,0 +1,16 @@
+/**
+ * Try to resolve a module, returning null if not found
+ *
+ * @param moduleName
+ * @param paths
+ */
+function tryResolve(moduleName, paths) {
+  try {
+    return require.resolve(moduleName, { paths });
+  } catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') return null;
+    throw err;
+  }
+}
+
+module.exports = tryResolve;

--- a/packages/gasket-plugin-nextjs/lib/webpack-config.js
+++ b/packages/gasket-plugin-nextjs/lib/webpack-config.js
@@ -11,7 +11,6 @@ const isGasketCore = /@gasket[/\\]core$/;
  * @returns {void}
  */
 function validateNoGasketCore(ctx, callback) {
-  // console.log(ctx.request);
   if (isGasketCore.test(ctx.request)) {
     return callback(new Error('@gasket/core should not be used in browser code.'));
   }

--- a/packages/gasket-plugin-nextjs/test/webpack-config.test.js
+++ b/packages/gasket-plugin-nextjs/test/webpack-config.test.js
@@ -1,7 +1,10 @@
 const { webpackConfig, validateNoGasketCore, externalizeGasketCore } = require('../lib/webpack-config.js');
 const webpack = require('webpack');
 
-const mockFilename = '/path/to/gasket.js';
+jest.mock('../lib/utils/try-resolve.js');
+const tryResolve = require('../lib/utils/try-resolve.js');
+
+const mockFilename = '/path/to/app/gasket.js';
 
 describe('webpackConfigHook', () => {
   let mockGasket, mockWebpackConfig, mockContext;
@@ -9,7 +12,7 @@ describe('webpackConfigHook', () => {
   beforeEach(() => {
     mockGasket = {
       config: {
-        filename: mockFilename
+        root: '/path/to/app'
       },
       logger: {
         warn: jest.fn()
@@ -37,14 +40,9 @@ describe('webpackConfigHook', () => {
   });
 
   it('adds empty alias for gasket file in client', () => {
+    tryResolve.mockReturnValue(mockFilename);
     const result = webpackConfig(mockGasket, mockWebpackConfig, mockContext);
     expect(result.resolve.alias).toEqual(expect.objectContaining({ [mockFilename]: false }));
-  });
-
-  it('warns if filename not configured', () => {
-    delete mockGasket.config.filename;
-    webpackConfig(mockGasket, mockWebpackConfig, mockContext);
-    expect(mockGasket.logger.warn).toHaveBeenCalledWith('Gasket `filename` was not configured in makeGasket');
   });
 
   it('adds validateNoGasketCore to externals for client', () => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Avoid needing to set the filename in the `gasket.js/ts` and also capture the `./dist/gasket.js` for custom server Next apps using Typescript.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

- Exclude common gasket files from webpack.

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

Tested locally

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
