### PR TITLE
V7 pr/chaos 1706@export prompt typings

### DIFF
--- a/packages/create-gasket-app/lib/index.d.ts
+++ b/packages/create-gasket-app/lib/index.d.ts
@@ -277,29 +277,23 @@ export interface ActionWrapperParams {
   spinner?: any;
 }
 
+export interface PromptUtils {
+  prompt(prompts: Array<Record<string, any>>): Promise<Record<string, any>>;
+  addPlugins(plugins: Array<string>): Promise<void>;
+}
+
+export interface PostCreatetUtils {
+  runScript: (script: string) => Promise<void>;
+}
+
 declare module '@gasket/core' {
   import { CreateContext } from 'create-gasket-app';
 
   export interface HookExecTypes {
-    presetPrompt(context: CreateContext): Promise<void>;
+    presetPrompt(context: CreateContext, utils: PromptUtils): Promise<void>;
     presetConfig(context: CreateContext): Promise<CreateContext['presetConfig']>;
-    prompt(
-      context: CreateContext,
-      utils: {
-        prompt: (
-          prompts: Array<Record<string, any>>
-        ) => Promise<Record<string, any>>;
-        addPlugins: (plugins: Array<string>) => Promise<void>;
-      }
-    ): MaybeAsync<CreateContext>;
-
+    prompt(context: CreateContext, utils: PromptUtils): MaybeAsync<CreateContext>;
     create(context: CreateContext): MaybeAsync<void>;
-
-    postCreate(
-      context: CreateContext,
-      utils: {
-        runScript: (script: string) => Promise<void>;
-      }
-    ): MaybeAsync<void>;
+    postCreate(context: CreateContext, utils: PostCreatetUtils): MaybeAsync<void>;
   }
 }

--- a/packages/create-gasket-app/lib/index.d.ts
+++ b/packages/create-gasket-app/lib/index.d.ts
@@ -284,7 +284,7 @@ export interface PromptUtils {
   prompt: CreatePrompt;
 }
 
-export interface PostCreatetUtils {
+export interface PostCreateUtils {
   runScript: (script: string) => Promise<void>;
 }
 
@@ -294,6 +294,6 @@ declare module '@gasket/core' {
     presetConfig(context: CreateContext): Promise<CreateContext['presetConfig']>;
     prompt(context: CreateContext, utils: PromptUtils): MaybeAsync<CreateContext>;
     create(context: CreateContext): MaybeAsync<void>;
-    postCreate(context: CreateContext, utils: PostCreatetUtils): MaybeAsync<void>;
+    postCreate(context: CreateContext, utils: PostCreateUtils): MaybeAsync<void>;
   }
 }


### PR DESCRIPTION
## Summary

https://godaddy-corp.atlassian.net/browse/CHAOS-1706

having the create-gasket-app package export typings used on the prompts typings so the consuming apps can use the typings directly on new prompt hooks. This will allow the consuming app to resolve any issue related to typescript by casting needed args directly

## Changelog

- Created and exported typing `PromptUtils` so consuming apps could force proper typings on Args when creating prompts. This allows the consuming app to fix any odd typing issues that might popup

- Created and exported typing `PostCreatetUtils` so consuming apps could force proper typings on Args when creating prompts. This allows the consuming app to fix any odd typing issues that might popup

