### PR TITLE
[PFX-770]: Fix [object Object] logs in Fastify api apps

### DIFF
--- a/packages/gasket-plugin-fastify/README.md
+++ b/packages/gasket-plugin-fastify/README.md
@@ -31,6 +31,7 @@ All the configurations for the plugin are added under `fastify` in the config:
 - `compression`: true by default. Can be set to false if applying compression
   differently.
 - `trustProxy`: Enable trust proxy option, [see Fastify documentation for possible values](https://fastify.dev/docs/latest/Reference/Server/#trustproxy)
+- `disableRequestLogging`: Turn off request logging, true by default
 
 #### Example configuration
 

--- a/packages/gasket-plugin-fastify/lib/index.d.ts
+++ b/packages/gasket-plugin-fastify/lib/index.d.ts
@@ -29,6 +29,7 @@ declare module '@gasket/core' {
       excludedRoutesRegex?: RegExp;
       /** Trust proxy configuration */
       trustProxy?: FastifyServerOptions['trustProxy'];
+      disableRequestLogging?: boolean;
     };
     /** Middleware configuration */
     middleware?: {

--- a/packages/gasket-plugin-fastify/lib/index.d.ts
+++ b/packages/gasket-plugin-fastify/lib/index.d.ts
@@ -29,6 +29,7 @@ declare module '@gasket/core' {
       excludedRoutesRegex?: RegExp;
       /** Trust proxy configuration */
       trustProxy?: FastifyServerOptions['trustProxy'];
+      /** Fastify request logging per route */
       disableRequestLogging?: boolean;
     };
     /** Middleware configuration */

--- a/packages/gasket-plugin-fastify/lib/index.js
+++ b/packages/gasket-plugin-fastify/lib/index.js
@@ -25,7 +25,7 @@ const plugin = {
       const fastifyLogger = alignLogger(gasket.logger);
 
       // @ts-ignore
-      app ??= fastify({ logger: fastifyLogger, trustProxy, https, http2 });
+      app ??= fastify({ logger: fastifyLogger, trustProxy, https, http2, disableRequestLogging: true });
 
       return app;
     }

--- a/packages/gasket-plugin-fastify/lib/index.js
+++ b/packages/gasket-plugin-fastify/lib/index.js
@@ -21,11 +21,11 @@ const plugin = {
   actions: {
     getFastifyApp(gasket) {
       const { fastify: fastifyConfig = {}, http2, https } = gasket.config;
-      const { trustProxy = false } = fastifyConfig;
+      const { trustProxy = false, disableRequestLogging = true } = fastifyConfig;
       const fastifyLogger = alignLogger(gasket.logger);
 
       // @ts-ignore
-      app ??= fastify({ logger: fastifyLogger, trustProxy, https, http2, disableRequestLogging: true });
+      app ??= fastify({ logger: fastifyLogger, trustProxy, https, http2, disableRequestLogging });
 
       return app;
     }

--- a/packages/gasket-plugin-fastify/test/plugin.test.js
+++ b/packages/gasket-plugin-fastify/test/plugin.test.js
@@ -70,7 +70,11 @@ describe('actions', () => {
   it('does not enable trust proxy by default', async () => {
     const pluginInstance = require('../lib/index');
     await pluginInstance.actions.getFastifyApp(gasket);
-    expect(mockFastify).toHaveBeenCalledWith({ logger: gasket.logger, trustProxy: false });
+    expect(mockFastify).toHaveBeenCalledWith({
+      logger: gasket.logger,
+      trustProxy: false,
+      disableRequestLogging: true
+    });
   });
 
   it('does enable trust proxy by if set to true', async () => {
@@ -78,7 +82,11 @@ describe('actions', () => {
     const pluginInstance = require('../lib/index');
     await pluginInstance.actions.getFastifyApp(gasket);
 
-    expect(mockFastify).toHaveBeenCalledWith({ logger: gasket.logger, trustProxy: true });
+    expect(mockFastify).toHaveBeenCalledWith({
+      logger: gasket.logger,
+      trustProxy: true,
+      disableRequestLogging: true
+    });
   });
 
   it('does enable trust proxy by if set to string', async () => {
@@ -88,7 +96,8 @@ describe('actions', () => {
 
     expect(mockFastify).toHaveBeenCalledWith({
       logger: gasket.logger,
-      trustProxy: '127.0.0.1'
+      trustProxy: '127.0.0.1',
+      disableRequestLogging: true
     });
   });
 
@@ -96,7 +105,11 @@ describe('actions', () => {
     const pluginInstance = require('../lib/index');
     await pluginInstance.actions.getFastifyApp(gasket);
 
-    expect(mockFastify).toHaveBeenCalledWith({ logger: gasket.logger, trustProxy: false });
+    expect(mockFastify).toHaveBeenCalledWith({
+      logger: gasket.logger,
+      trustProxy: false,
+      disableRequestLogging: true
+    });
   });
 });
 

--- a/packages/gasket-plugin-fastify/test/plugin.test.js
+++ b/packages/gasket-plugin-fastify/test/plugin.test.js
@@ -101,6 +101,27 @@ describe('actions', () => {
     });
   });
 
+  it('defaults to true for disableRequestLogging', async () => {
+    const pluginInstance = require('../lib/index');
+    await pluginInstance.actions.getFastifyApp(gasket);
+    expect(mockFastify).toHaveBeenCalledWith({
+      logger: gasket.logger,
+      trustProxy: false,
+      disableRequestLogging: true
+    });
+  });
+
+  it('allows request logging if disableRequestLogging is set to false', async () => {
+    gasket.config.fastify = { disableRequestLogging: false };
+    const pluginInstance = require('../lib/index');
+    await pluginInstance.actions.getFastifyApp(gasket);
+    expect(mockFastify).toHaveBeenCalledWith({
+      logger: gasket.logger,
+      trustProxy: false,
+      disableRequestLogging: false
+    });
+  });
+
   it('adds log plugin as logger to fastify', async function () {
     const pluginInstance = require('../lib/index');
     await pluginInstance.actions.getFastifyApp(gasket);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

In the logs for a Fastify api, we were seeing `info: [object Object] {"reqId":"req-1"}`. This comes from fastify req logging. One way to fix these logs is by turning off the request logging. 

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

- add `disableRequestLogging` option to fastify config

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
<img width="453" alt="Screenshot 2024-10-07 at 11 58 34 AM" src="https://github.com/user-attachments/assets/8d9090b9-26cb-4dc0-8f0d-7c28ef5db699">

- This is how the logs now look with the `disableRequestLogging` set to true.

<img width="732" alt="Screenshot 2024-10-08 at 1 45 22 PM" src="https://github.com/user-attachments/assets/6a247ebd-4fb3-40f3-a239-06a5237e38d4">

- `@gasket/plugin-fastify` test suite is passing with new tests added

