### PR TITLE
[PFX-773]: Compile warning with App Router

### DIFF
--- a/packages/gasket-plugin-webpack/lib/webpack-metrics-plugin.js
+++ b/packages/gasket-plugin-webpack/lib/webpack-metrics-plugin.js
@@ -45,8 +45,7 @@ class WebpackMetricsPlugin {
       let name;
 
       try {
-        const packagePath = path.join(context, '/package.json');
-        const packageJSON = require(packagePath);
+        const packageJSON = require(`${context}/package.json`);
 
         name = packageJSON.name;
       } catch (e) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Ticket: [PFX-773](https://godaddy-corp.atlassian.net/browse/PFX-773)

There is a warning when running `npm run build` in new app router applications. When compiling the application, the webpack plugin logs `Critical dependency: the request of a dependency is an expression`. Webpack looks for strings as the arguments to require and import statements. 

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

- change require statement in webpack plugin to use string interpolation

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

- all tests pass
