### PR TITLE
[PFX-714]: Gasket logger is showing incorrect formatting

### DIFF
--- a/packages/gasket-plugin-winston/lib/index.js
+++ b/packages/gasket-plugin-winston/lib/index.js
@@ -48,7 +48,7 @@ const plugin = {
         ),
         format:
           config.winston?.format ??
-          format.combine(format.splat(), format.json()),
+          format.combine(format.colorize(), format.simple()),
         levels: Object.assign({ fatal: 0, warn: 4, trace: 7 }, winstonConfig.syslog.levels),
         exitOnError: true
       });

--- a/packages/gasket-plugin-winston/lib/index.js
+++ b/packages/gasket-plugin-winston/lib/index.js
@@ -48,7 +48,7 @@ const plugin = {
         ),
         format:
           config.winston?.format ??
-          format.combine(format.colorize(), format.simple()),
+          format.simple(),
         levels: Object.assign({ fatal: 0, warn: 4, trace: 7 }, winstonConfig.syslog.levels),
         exitOnError: true
       });

--- a/packages/gasket-plugin-winston/lib/index.js
+++ b/packages/gasket-plugin-winston/lib/index.js
@@ -40,7 +40,9 @@ const plugin = {
 
       // eslint-disable-next-line no-sync
       const pluginTransports = gasket.execSync('winstonTransports');
-      const defaultFormat = gasket.config.env.startsWith('local') ? format.simple() : format.combine(format.splat());
+      const defaultFormat = gasket.config.env.startsWith('local') ?
+        format.simple() :
+        format.combine(format.splat(), format.json());
 
       return createLogger({
         ...config.winston,

--- a/packages/gasket-plugin-winston/lib/index.js
+++ b/packages/gasket-plugin-winston/lib/index.js
@@ -40,15 +40,14 @@ const plugin = {
 
       // eslint-disable-next-line no-sync
       const pluginTransports = gasket.execSync('winstonTransports');
+      const defaultFormat = gasket.config.env.startsWith('local') ? format.simple() : format.combine(format.splat());
 
       return createLogger({
         ...config.winston,
         transports: configTransports.concat(
           pluginTransports.flat().filter(Boolean)
         ),
-        format:
-          config.winston?.format ??
-          format.simple(),
+        format: config.winston?.format ?? defaultFormat,
         levels: Object.assign({ fatal: 0, warn: 4, trace: 7 }, winstonConfig.syslog.levels),
         exitOnError: true
       });

--- a/packages/gasket-plugin-winston/test/index.test.js
+++ b/packages/gasket-plugin-winston/test/index.test.js
@@ -88,12 +88,7 @@ describe('@gasket/plugin-winston', function () {
 
         logger.error('test');
 
-        expect(consoleSpy).toHaveBeenCalledWith(
-          JSON.stringify({
-            level: 'error',
-            message: 'test'
-          }) + '\n'
-        );
+        expect(consoleSpy).toHaveBeenCalledWith('error: test\n');
       } finally {
         consoleSpy.mockRestore();
       }
@@ -129,10 +124,7 @@ describe('@gasket/plugin-winston', function () {
             level: 'error',
             message: 'test',
             [LEVEL]: 'error',
-            [MESSAGE]: JSON.stringify({
-              level: 'error',
-              message: 'test'
-            })
+            [MESSAGE]: 'error: test'
           },
           expect.any(Function)
         );
@@ -151,7 +143,7 @@ describe('@gasket/plugin-winston', function () {
             level: 'error',
             message: 'test',
             [LEVEL]: 'error',
-            [MESSAGE]: JSON.stringify({ level: 'error', message: 'test' })
+            [MESSAGE]: 'error: test'
           },
           expect.any(Function)
         );
@@ -174,7 +166,7 @@ describe('@gasket/plugin-winston', function () {
               level: 'error',
               message: 'test',
               [LEVEL]: 'error',
-              [MESSAGE]: JSON.stringify({ level: 'error', message: 'test' })
+              [MESSAGE]: 'error: test'
             },
             expect.any(Function)
           );
@@ -195,7 +187,7 @@ describe('@gasket/plugin-winston', function () {
               level: 'error',
               message: 'test',
               [LEVEL]: 'error',
-              [MESSAGE]: JSON.stringify({ level: 'error', message: 'test' })
+              [MESSAGE]: 'error: test'
             },
             expect.any(Function)
           );

--- a/packages/gasket-plugin-winston/test/index.test.js
+++ b/packages/gasket-plugin-winston/test/index.test.js
@@ -13,7 +13,7 @@ describe('@gasket/plugin-winston', function () {
 
   beforeEach(() => {
     gasket = new Gasket({ plugins: [PluginLogger, plugin] });
-    gasket.config = {};
+    gasket.config = { env: 'local' };
   });
 
   afterEach(() => {
@@ -89,6 +89,28 @@ describe('@gasket/plugin-winston', function () {
         logger.error('test');
 
         expect(consoleSpy).toHaveBeenCalledWith('error: test\n');
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
+
+    it('defaults to json format when env is not local', function () {
+      gasket.config.env = 'prod';
+      const consoleSpy = jest
+        // eslint-disable-next-line no-console
+        .spyOn(console._stdout, 'write')
+        .mockImplementation();
+      try {
+        const [logger] = gasket.execSync('createLogger');
+
+        logger.error('test');
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          JSON.stringify({
+            level: 'error',
+            message: 'test'
+          }) + '\n'
+        );
       } finally {
         consoleSpy.mockRestore();
       }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

[Ticket](https://godaddy-corp.atlassian.net/browse/PFX-714)

Log messages using the winston logger were being displayed in a json object. The goal is to display just the message in the console. 

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

- update default winston format to be `format.simple()`

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
<img width="532" alt="Screenshot 2024-08-26 at 2 06 47 PM" src="https://github.com/user-attachments/assets/bb04b2f0-5993-4fc9-939a-6f85b4bc2653">

- all tests are passing in the winston plugin

<img width="390" alt="Screenshot 2024-08-26 at 2 13 00 PM" src="https://github.com/user-attachments/assets/31a95ee1-e02a-4eae-a4d6-f4195b24becb">

- tested by creating a local gasket app and installing the changes in this PR
