### PR TITLE
Remove depreacted http2 dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22644,17 +22644,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/http2": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/http2/-/http2-3.3.7.tgz",
-      "integrity": "sha512-puSi8M8WNlFJm9Pk4c/Mbz9Gwparuj3gO9/RRO5zv6piQ0FY+9Qywp0PdWshYgsMJSalixFY7eC6oPu0zRxLAQ==",
-      "deprecated": "Use the built-in module in node 9.0.0 or newer, instead",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0 <9.0.0"
-      }
-    },
     "node_modules/http2-express": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/http2-express/-/http2-express-1.0.0.tgz",
@@ -44417,7 +44406,6 @@
         "eslint-plugin-json": "^3.1.0",
         "eslint-plugin-unicorn": "^55.0.0",
         "fastify": "^4.28.1",
-        "http2": "^3.3.7",
         "jest": "^29.7.0",
         "typescript": "^5.4.5"
       },
@@ -44773,7 +44761,6 @@
         "eslint-plugin-jest": "^28.6.0",
         "eslint-plugin-json": "^3.1.0",
         "eslint-plugin-unicorn": "^55.0.0",
-        "http2": "^3.3.7",
         "jest": "^29.7.0",
         "typescript": "^5.4.5"
       }

--- a/packages/gasket-plugin-fastify/lib/index.d.ts
+++ b/packages/gasket-plugin-fastify/lib/index.d.ts
@@ -9,7 +9,6 @@ import type {
   FastifyTypeProviderDefault,
   RawServerDefault
 } from 'fastify';
-import { Http2SecureServer, Http2ServerRequest, Http2ServerResponse } from 'http2';
 import { IncomingMessage, ServerResponse } from 'http';
 
 export type AppRoutes = Array<MaybeAsync<(app: FastifyInstance) => void>>;

--- a/packages/gasket-plugin-fastify/package.json
+++ b/packages/gasket-plugin-fastify/package.json
@@ -48,7 +48,6 @@
     "eslint-plugin-json": "^3.1.0",
     "eslint-plugin-unicorn": "^55.0.0",
     "fastify": "^4.28.1",
-    "http2": "^3.3.7",
     "jest": "^29.7.0",
     "typescript": "^5.4.5"
   },

--- a/packages/gasket-plugin-middleware/package.json
+++ b/packages/gasket-plugin-middleware/package.json
@@ -42,7 +42,6 @@
     "eslint-plugin-jest": "^28.6.0",
     "eslint-plugin-json": "^3.1.0",
     "eslint-plugin-unicorn": "^55.0.0",
-    "http2": "^3.3.7",
     "jest": "^29.7.0",
     "typescript": "^5.4.5"
   },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Addressing `npm i` warning:
```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'http2@3.3.7',
npm warn EBADENGINE   required: { node: '>=0.12.0 <9.0.0' },
npm warn EBADENGINE   current: { node: 'v20.15.0', npm: '10.8.2' }
npm warn EBADENGINE }
```

Solution is to
> Use the built-in module in node 9.0.0 or newer, instead

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**@gasket/plugin-fastify**
- Remove legacy http2 dependency

**@gasket/plugin-middleware**
- Remove legacy http2 dependency

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

N/A

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
