### PR TITLE
Disable intl prompt for app router apps

### DIFF
--- a/packages/gasket-plugin-intl/lib/prompt.js
+++ b/packages/gasket-plugin-intl/lib/prompt.js
@@ -7,7 +7,7 @@
  * @type {import('@gasket/core').HookHandler<'prompt'>}
  */
 module.exports = async function promptHook(gasket, context, { prompt }) {
-  if (!('hasGasketIntl' in context)) {
+  if (!('hasGasketIntl' in context) && !context.useAppRouter) {
     const { useGasketIntl } = await prompt([
       {
         name: 'useGasketIntl',

--- a/packages/gasket-plugin-intl/test/prompt.test.js
+++ b/packages/gasket-plugin-intl/test/prompt.test.js
@@ -29,4 +29,11 @@ describe('promptHook', () => {
     expect(prompt).not.toHaveBeenCalled();
     expect(result.hasGasketIntl).toEqual(mockCreateContext.hasGasketIntl);
   });
+
+  it('does not prompt if useAppRouter is true', async () => {
+    mockCreateContext.useAppRouter = true;
+    const result = await promptHook(mockGasket, mockCreateContext, { prompt });
+    expect(prompt).not.toHaveBeenCalled();
+    expect(result.hasGasketIntl).toEqual(mockCreateContext.hasGasketIntl);
+  });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Disable intl prompt for app router apps because the intl plugin currently does not support app router

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

**@gasket/plugin-intl**
- Disable prompt when useAppRouter is true

## Test Plan

- Updated unit test
- Tested locally
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
