### PR TITLE
Add ajv as dev dep for docusaurus apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41364,6 +41364,7 @@
         "@docusaurus/core": "^3.4.0",
         "@docusaurus/preset-classic": "^3.4.0",
         "@gasket/core": "7.0.0-next.63",
+        "ajv": "^8.17.1",
         "cross-env": "^7.0.3",
         "eslint": "^8.56.0",
         "eslint-config-godaddy": "^7.1.1",
@@ -41376,6 +41377,34 @@
         "search-insights": "^2.13.0",
         "typescript": "^5.4.5"
       }
+    },
+    "packages/gasket-plugin-docusaurus/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/gasket-plugin-docusaurus/node_modules/fast-uri": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
+      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+      "dev": true
+    },
+    "packages/gasket-plugin-docusaurus/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "packages/gasket-plugin-elastic-apm": {
       "name": "@gasket/plugin-elastic-apm",
@@ -46813,6 +46842,7 @@
         "@docusaurus/core": "^3.4.0",
         "@docusaurus/preset-classic": "^3.4.0",
         "@gasket/core": "7.0.0-next.63",
+        "ajv": "^8.17.1",
         "cross-env": "^7.0.3",
         "eslint": "^8.56.0",
         "eslint-config-godaddy": "^7.1.1",
@@ -46825,6 +46855,32 @@
         "react-dom": "^18.2.0",
         "search-insights": "^2.13.0",
         "typescript": "^5.4.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.17.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+          "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2"
+          }
+        },
+        "fast-uri": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
+          "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
       }
     },
     "@gasket/plugin-elastic-apm": {

--- a/packages/gasket-plugin-docusaurus/lib/create.js
+++ b/packages/gasket-plugin-docusaurus/lib/create.js
@@ -14,7 +14,8 @@ module.exports = function create(gasket, { pkg, gasketConfig, readme }) {
     '@docusaurus/core': devDependencies['@docusaurus/core'],
     '@docusaurus/preset-classic': devDependencies['@docusaurus/preset-classic'],
     'react': devDependencies.react,
-    'react-dom': devDependencies['react-dom']
+    'react-dom': devDependencies['react-dom'],
+    'ajv': devDependencies.ajv
   });
 
   readme

--- a/packages/gasket-plugin-docusaurus/package.json
+++ b/packages/gasket-plugin-docusaurus/package.json
@@ -47,6 +47,7 @@
     "@docusaurus/core": "^3.4.0",
     "@docusaurus/preset-classic": "^3.4.0",
     "@gasket/core": "7.0.0-next.63",
+    "ajv": "^8.17.1",
     "cross-env": "^7.0.3",
     "eslint": "^8.56.0",
     "eslint-config-godaddy": "^7.1.1",

--- a/packages/gasket-plugin-docusaurus/test/create.test.js
+++ b/packages/gasket-plugin-docusaurus/test/create.test.js
@@ -37,7 +37,8 @@ describe('createHook', () => {
       '@docusaurus/core': devDependencies['@docusaurus/core'],
       '@docusaurus/preset-classic': devDependencies['@docusaurus/preset-classic'],
       'react': devDependencies.react,
-      'react-dom': devDependencies['react-dom']
+      'react-dom': devDependencies['react-dom'],
+      'ajv': devDependencies.ajv
     });
   });
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

The docs command would fail in api apps if the api app added eslint through the eslint prompt.

When adding eslint through the prompt, it changes the version of ajv to be incompatible with Docusaurus. 

```
node:internal/modules/cjs/loader:1145
  const err = new Error(message);
              ^

Error: Cannot find module 'ajv/dist/compile/codegen'
```
This PR adds ajv as a dev dependency to Docusaurus apps to prevent a version mismatch.

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/plugin-docusaurus**
- Add ajv as a dev dependency for docusaurus apps

## Test Plan

- Updated unit tests
- Tested locally
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
