### PR TITLE
adjust cookie parser invocation to earlier in the lifecycle chain

### DIFF
--- a/packages/gasket-plugin-express/CHANGELOG.md
+++ b/packages/gasket-plugin-express/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-express`
 
+- adjust cookie parser invocation to earlier in the lifecycle chain ([#1009])
+
 ### 7.1.1
 
 - Ensure cookies are parsed ([#1001])
@@ -146,3 +148,4 @@
 [#959]: https://github.com/godaddy/gasket/pull/959
 [#969]: https://github.com/godaddy/gasket/pull/969
 [#1001]: https://github.com/godaddy/gasket/pull/1001
+[#1009]: https://github.com/godaddy/gasket/pull/1009

--- a/packages/gasket-plugin-express/lib/create-servers.js
+++ b/packages/gasket-plugin-express/lib/create-servers.js
@@ -8,7 +8,6 @@
  */
 module.exports = async function createServers(gasket, serverOpts) {
   const app = gasket.actions.getExpressApp();
-  app.use(require('cookie-parser')());
 
   await gasket.exec('express', app);
 

--- a/packages/gasket-plugin-express/lib/index.js
+++ b/packages/gasket-plugin-express/lib/index.js
@@ -17,7 +17,16 @@ const plugin = {
     getExpressApp(gasket) {
       const express = require('express');
       const { http2 } = gasket.config;
-      app ??= http2 ? require('http2-express')(express) : express();
+
+      if (!app) {
+        if (http2) {
+          app = require('http2-express')(express);
+        } else {
+          app = express();
+        }
+
+        app.use(require('cookie-parser')());
+      }
 
       return app;
     }

--- a/packages/gasket-plugin-express/test/plugin.test.js
+++ b/packages/gasket-plugin-express/test/plugin.test.js
@@ -87,7 +87,7 @@ describe('createServers', () => {
   });
 
   it('attaches cookie parser middleware', async function () {
-    await plugin.hooks.createServers(gasket, {});
+    plugin.actions.getExpressApp(gasket);
     expect(app.use).toHaveBeenCalledWith(cookieParserMiddleware);
   });
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
`createServers` is too late for the `cookie-parser` middleware to be applied. In API apps, the express instance is already mutated before the server is created.
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog
- adjust cookie parser invocation to earlier in the lifecycle chain
<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan
tests updated
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
