### PR TITLE
Fastify fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43704,7 +43704,6 @@
       "dependencies": {
         "@gasket/plugin-cypress": "7.0.0-next.69",
         "@gasket/plugin-express": "7.0.0-next.69",
-        "@gasket/plugin-fastify": "7.0.0-next.69",
         "@gasket/plugin-https": "7.0.0-next.69",
         "@gasket/plugin-intl": "7.0.0-next.69",
         "@gasket/plugin-jest": "7.0.0-next.69",

--- a/packages/gasket-plugin-fastify/package.json
+++ b/packages/gasket-plugin-fastify/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
+    "generator",
     "lib"
   ],
   "scripts": {

--- a/packages/gasket-preset-api/lib/create.js
+++ b/packages/gasket-preset-api/lib/create.js
@@ -21,7 +21,7 @@ export default function create(gasket, context) {
     pkg.add('scripts', {
       start: 'node server.js',
       local: 'nodemon server.js',
-      preview: 'npm run build && npm run start'
+      preview: 'npm run start'
     });
   }
 }

--- a/packages/gasket-preset-api/test/create.test.js
+++ b/packages/gasket-preset-api/test/create.test.js
@@ -53,7 +53,7 @@ describe('create', function () {
     expect(mockPkgAdd).toHaveBeenCalledWith('scripts', {
       start: 'node server.js',
       local: 'nodemon server.js',
-      preview: 'npm run build && npm run start'
+      preview: 'npm run start'
     });
   });
 

--- a/packages/gasket-preset-nextjs/lib/index.d.ts
+++ b/packages/gasket-preset-nextjs/lib/index.d.ts
@@ -1,5 +1,4 @@
 import '@gasket/plugin-express';
-import '@gasket/plugin-fastify';
 import '@gasket/plugin-https';
 import '@gasket/plugin-nextjs';
 import '@gasket/plugin-webpack';

--- a/packages/gasket-preset-nextjs/lib/preset-config.js
+++ b/packages/gasket-preset-nextjs/lib/preset-config.js
@@ -23,10 +23,9 @@ export default async function presetConfig(gasket, context) {
     pluginLint
   ];
 
-  if ('server' in context) {
-    const frameworkPlugin = context.server === 'express'
-      ? await import('@gasket/plugin-express')
-      : await import('@gasket/plugin-fastify');
+
+  if (context.nextServerType === 'customServer') {
+    const frameworkPlugin = await import('@gasket/plugin-express');
 
     plugins.push(frameworkPlugin.default || frameworkPlugin);
   }

--- a/packages/gasket-preset-nextjs/lib/preset-prompt.js
+++ b/packages/gasket-preset-nextjs/lib/preset-prompt.js
@@ -13,21 +13,5 @@ export default async function presetPrompt(gasket, context, { prompt }) {
   await nextJsPrompts.promptNextServerType(context, prompt);
   await nextJsPrompts.promptNextDevProxy(context, prompt);
 
-  if (!('server' in context) && context.nextServerType === 'customServer') {
-    const { server } = await prompt([
-      {
-        name: 'server',
-        message: 'Which custom server framework would you like to use?',
-        type: 'list',
-        choices: [
-          { name: 'Express', value: 'express' },
-          { name: 'Fastify', value: 'fastify' }
-        ]
-      }
-    ]);
-
-    Object.assign(context, { server });
-  }
-
   return context;
 }

--- a/packages/gasket-preset-nextjs/package.json
+++ b/packages/gasket-preset-nextjs/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@gasket/plugin-cypress": "7.0.0-next.69",
     "@gasket/plugin-express": "7.0.0-next.69",
-    "@gasket/plugin-fastify": "7.0.0-next.69",
     "@gasket/plugin-https": "7.0.0-next.69",
     "@gasket/plugin-intl": "7.0.0-next.69",
     "@gasket/plugin-jest": "7.0.0-next.69",

--- a/packages/gasket-preset-nextjs/test/preset-config.test.js
+++ b/packages/gasket-preset-nextjs/test/preset-config.test.js
@@ -58,21 +58,11 @@ describe('presetConfig', () => {
 
   describe('adds server framework plugin', () => {
     it('express', async () => {
-      mockContext.server = 'express';
+      mockContext.nextServerType = 'customServer';
       const config = await presetConfig({}, mockContext);
       expect(config.plugins).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ name: '@gasket/plugin-express' })
-        ])
-      );
-    });
-
-    it('fastify', async () => {
-      mockContext.server = 'fastify';
-      const config = await presetConfig({}, mockContext);
-      expect(config.plugins).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ name: '@gasket/plugin-fastify' })
         ])
       );
     });

--- a/packages/gasket-preset-nextjs/test/preset-prompt.test.js
+++ b/packages/gasket-preset-nextjs/test/preset-prompt.test.js
@@ -62,36 +62,4 @@ describe('presetPrompt', () => {
     expect(mockNextDevProxyPrompt).toHaveBeenCalled();
     expect(mockPrompt.prompt).toHaveBeenCalled();
   });
-
-  it('prompts for server if nextServerType is customServer', async () => {
-    mockContext.nextServerType = 'customServer';
-    await presetPrompt({}, mockContext, mockPrompt);
-    expect(mockPrompt.prompt).toHaveBeenCalledWith([
-      {
-        name: 'server',
-        message: 'Which custom server framework would you like to use?',
-        type: 'list',
-        choices: [
-          { name: 'Express', value: 'express' },
-          { name: 'Fastify', value: 'fastify' }
-        ]
-      }
-    ]);
-  });
-
-  it('does not prompt for server if nextServerType is not customServer', async () => {
-    mockContext.nextServerType = 'defaultServer';
-    await presetPrompt({}, mockContext, mockPrompt);
-    expect(mockPrompt.prompt).not.toHaveBeenCalledWith([
-      {
-        name: 'server',
-        message: 'Which server framework would you like to use?',
-        type: 'list',
-        choices: [
-          { name: 'Express', value: 'express' },
-          { name: 'Fastify', value: 'fastify' }
-        ]
-      }
-    ]);
-  });
 });


### PR DESCRIPTION
Fixes for
- missing routes with Fastify APIs
- Fastify 4 not feasible with Next 14
- `npm run preview` should not build for non-TS APIs