### PR TITLE
Prod proxy support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14150,6 +14150,48 @@
         "typedarray": "^0.0.6"
       }
     },
+    "node_modules/concurrently": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.1.0.tgz",
+      "integrity": "sha512-VxkzwMAn4LP7WyMnJNbHN5mKV9L2IbyDjpzemKr99sXNR3GqRNMMHdm7prV1ws9wg7ETj6WUkNOigZVsptwbgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/config-chain": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
@@ -38747,6 +38789,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/treeverse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
@@ -43439,6 +43491,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.5",
+        "concurrently": "^9.1.0",
         "cross-env": "^7.0.3",
         "eslint": "^8.56.0",
         "eslint-config-godaddy": "^7.1.1",

--- a/packages/gasket-plugin-data/lib/create.js
+++ b/packages/gasket-plugin-data/lib/create.js
@@ -9,9 +9,7 @@ async function create(gasket, {
   pkg,
   files,
   gasketConfig,
-  typescript,
-  nextServerType,
-  apiApp
+  typescript
 }) {
   pkg.add('dependencies', {
     [name]: `^${version}`,

--- a/packages/gasket-plugin-data/lib/create.js
+++ b/packages/gasket-plugin-data/lib/create.js
@@ -27,15 +27,8 @@ async function create(gasket, {
   gasketConfig
     .addPlugin('pluginData', name);
 
-  // Default server TS use .ts
-  // Else use .js
-  let importFile = './gasket-data.js';
-  if (typescript && nextServerType !== 'customServer' && !apiApp) {
-    importFile = './gasket-data.ts';
-  }
-
   gasketConfig
-    .addImport('gasketData', `${importFile}`)
+    .addImport('gasketData', `./gasket-data.js`)
     .injectValue('data', 'gasketData');
 }
 

--- a/packages/gasket-plugin-data/test/create.test.js
+++ b/packages/gasket-plugin-data/test/create.test.js
@@ -72,15 +72,9 @@ describe('create', function () {
     expect(mockContext.gasketConfig.addImport).toHaveBeenCalledWith('gasketData', './gasket-data.js');
   });
 
-  it('adds TS data file import to the gasket file', async function () {
+  it('adds .js import', async function () {
     mockContext.typescript = true;
-    await plugin.hooks.create({}, mockContext);
-    expect(mockContext.gasketConfig.addImport).toHaveBeenCalledWith('gasketData', './gasket-data.ts');
-  });
-
-  it('adds .js import for customServer', async function () {
-    mockContext.typescript = true;
-    mockContext.nextServerType = 'customServer';
+    mockContext.nextServerType = 'appRouter';
     await plugin.hooks.create({}, mockContext);
     expect(mockContext.gasketConfig.addImport).toHaveBeenCalledWith('gasketData', './gasket-data.js');
   });

--- a/packages/gasket-plugin-nextjs/generator/app/app-router/app/layout.tsx
+++ b/packages/gasket-plugin-nextjs/generator/app/app-router/app/layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import gasket from '../gasket';
+import gasket from '@/gasket'; // tsconfig alias
 import { withGasketData } from '@gasket/nextjs/layout';
 
 function RootLayout({ children }) {

--- a/packages/gasket-plugin-nextjs/generator/app/page-router/pages/_document.ts
+++ b/packages/gasket-plugin-nextjs/generator/app/page-router/pages/_document.ts
@@ -1,8 +1,5 @@
 import Document from 'next/document';
 import { withGasketData } from '@gasket/nextjs/document';
-{{#if (eq nextServerType 'customServer')}}
 import gasket from '@/gasket'; // tsconfig path alias
-{{else}}
-import gasket from '../gasket';
-{{/if}}
+
 export default withGasketData(gasket)(Document);

--- a/packages/gasket-plugin-nextjs/generator/next/typescript/next-env.d.ts
+++ b/packages/gasket-plugin-nextjs/generator/next/typescript/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/packages/gasket-plugin-nextjs/lib/create.js
+++ b/packages/gasket-plugin-nextjs/lib/create.js
@@ -171,7 +171,7 @@ function addNpmScripts({ pkg, nextServerType, nextDevProxy, typescript, hasGaske
       scripts['build:tsc'] = 'tsc -p ./tsconfig.server.json';
       scripts.build = 'npm run build:tsc && next build';
       scripts['start:https'] = `node dist/server.js`;
-      scripts.local = 'concurrently \"npm run build:tsc:watch\" \"npm run local:https\" \"next dev\"';
+      scripts.local = 'concurrently "npm run build:tsc:watch" "npm run local:https" "next dev"';
     }
   }
 

--- a/packages/gasket-plugin-nextjs/lib/create.js
+++ b/packages/gasket-plugin-nextjs/lib/create.js
@@ -157,9 +157,10 @@ function addNpmScripts({ pkg, nextServerType, nextDevProxy, typescript, hasGaske
     scripts.local = `GASKET_DEV=1 ${watcher} server.${fileExtension}`;
     if (typescript) {
       scripts['build:tsc'] = 'tsc -p ./tsconfig.server.json';
+      scripts['build:tsc:watch'] = 'tsc -p ./tsconfig.server.json --watch';
       scripts.build = 'npm run build:tsc && next build';
       scripts.start = 'node dist/server.js';
-      scripts.local = `npm run build:tsc && GASKET_DEV=1 ${watcher} server.${fileExtension}`;
+      scripts.local = `concurrently "npm run build:tsc:watch" "GASKET_DEV=1 ${watcher} server.${fileExtension}"`;
     }
   } else if (nextDevProxy) {
     scripts['start:https'] = `node server.js`;

--- a/packages/gasket-plugin-nextjs/lib/create.js
+++ b/packages/gasket-plugin-nextjs/lib/create.js
@@ -166,7 +166,7 @@ function addNpmScripts({ pkg, nextServerType, nextDevProxy, typescript, hasGaske
     scripts['start:https'] = `node server.js`;
     scripts['local:https'] = `${watcher} server.${fileExtension}`;
     scripts.start = `npm run start:https & next start`;
-    scripts.local = ` npm run local:https & next dev`;
+    scripts.local = `npm run local:https & next dev`;
     if (typescript) {
       scripts['build:tsc:watch'] = 'tsc -p ./tsconfig.server.json --watch';
       scripts['build:tsc'] = 'tsc -p ./tsconfig.server.json';

--- a/packages/gasket-plugin-nextjs/lib/create.js
+++ b/packages/gasket-plugin-nextjs/lib/create.js
@@ -164,12 +164,14 @@ function addNpmScripts({ pkg, nextServerType, nextDevProxy, typescript, hasGaske
   } else if (nextDevProxy) {
     scripts['start:https'] = `node server.js`;
     scripts['local:https'] = `${watcher} server.${fileExtension}`;
-    scripts.start = `next start & npm run start:https`;
-    scripts.local = `next dev & npm run local:https`;
+    scripts.start = `npm run start:https & next start`;
+    scripts.local = ` npm run local:https & next dev`;
     if (typescript) {
+      scripts['build:tsc:watch'] = 'tsc -p ./tsconfig.server.json --watch';
       scripts['build:tsc'] = 'tsc -p ./tsconfig.server.json';
       scripts.build = 'npm run build:tsc && next build';
       scripts['start:https'] = `node dist/server.js`;
+      scripts.local = 'concurrently \"npm run build:tsc:watch\" \"npm run local:https\" \"next dev\"';
     }
   }
 

--- a/packages/gasket-plugin-nextjs/test/create.test.js
+++ b/packages/gasket-plugin-nextjs/test/create.test.js
@@ -318,10 +318,11 @@ describe('create hook', () => {
       await create.handler({}, mockContext);
       expect(mockContext.pkg.add).toHaveBeenCalledWith('scripts', {
         'build:tsc': 'tsc -p ./tsconfig.server.json',
+        'build:tsc:watch': 'tsc -p ./tsconfig.server.json --watch',
         'build': 'npm run build:tsc && next build',
         'start': 'node dist/server.js',
         'preview': 'npm run build && npm run start',
-        'local': 'npm run build:tsc && GASKET_DEV=1 tsx watch server.ts',
+        'local': 'concurrently "npm run build:tsc:watch" "GASKET_DEV=1 tsx watch server.ts"',
         'prebuild': 'tsx gasket.ts build'
       });
     });

--- a/packages/gasket-plugin-nextjs/test/create.test.js
+++ b/packages/gasket-plugin-nextjs/test/create.test.js
@@ -289,12 +289,12 @@ describe('create hook', () => {
       mockContext.nextDevProxy = true;
       await create.handler({}, mockContext);
       expect(mockContext.pkg.add).toHaveBeenCalledWith('scripts', {
-        'start:https': 'node server.js',
-        'local:https': 'nodemon server.js',
-        'start': 'next start & npm run start:https',
-        'local': 'next dev & npm run local:https',
+        'build': 'next build',
+        'start': 'npm run start:https & next start',
+        'local': ' npm run local:https & next dev',
         'preview': 'npm run build && npm run start',
-        'build': 'next build'
+        'start:https': 'node server.js',
+        'local:https': 'nodemon server.js'
       });
     });
 
@@ -326,7 +326,7 @@ describe('create hook', () => {
       });
     });
 
-    it('adjusts scripts for devProxy & typescript', async function () {
+    it('adjusts scripts for nextDevProxy & typescript', async function () {
       mockContext.nextServerType = 'appRouter';
       mockContext.nextDevProxy = true;
       mockContext.typescript = true;
@@ -335,9 +335,10 @@ describe('create hook', () => {
       expect(mockContext.pkg.add).toHaveBeenCalledWith('scripts', {
         'start:https': 'node dist/server.js',
         'local:https': 'tsx watch server.ts',
-        'start': 'next start & npm run start:https',
-        'local': 'next dev & npm run local:https',
+        'start': 'npm run start:https & next start',
+        'local': 'concurrently "npm run build:tsc:watch" "npm run local:https" "next dev"',
         'build:tsc': 'tsc -p ./tsconfig.server.json',
+        'build:tsc:watch': 'tsc -p ./tsconfig.server.json --watch',
         'build': 'npm run build:tsc && next build',
         'preview': 'npm run build && npm run start',
         'prebuild': 'tsx gasket.ts build'

--- a/packages/gasket-plugin-nextjs/test/create.test.js
+++ b/packages/gasket-plugin-nextjs/test/create.test.js
@@ -291,7 +291,7 @@ describe('create hook', () => {
       expect(mockContext.pkg.add).toHaveBeenCalledWith('scripts', {
         'build': 'next build',
         'start': 'npm run start:https & next start',
-        'local': ' npm run local:https & next dev',
+        'local': 'npm run local:https & next dev',
         'preview': 'npm run build && npm run start',
         'start:https': 'node server.js',
         'local:https': 'nodemon server.js'

--- a/packages/gasket-plugin-typescript/lib/create.js
+++ b/packages/gasket-plugin-typescript/lib/create.js
@@ -21,6 +21,13 @@ module.exports = async function create(gasket, context) {
     typescript: devDependencies.typescript
   });
 
+  // Add devDependencies for non-API apps
+  if (!apiApp) {
+    pkg.add('devDependencies', {
+      concurrently: devDependencies.concurrently
+    });
+  }
+
   // Shared add TS links
   readme
     .link('tsx', 'https://tsx.is/')
@@ -58,9 +65,6 @@ module.exports = async function create(gasket, context) {
   // Also add concurrently for running multiple scripts
   if (nextDevProxy) {
     files.add(`${generatorDir}/next/*`, `${generatorDir}/shared/*`);
-    pkg.add('devDependencies', {
-      concurrently: devDependencies.concurrently
-    });
   }
 
   // Files for Next.js default server w/o dev proxy

--- a/packages/gasket-plugin-typescript/lib/create.js
+++ b/packages/gasket-plugin-typescript/lib/create.js
@@ -59,7 +59,7 @@ module.exports = async function create(gasket, context) {
   if (nextDevProxy) {
     files.add(`${generatorDir}/next/*`, `${generatorDir}/shared/*`);
     pkg.add('devDependencies', {
-      concurrently: devDependencies.concurrently,
+      concurrently: devDependencies.concurrently
     });
   }
 

--- a/packages/gasket-plugin-typescript/lib/create.js
+++ b/packages/gasket-plugin-typescript/lib/create.js
@@ -55,8 +55,12 @@ module.exports = async function create(gasket, context) {
   }
 
   // Files for Next.js default server w/ https proxy
+  // Also add concurrently for running multiple scripts
   if (nextDevProxy) {
     files.add(`${generatorDir}/next/*`, `${generatorDir}/shared/*`);
+    pkg.add('devDependencies', {
+      concurrently: devDependencies.concurrently,
+    });
   }
 
   // Files for Next.js default server w/o dev proxy

--- a/packages/gasket-plugin-typescript/package.json
+++ b/packages/gasket-plugin-typescript/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.5",
+    "concurrently": "^9.1.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.56.0",
     "eslint-config-godaddy": "^7.1.1",

--- a/packages/gasket-plugin-typescript/test/create.test.js
+++ b/packages/gasket-plugin-typescript/test/create.test.js
@@ -135,8 +135,8 @@ describe('create hook', () => {
       );
     });
 
-    it('adds concurrently for dev proxy', () => {
-      mockContext.nextDevProxy = true;
+    it('adds concurrently for non-API apps', () => {
+      mockContext.apiApp = false;
       create({}, mockContext);
       expect(mockContext.pkg.add).toHaveBeenCalledWith('devDependencies', {
         concurrently: devDependencies.concurrently

--- a/packages/gasket-plugin-typescript/test/create.test.js
+++ b/packages/gasket-plugin-typescript/test/create.test.js
@@ -134,5 +134,13 @@ describe('create hook', () => {
         expect.stringMatching(/generator\/shared\/\*$/)
       );
     });
+
+    it('adds concurrently for dev proxy', () => {
+      mockContext.nextDevProxy = true;
+      create({}, mockContext);
+      expect(mockContext.pkg.add).toHaveBeenCalledWith('devDependencies', {
+        concurrently: devDependencies.concurrently
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
Tuning to allow for the new `gasket-plugin-https-proxy` to be implemented correctly. Proxies we're never considered in the production use case so now we can allow for a proxy setup in non-local situations.

- Force `gasket-data` to `.js` for app variations
- Update generated file gasket imports to use `@/gasket` alias in TS scenarios
- Tune TS app `local` scripts to correctly rebuild the `dist` folder (issue with Page Router Default Server where the `dist` directory changes doesn't cause a reload in `next dev` but it works in app router 🤷‍♂️  Ticket to be created).
- Add `concurrently` for `local` script reloading
- Tune `local` script for all server types
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
- Tuning to allow for the new `gasket-plugin-https-proxy` to be implemented correctly for prod use cases
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
Tests updated
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
