### PR TITLE
fix issue with loading .ts jest.config

### DIFF
--- a/packages/gasket-plugin-express/generator/jest/jest.config.ts
+++ b/packages/gasket-plugin-express/generator/jest/jest.config.ts
@@ -1,7 +1,7 @@
-import { type JestConfigWithTsJest } from 'ts-jest';
+import type { JestConfigWithTsJest } from 'ts-jest';
 
 const config: JestConfigWithTsJest = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   injectGlobals: true,
   moduleDirectories: ['node_modules', '<rootDir>'],

--- a/packages/gasket-plugin-express/generator/jest/tsconfig.test.json
+++ b/packages/gasket-plugin-express/generator/jest/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-      "moduleResolution": "Node10",
-      "module": "CommonJS",
+    "moduleResolution": "Node10",
+    "module": "CommonJS",
   }
 }

--- a/packages/gasket-plugin-express/generator/jest/tsconfig.test.json
+++ b/packages/gasket-plugin-express/generator/jest/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+      "moduleResolution": "Node10",
+      "module": "CommonJS",
+  }
+}

--- a/packages/gasket-plugin-express/lib/create.js
+++ b/packages/gasket-plugin-express/lib/create.js
@@ -53,7 +53,7 @@ module.exports = async function create(gasket, context) {
   });
 
   if (apiApp && addApiRoutes) {
-    const globIgnore = typescript ? '!(*.js)' : '!(*.ts)';
+    const globIgnore = typescript ? '!(*.js)' : '!(*.ts|*.json)';
     files.add(`${generatorDir}/app/**/${globIgnore}`);
 
     createTestFiles({ files, generatorDir, testPlugins, globIgnore });

--- a/packages/gasket-plugin-express/test/plugin.test.js
+++ b/packages/gasket-plugin-express/test/plugin.test.js
@@ -207,7 +207,7 @@ describe('create', () => {
   it('respects the typescript flag', async () => {
     mockContext.typescript = false;
     await expectCreatedWith(({ files }) => {
-      expect(files.add).toHaveBeenCalledWith(expect.stringContaining('../generator/app/**/!(*.ts)'));
+      expect(files.add).toHaveBeenCalledWith(expect.stringContaining('../generator/app/**/!(*.ts|*.json)'));
     })();
     mockContext.typescript = true;
     await expectCreatedWith(({ files }) => {
@@ -232,8 +232,8 @@ describe('create', () => {
       mockContext.testPlugins = ['@gasket/mocha'];
       await expectCreatedWith(({ files }) => {
         expect(files.add).toHaveBeenCalledWith(
-          expect.stringContaining(`/generator/mocha/*/!(*.ts)`),
-          expect.stringContaining(`/generator/mocha/**/!(*.ts)`)
+          expect.stringContaining(`/generator/mocha/*/!(*.ts|*.json)`),
+          expect.stringContaining(`/generator/mocha/**/!(*.ts|*.json)`)
         );
       })();
     });
@@ -242,8 +242,8 @@ describe('create', () => {
       mockContext.testPlugins = ['@gasket/jest'];
       await expectCreatedWith(({ files }) => {
         expect(files.add).toHaveBeenCalledWith(
-          expect.stringContaining(`/generator/jest/*/!(*.ts)`),
-          expect.stringContaining(`/generator/jest/**/!(*.ts)`)
+          expect.stringContaining(`/generator/jest/*/!(*.ts|*.json)`),
+          expect.stringContaining(`/generator/jest/**/!(*.ts|*.json)`)
         );
       })();
     });

--- a/packages/gasket-plugin-fastify/generator/jest/jest.config.ts
+++ b/packages/gasket-plugin-fastify/generator/jest/jest.config.ts
@@ -1,7 +1,7 @@
-import { type JestConfigWithTsJest } from 'ts-jest';
+import type { JestConfigWithTsJest } from 'ts-jest';
 
 const config: JestConfigWithTsJest = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   injectGlobals: true,
   moduleDirectories: ['node_modules', '<rootDir>'],
@@ -14,3 +14,4 @@ const config: JestConfigWithTsJest = {
 };
 
 export default config;
+

--- a/packages/gasket-plugin-fastify/generator/jest/tsconfig.test.json
+++ b/packages/gasket-plugin-fastify/generator/jest/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-      "moduleResolution": "Node10",
-      "module": "CommonJS",
+    "moduleResolution": "Node10",
+    "module": "CommonJS",
   }
 }

--- a/packages/gasket-plugin-fastify/generator/jest/tsconfig.test.json
+++ b/packages/gasket-plugin-fastify/generator/jest/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+      "moduleResolution": "Node10",
+      "module": "CommonJS",
+  }
+}

--- a/packages/gasket-plugin-fastify/lib/create.js
+++ b/packages/gasket-plugin-fastify/lib/create.js
@@ -53,7 +53,7 @@ module.exports = async function create(gasket, context) {
   });
 
   if (apiApp && addApiRoutes) {
-    const globIgnore = typescript ? '!(*.js)' : '!(*.ts)';
+    const globIgnore = typescript ? '!(*.js)' : '!(*.ts|*.json)';
     files.add(`${generatorDir}/app/**/${globIgnore}`);
 
     createTestFiles({ files, generatorDir, testPlugins, globIgnore });

--- a/packages/gasket-plugin-fastify/test/plugin.test.js
+++ b/packages/gasket-plugin-fastify/test/plugin.test.js
@@ -259,8 +259,8 @@ describe('create', () => {
       mockContext.testPlugins = ['@gasket/mocha'];
       await expectCreatedWith(({ files }) => {
         expect(files.add).toHaveBeenCalledWith(
-          expect.stringContaining(`/generator/mocha/*/!(*.ts)`),
-          expect.stringContaining(`/generator/mocha/**/!(*.ts)`)
+          expect.stringContaining(`/generator/mocha/*/!(*.ts|*.json)`),
+          expect.stringContaining(`/generator/mocha/**/!(*.ts|*.json)`)
         );
       })();
     });
@@ -269,8 +269,8 @@ describe('create', () => {
       mockContext.testPlugins = ['@gasket/jest'];
       await expectCreatedWith(({ files }) => {
         expect(files.add).toHaveBeenCalledWith(
-          expect.stringContaining(`/generator/jest/*/!(*.ts)`),
-          expect.stringContaining(`/generator/jest/**/!(*.ts)`)
+          expect.stringContaining(`/generator/jest/*/!(*.ts|*.json)`),
+          expect.stringContaining(`/generator/jest/**/!(*.ts|*.json)`)
         );
       })();
     });

--- a/packages/gasket-plugin-jest/lib/index.js
+++ b/packages/gasket-plugin-jest/lib/index.js
@@ -57,8 +57,8 @@ const plugin = {
 
             pkg.add('scripts', {
               'test': 'TS_NODE_PROJECT=./tsconfig.test.json jest',
-              'test:watch': 'TS_NODE_PROJECT=./tsconfig.test.json jest --watchAll',
-              'test:coverage': 'TS_NODE_PROJECT=./tsconfig.test.json jest --coverage'
+              'test:watch': 'npm run test -- --watchAll',
+              'test:coverage': 'npm run test -- --coverage'
             });
           } else {
             pkg.add('devDependencies', {

--- a/packages/gasket-plugin-jest/lib/index.js
+++ b/packages/gasket-plugin-jest/lib/index.js
@@ -56,9 +56,9 @@ const plugin = {
             });
 
             pkg.add('scripts', {
-              'test': 'jest',
-              'test:watch': 'jest --watchAll',
-              'test:coverage': 'jest --coverage'
+              'test': 'TS_NODE_PROJECT=./tsconfig.test.json jest',
+              'test:watch': 'TS_NODE_PROJECT=./tsconfig.test.json jest --watchAll',
+              'test:coverage': 'TS_NODE_PROJECT=./tsconfig.test.json jest --coverage'
             });
           } else {
             pkg.add('devDependencies', {

--- a/packages/gasket-plugin-jest/test/index.test.js
+++ b/packages/gasket-plugin-jest/test/index.test.js
@@ -184,8 +184,8 @@ describe('Plugin', function () {
       expect(pkg.devDependencies['ts-node']).toEqual(devDependencies['ts-node']);
       expect(pkg.scripts).toEqual({
         'test': 'TS_NODE_PROJECT=./tsconfig.test.json jest',
-        'test:watch': 'TS_NODE_PROJECT=./tsconfig.test.json jest --watchAll',
-        'test:coverage': 'TS_NODE_PROJECT=./tsconfig.test.json jest --coverage'
+        'test:watch': 'npm run test -- --watchAll',
+        'test:coverage': 'npm run test -- --coverage'
       });
     });
   });

--- a/packages/gasket-plugin-jest/test/index.test.js
+++ b/packages/gasket-plugin-jest/test/index.test.js
@@ -183,9 +183,9 @@ describe('Plugin', function () {
       expect(pkg.devDependencies['ts-jest']).toEqual(devDependencies['ts-jest']);
       expect(pkg.devDependencies['ts-node']).toEqual(devDependencies['ts-node']);
       expect(pkg.scripts).toEqual({
-        'test': 'jest',
-        'test:watch': 'jest --watchAll',
-        'test:coverage': 'jest --coverage'
+        'test': 'TS_NODE_PROJECT=./tsconfig.test.json jest',
+        'test:watch': 'TS_NODE_PROJECT=./tsconfig.test.json jest --watchAll',
+        'test:coverage': 'TS_NODE_PROJECT=./tsconfig.test.json jest --coverage'
       });
     });
   });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
Issue with Jest + TypeScript not being able to load the `jest.config.ts`. Seems that this issue is fixed in Jest v30 which is in alpha. A workaround was found [here](https://github.com/jestjs/jest/issues/13350#issuecomment-1737623479). Later down the line hopefully we can remove this.
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
- TypeScript + Jest fixes
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
Tests updated and tested locally with the testing tool.
<img width="476" alt="Screenshot 2024-09-20 at 9 28 52 AM" src="https://github.com/user-attachments/assets/39a852b4-0a15-4373-a932-8d11176306f3">

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
