### PR TITLE
Fix to use start:local only if set

### DIFF
--- a/packages/gasket-plugin-cypress/README.md
+++ b/packages/gasket-plugin-cypress/README.md
@@ -30,7 +30,7 @@ will automatically add the following `scripts` to your `package.json`:
 
 - Before running `npm run cypress` or `npm run cypress:headless`, make sure the
   server is running in a separate terminal tab. You can start the server by
-  running `npm run start:local` or `next start`.
+  running `npm run start` (or `npm run start:local`).
 - Before starting the server for the first time, you must run
   `npm run build` to ensure that all necessary assets are built and available
   for testing.

--- a/packages/gasket-plugin-cypress/lib/index.js
+++ b/packages/gasket-plugin-cypress/lib/index.js
@@ -36,13 +36,14 @@ const plugin = {
           });
         }
 
+        const startCmd = pkg.has('scripts', 'start:local') ? 'start:local' : 'start';
+
         pkg.add('scripts', {
-          'start:local': 'next start',
           'cypress': 'cypress open',
           'cypress:headless': 'cypress run',
-          'e2e': `start-server-and-test start:local ${LOCAL_SERVER_URL} cypress`,
+          'e2e': `start-server-and-test ${startCmd} ${LOCAL_SERVER_URL} cypress`,
           'e2e:headless':
-            `start-server-and-test start:local ${LOCAL_SERVER_URL} cypress:headless`
+            `start-server-and-test ${startCmd} ${LOCAL_SERVER_URL} cypress:headless`
         });
       }
     },

--- a/packages/gasket-plugin-cypress/package.json
+++ b/packages/gasket-plugin-cypress/package.json
@@ -8,8 +8,8 @@
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "test": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' jest",
-    "test:watch": "jest --watchAll",
-    "test:coverage": "jest --coverage",
+    "test:watch": "npm run test -- --watchAll",
+    "test:coverage": "npm run test -- --coverage",
     "posttest": "npm run lint && npm run typecheck",
     "typecheck": "tsc",
     "typecheck:watch": "tsc --watch"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

The cypress was introducing a `start:local` script, which would sometimes be inaccurate, and not always necessary.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/plugin-cypress**
- Only use `start:local` script if it has been added

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

- Updated unit tests
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
