### PR TITLE
Cli fix

### DIFF
--- a/packages/gasket-core/lib/index.d.ts
+++ b/packages/gasket-core/lib/index.d.ts
@@ -19,7 +19,7 @@ declare module '@gasket/core' {
     init(): void
     configure(config: GasketConfig): GasketConfig
     ready(): MaybeAsync<void>
-    prepare(): MaybeAsync<void>
+    prepare(config: GasketConfig): MaybeAsync<GasketConfig>
   }
 
   export type HookId = keyof HookExecTypes;

--- a/packages/gasket-plugin-command/lib/ready.js
+++ b/packages/gasket-plugin-command/lib/ready.js
@@ -2,7 +2,7 @@ import { gasketBin } from './cli.js';
 
 /** @type {import('@gasket/core').HookHandler<'ready'>} */
 export default async function ready(gasket) {
-  gasket.isReady.then(() => {
+  if (gasket.config.command) {
     gasketBin.parse();
-  });
+  }
 }

--- a/packages/gasket-plugin-command/test/ready.test.js
+++ b/packages/gasket-plugin-command/test/ready.test.js
@@ -23,7 +23,6 @@ describe('ready', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGasket = {
-      isReady: Promise.resolve(),
       execSync: jest.fn().mockReturnValue([{ id: 'test', description: 'test', action: jest.fn() }]),
       config: {
         env: 'development'
@@ -35,13 +34,14 @@ describe('ready', () => {
     expect(ready).toEqual(expect.any(Function));
   });
 
-  it('should parse gasketBin', async () => {
+  it('should parse gasketBin if gasket custom command is set', async () => {
+    mockGasket.config.command = 'docs';
     await ready(mockGasket);
     expect(mockParse).toHaveBeenCalled();
   });
 
-  it('should wait for gasket to be ready', async () => {
+  it('should not parse gasketBin if gasket custom command is not set', async () => {
     await ready(mockGasket);
-    await expect(mockGasket.isReady).resolves.toBeUndefined();
+    expect(mockParse).not.toHaveBeenCalled();
   });
 });

--- a/packages/gasket-plugin-dynamic-plugins/lib/index.js
+++ b/packages/gasket-plugin-dynamic-plugins/lib/index.js
@@ -10,23 +10,23 @@ export default {
   version,
   hooks: {
     async prepare(gasket, config) {
-      if (!gasket.config.dynamicPlugins?.length) return config;
+      if (!config.dynamicPlugins?.length) return config;
 
-      const load = await Promise.all(gasket.config.dynamicPlugins.map(plugin => import(plugin)));
+      const load = await Promise.all(config.dynamicPlugins.map(plugin => import(plugin)));
       load.forEach(mod => {
-        gasket.config.plugins.push(mod.default);
+        config.plugins.push(mod.default);
       });
-      gasket.engine.registerPlugins(gasket.config.plugins);
+      gasket.engine.registerPlugins(config.plugins);
       // eslint-disable-next-line no-sync
       gasket.execApplySync('init', function (plugin, handler) {
-        if (gasket.config.dynamicPlugins.includes(plugin.name)) {
+        if (config.dynamicPlugins.includes(plugin.name)) {
           handler();
         }
       });
       // eslint-disable-next-line no-sync
       gasket.execApplySync('configure', async function (plugin, handler) {
-        if (gasket.config.dynamicPlugins.includes(plugin.name)) {
-          gasket.config = handler(gasket.config);
+        if (config.dynamicPlugins.includes(plugin.name)) {
+          config = handler(config);
         }
       });
 

--- a/packages/gasket-plugin-dynamic-plugins/lib/index.js
+++ b/packages/gasket-plugin-dynamic-plugins/lib/index.js
@@ -9,8 +9,8 @@ export default {
   name,
   version,
   hooks: {
-    async prepare(gasket) {
-      if (!gasket.config.dynamicPlugins?.length) return;
+    async prepare(gasket, config) {
+      if (!gasket.config.dynamicPlugins?.length) return config;
 
       const load = await Promise.all(gasket.config.dynamicPlugins.map(plugin => import(plugin)));
       load.forEach(mod => {
@@ -29,6 +29,8 @@ export default {
           gasket.config = handler(gasket.config);
         }
       });
+
+      return config;
     },
     metadata(gasket, meta) {
       return {

--- a/packages/gasket-plugin-dynamic-plugins/test/prepare-hook.test.js
+++ b/packages/gasket-plugin-dynamic-plugins/test/prepare-hook.test.js
@@ -23,7 +23,6 @@ describe('Prepare Hook', () => {
   let registerPluginsSpy, execApplySyncSpy, generateGasket, mockConfig;
 
   beforeEach(() => {
-    mockConfig = {};
     generateGasket = function (gasketEnv) {
       process.env.GASKET_ENV = gasketEnv;
       const gasket = makeGasket({
@@ -43,6 +42,7 @@ describe('Prepare Hook', () => {
           }
         }
       });
+      mockConfig = gasket.config;
       registerPluginsSpy = jest.spyOn(gasket.engine, 'registerPlugins');
       execApplySyncSpy = jest.spyOn(gasket, 'execApplySync');
       return gasket;

--- a/packages/gasket-plugin-dynamic-plugins/test/prepare-hook.test.js
+++ b/packages/gasket-plugin-dynamic-plugins/test/prepare-hook.test.js
@@ -20,9 +20,10 @@ jest.unstable_mockModule('@gasket/plugin-two', () => mockPluginTwo);
 const pluginDynamicPlugins = (await import('../lib/index.js')).default;
 
 describe('Prepare Hook', () => {
-  let registerPluginsSpy, execApplySyncSpy, generateGasket;
+  let registerPluginsSpy, execApplySyncSpy, generateGasket, mockConfig;
 
   beforeEach(() => {
+    mockConfig = {};
     generateGasket = function (gasketEnv) {
       process.env.GASKET_ENV = gasketEnv;
       const gasket = makeGasket({
@@ -55,7 +56,7 @@ describe('Prepare Hook', () => {
 
   it('does not register dynamic plugins if GASKET_ENV is not set', async () => {
     const gasket = generateGasket();
-    await pluginDynamicPlugins.hooks.prepare(gasket);
+    await pluginDynamicPlugins.hooks.prepare(gasket, mockConfig);
     expect(registerPluginsSpy).not.toHaveBeenCalled();
     expect(execApplySyncSpy).not.toHaveBeenCalled();
   });
@@ -63,7 +64,7 @@ describe('Prepare Hook', () => {
   it('does not add plugins if dynamicPlugins is not set on a GASKET_ENV', async () => {
     jest.clearAllMocks();
     const gasket = generateGasket('local.nothing');
-    await pluginDynamicPlugins.hooks.prepare(gasket);
+    await pluginDynamicPlugins.hooks.prepare(gasket, mockConfig);
     expect(registerPluginsSpy).not.toHaveBeenCalled();
     expect(execApplySyncSpy).not.toHaveBeenCalled();
   });
@@ -71,7 +72,7 @@ describe('Prepare Hook', () => {
   it('registers dynamic plugins and calls hooks for a specific GASKET_ENV', async () => {
     jest.clearAllMocks();
     const gasket = generateGasket('local.both');
-    await pluginDynamicPlugins.hooks.prepare(gasket);
+    await pluginDynamicPlugins.hooks.prepare(gasket, mockConfig);
     expect(gasket.engine.registerPlugins).toHaveBeenCalledWith(expect.arrayContaining([mockPluginOne.default, mockPluginTwo.default]));
     expect(gasket.config.plugins).toContain(mockPluginOne.default);
     expect(gasket.config.plugins).toContain(mockPluginTwo.default);
@@ -82,7 +83,7 @@ describe('Prepare Hook', () => {
   it('registers dynamic plugins and calls hooks for another GASKET_ENV', async () => {
     jest.clearAllMocks();
     const gasket = generateGasket('local.two');
-    await pluginDynamicPlugins.hooks.prepare(gasket);
+    await pluginDynamicPlugins.hooks.prepare(gasket, mockConfig);
     expect(gasket.engine.registerPlugins).toHaveBeenCalledWith(expect.arrayContaining([mockPluginTwo.default]));
     expect(gasket.config.plugins).toContain(mockPluginTwo.default);
     expect(execApplySyncSpy).toHaveBeenNthCalledWith(1, 'init', expect.any(Function));


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
Fix issue where the Commander instance was parsing the CLI args more than once during create.
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
- Add logic to the `ready` hook of the command plugin to only parse when the `gasket.config.command` is present
- Fixup dynamic-plugins plugin `prepare` hook to return the config
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
Updated tests
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
