### PR TITLE
add makeStoreOptionsFn

### DIFF
--- a/packages/gasket-redux/README.md
+++ b/packages/gasket-redux/README.md
@@ -17,6 +17,7 @@ Set up Redux store configuration and return a `makeStore` function
 **Signature**
 
 - `configureMakeStore(options, [postCreate]): makeStore`
+- `configureMakeStore(optionsFn, [postCreate]): makeStore`
 
 **Props**
 
@@ -30,8 +31,10 @@ Set up Redux store configuration and return a `makeStore` function
   - `enhancers` - (function[]) Any other redux store enhancers
   - `logging` - (boolean) set to true if you want to enable redux logger.
     (default: false)
+- `optionsFn` - (function) function that returns the Options object, receives `Request` object as arg.
 - `postCreate` - (function) Executed after the store is create the resulting
   store as the argument
+- 
 
 **Return Value**
 

--- a/packages/gasket-redux/src/configure-make-store.js
+++ b/packages/gasket-redux/src/configure-make-store.js
@@ -34,25 +34,25 @@ export function prepareReducer(allReducers, rootReducer) {
  * @type {import('./index').configureMakeStore}
  */
 export default function configureMakeStore(makeStoreOptions = {}, postCreate) {
-  const {
-    thunkMiddleware = thunk,
-    middleware = [],
-    logging = false,
-    enhancers = [(f) => f],
-    reducers = {},
-    rootReducer,
-    initialState = {}
-  } = makeStoreOptions;
-
-  const baseMiddleware = [thunkMiddleware];
-
   /**
    * Wrapper for store create to create instance with SSR and to hydrate in
    * browser.
    * @type {import('./index').MakeStoreFn}
    */
+  // eslint-disable-next-line max-statements
   function makeStore(state = {}, options = {}) {
     const { req, logger = new Log() } = options;
+    const {
+      thunkMiddleware = thunk,
+      middleware = [],
+      logging = false,
+      enhancers = [(f) => f],
+      reducers = {},
+      rootReducer,
+      initialState = {}
+    } = typeof makeStoreOptions === 'function' ? makeStoreOptions(req) : makeStoreOptions;
+
+    const baseMiddleware = [thunkMiddleware];
 
     // Use existing redux store if it has been already been instantiated by
     // redux-plugin

--- a/packages/gasket-redux/src/index.d.ts
+++ b/packages/gasket-redux/src/index.d.ts
@@ -53,7 +53,7 @@ export function prepareReducer(
  * Set up redux store configuration and return a makeStore function
  */
 export function configureMakeStore(
-  options?: ConfigureMakeStoreOptions,
+  options?: ConfigureMakeStoreOptions | ((req: IncomingMessage) => ConfigureMakeStoreOptions),
   postCreate?: Function
 ): MakeStoreFn;
 

--- a/packages/gasket-redux/test/configure-make-store.spec.js
+++ b/packages/gasket-redux/test/configure-make-store.spec.js
@@ -15,6 +15,7 @@ const mockEnhancer = jest.fn(createStore => (reducer, initialState, enhancer) =>
 const mockPostCreate = jest.fn();
 
 
+// eslint-disable-next-line max-statements
 describe('configureMakeStore', () => {
   const mockReducers = {
     reducer1: f => f || {}
@@ -47,6 +48,11 @@ describe('configureMakeStore', () => {
     expect(result).toBeInstanceOf(Function);
   });
 
+  it('accepts callback optionsFn', () => {
+    result = configureMakeStore(() => {});
+    expect(result).toBeInstanceOf(Function);
+  });
+
   it('allows custom initial state', () => {
     store = configureMakeStore({ initialState: mockInitialState })();
     const state = store.getState();
@@ -56,8 +62,22 @@ describe('configureMakeStore', () => {
     }
   });
 
+  it('allows custom initial state from callback optionsFn', () => {
+    store = configureMakeStore(() => ({ initialState: mockInitialState }))();
+    const state = store.getState();
+
+    for (const [key, value] of Object.entries(mockInitialState)) {
+      expect(state).toHaveProperty(key, value);
+    }
+  });
+
   it('allows custom middleware', () => {
     configureMakeStore({ middleware: [mockMiddleware] })();
+    expect(applyMiddlewareSpy.mock.calls[0][1]).toBe(mockMiddleware);
+  });
+
+  it('allows custom middleware from callback optionsFn', () => {
+    configureMakeStore(() => ({ middleware: [mockMiddleware] }))();
     expect(applyMiddlewareSpy.mock.calls[0][1]).toBe(mockMiddleware);
   });
 


### PR DESCRIPTION
Updated the makeStoreOptions to be a callback that is callback or an object. This allows the makeStoreOptions to be triggered per request.

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
