### PR TITLE
Fix to load local path presets with `@file:`

### DIFF
--- a/docs/testing-gasket-locally.md
+++ b/docs/testing-gasket-locally.md
@@ -12,6 +12,15 @@ npx create-gasket-app test-app --preset-path=/absolute/path/gasket/packages/gask
 
 This command will create a new Gasket app using your local preset. You can then test your changes by running the app and verifying that your changes work as expected.
 
+## Testing local preset changes with installed plugins
+
+Another way to test a preset locally, but with plugins installed from npm,
+is to use the `--presets` flag while specifying the [local paths].
+
+```sh
+npx create-gasket-app test-app --presets=gasket-preset-example@file:/absolute/path/gasket/packages/gasket-preset-example
+```
+
 ## Testing plugin changes locally
 
 Two options for testing your plugin locally are to point a local app's dependencies a the local plugin or to use `npm link`.
@@ -48,3 +57,4 @@ When testing a preset locally, you might encounter an issue where the local vers
 
 
 [testing plugin changes locally]: #testing-plugin-changes-locally
+[local paths]: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#local-paths

--- a/packages/create-gasket-app/lib/scaffold/actions/load-preset.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/load-preset.js
@@ -5,8 +5,7 @@ import { default as gasketUtils } from '@gasket/utils';
 import { mkdtemp } from 'fs/promises';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const hasFile = /@file:/;
-const hasVersionOrTag = /@([\^~]?\d+\.\d+\.\d+(?:-[\d\w.-]+)?|[\^~]?\d+\.\d+\.\d+|[a-zA-Z]+|file:\/.+)$/;
+const hasVersionOrTag = /@([\^~]?\d+\.\d+\.\d+(?:-[\d\w.-]+)?|[\^~]?\d+\.\d+\.\d+|[a-zA-Z]+|file:.+)$/;
 
 /**
  * loadPresets - Load presets to temp directory

--- a/packages/create-gasket-app/lib/scaffold/actions/load-preset.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/load-preset.js
@@ -5,7 +5,8 @@ import { default as gasketUtils } from '@gasket/utils';
 import { mkdtemp } from 'fs/promises';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const hasVersionOrTag = /@([\^~]?\d+\.\d+\.\d+(?:-[\d\w.-]+)?|[\^~]?\d+\.\d+\.\d+|[a-zA-Z]+)$/;
+const hasFile = /@file:/;
+const hasVersionOrTag = /@([\^~]?\d+\.\d+\.\d+(?:-[\d\w.-]+)?|[\^~]?\d+\.\d+\.\d+|[a-zA-Z]+|file:\/.+)$/;
 
 /**
  * loadPresets - Load presets to temp directory

--- a/packages/create-gasket-app/test/unit/scaffold/actions/load-preset.test.js
+++ b/packages/create-gasket-app/test/unit/scaffold/actions/load-preset.test.js
@@ -222,7 +222,7 @@ describe('loadPreset', () => {
     expect(mockContext.presets).toHaveLength(2);
   });
 
-  it('support preset with tags', async () => {
+  it('supports preset with tags', async () => {
     mockContext.rawPresets = ['@gasket/preset-bogus@canary', '@gasket/preset-all-i-ever-wanted@next'];
 
     await loadPreset({ context: mockContext });
@@ -231,5 +231,19 @@ describe('loadPreset', () => {
       expect.objectContaining(presetAllIEverWanted)
     ]);
     expect(mockContext.presets).toHaveLength(2);
+  });
+
+  it('supports preset with file version', async () => {
+    const filePath = path.resolve(__dirname, '..', '..', '..', '__mocks__', '@gasket', 'preset-bogus');
+
+    mockContext.rawPresets = [
+      `@gasket/preset-bogus@file:${filePath}`
+    ];
+
+    await loadPreset({ context: mockContext });
+    expect(mockContext).toHaveProperty('presets', [
+      expect.objectContaining(presetBogus)
+    ]);
+    expect(mockContext.presets).toHaveLength(1);
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

For testing local presets, but installing the preset plugin dependencies, this change allows the `@file:` [local paths](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#local-paths) to be used.

```
create-gasket-app my-app -p @some/preset@file:/path/to/my/preset
```

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**create-gasket-app**
- Support for `@file:` in with --presets

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

Tested with local package
```
/absolute/path/to/godaddy/gasket/packages/create-gasket-app/lib/index.js test-local-preset -p @gasket/preset-nextjs@file:/absolute/path/to/godaddy/gasket/packages/gasket-preset-nextjs

```

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
