### PR TITLE
Add addEnvironment to ConfigBuilder - use with Analyze plugin

### DIFF
--- a/packages/create-gasket-app/CHANGELOG.md
+++ b/packages/create-gasket-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `create-gasket-app`
 
+- Add `addEnvironment` method for create context ([#1010])
+
 ### 7.2.0
 
 - Move default plugins into presets ([#1014])
@@ -88,4 +90,5 @@ Added `@gasket/plugin-dynamic-plugin` to default plugins ([#970])
 [#936]: https://github.com/godaddy/gasket/pull/936
 [#943]: https://github.com/godaddy/gasket/pull/943
 [#970]: https://github.com/godaddy/gasket/pull/970
+[#1010]: https://github.com/godaddy/gasket/pull/1010
 [#1014]: https://github.com/godaddy/gasket/pull/1014

--- a/packages/create-gasket-app/lib/index.d.ts
+++ b/packages/create-gasket-app/lib/index.d.ts
@@ -138,6 +138,25 @@ export interface ConfigBuilder<Config> {
   addPlugin(pluginImport: string, pluginName: string): void;
 
   /**
+   * addEnvironment - Add environments to the gasket file and use the value in the plugins array
+   * @param {string} key - name of the environment - `local.analyze`
+   * @param {object} value - configuration for the environment - `{
+   *   dynamicPlugins: [
+   *     '@gasket/plugin-analyze',
+   *   ]
+   * }`
+   * @example
+   *   environments: {
+   *    'local.analyze': {
+   *      dynamicPlugins: [
+   *        '@gasket/plugin-analyze',
+   *      ]
+   *     }
+   *   },
+   */
+  addEnvironment(key:string, value: object): void;
+
+  /**
    * addImport - Add a non-plugin import to the gasket file
    * @param {string} importName - name of the import used as a value - `import fs...`
    * @param {string} importPath - path of the import - `from 'fs'`

--- a/packages/create-gasket-app/lib/scaffold/config-builder.js
+++ b/packages/create-gasket-app/lib/scaffold/config-builder.js
@@ -239,7 +239,7 @@ export class ConfigBuilder {
   }
 
   /**
-   * addEnvironment - Add environments to the gasket file and use the value in the plugins array
+   * addEnvironment - Add environments to the gasket file
    * @param {string} key - name of the environment - `local.analyze`
    * @param {object} value - configuration for the environment - `{
    *   dynamicPlugins: [
@@ -259,6 +259,14 @@ export class ConfigBuilder {
     this.add('environments', {
       [key]: value
     });
+  }
+
+  /**
+   * addDynamicPlugin - Add plugin to the the dynamicPlugins array
+   * @param {string} pluginName - Name of the plugin to add to the dynamicPlugins array - `@gasket/plugin-example`
+   */
+  addDynamicPlugin(pluginName) {
+    this.add('dynamicPlugins', [`${pluginName}`]);
   }
 
   /**

--- a/packages/create-gasket-app/lib/scaffold/config-builder.js
+++ b/packages/create-gasket-app/lib/scaffold/config-builder.js
@@ -256,7 +256,7 @@ export class ConfigBuilder {
    *   },
    */
   addEnvironment(key, value) {
-    this.add(`environments`, {
+    this.add('environments', {
       [key]: value
     });
   }

--- a/packages/create-gasket-app/lib/scaffold/config-builder.js
+++ b/packages/create-gasket-app/lib/scaffold/config-builder.js
@@ -262,14 +262,6 @@ export class ConfigBuilder {
   }
 
   /**
-   * addDynamicPlugin - Add plugin to the the dynamicPlugins array
-   * @param {string} pluginName - Name of the plugin to add to the dynamicPlugins array - `@gasket/plugin-example`
-   */
-  addDynamicPlugin(pluginName) {
-    this.add('dynamicPlugins', [`${pluginName}`]);
-  }
-
-  /**
    * addImport - Add a non-plugin import to the gasket file
    * @param {string} importName - name of the import used as a value - `import fs...`
    * @param {string} importPath - path of the import - `from 'fs'`

--- a/packages/create-gasket-app/lib/scaffold/config-builder.js
+++ b/packages/create-gasket-app/lib/scaffold/config-builder.js
@@ -239,6 +239,29 @@ export class ConfigBuilder {
   }
 
   /**
+   * addEnvironment - Add environments to the gasket file and use the value in the plugins array
+   * @param {string} key - name of the environment - `local.analyze`
+   * @param {object} value - configuration for the environment - `{
+   *   dynamicPlugins: [
+   *     '@gasket/plugin-analyze',
+   *   ]
+   * }`
+   * @example
+   *   environments: {
+   *    'local.analyze': {
+   *      dynamicPlugins: [
+   *        '@gasket/plugin-analyze',
+   *      ]
+   *     }
+   *   },
+   */
+  addEnvironment(key, value) {
+    this.add(`environments`, {
+      [key]: value
+    });
+  }
+
+  /**
    * addImport - Add a non-plugin import to the gasket file
    * @param {string} importName - name of the import used as a value - `import fs...`
    * @param {string} importPath - path of the import - `from 'fs'`

--- a/packages/create-gasket-app/test/unit/scaffold/config-builder.test.js
+++ b/packages/create-gasket-app/test/unit/scaffold/config-builder.test.js
@@ -511,4 +511,32 @@ describe('ConfigBuilder', () => {
       expect(warnings).toHaveLength(1);
     });
   });
+
+
+  describe('.addEnvironment', () => {
+    let gasketConfig;
+    beforeEach(() => {
+      gasketConfig = new ConfigBuilder();
+    });
+
+    it('adds an environment to gasketConfig', () => {
+      gasketConfig.addEnvironment('test.env', { test: 'config ' });
+      expect(gasketConfig.fields.environments).toEqual({ 'test.env': { test: 'config ' } });
+    });
+
+    it('adds values to an environment in gasketConfig', () => {
+      gasketConfig.addEnvironment('test.env', { test: 'config ' });
+      gasketConfig.addEnvironment('test.env', { test2: 'config 2' });
+      expect(gasketConfig.fields.environments).toEqual({ 'test.env': { test: 'config ', test2: 'config 2' } });
+    });
+
+    it('adds multiple environments to gasketConfig', () => {
+      gasketConfig.addEnvironment('test.env', { test: 'config ' });
+      gasketConfig.addEnvironment('prod.env', { prod: 'config ' });
+      expect(gasketConfig.fields.environments).toEqual({
+        'test.env': { test: 'config ' },
+        'prod.env': { prod: 'config ' }
+      });
+    });
+  });
 });

--- a/packages/create-gasket-app/test/unit/scaffold/config-builder.test.js
+++ b/packages/create-gasket-app/test/unit/scaffold/config-builder.test.js
@@ -512,37 +512,36 @@ describe('ConfigBuilder', () => {
     });
   });
 
-  describe('gasketConfig', () => {
+
+  describe('.addEnvironment', () => {
     let gasketConfig;
     beforeEach(() => {
       gasketConfig = new ConfigBuilder();
     });
 
-    describe('.addEnvironment', () => {
-      it('adds an environment to gasketConfig', () => {
-        gasketConfig.addEnvironment('test.env', { test: 'config ' });
-        expect(gasketConfig.fields.environments).toEqual({ 'test.env': { test: 'config ' } });
-      });
+    it('adds an environment to gasketConfig', () => {
+      gasketConfig.addEnvironment('test.env', { test: 'config ' });
+      expect(gasketConfig.fields.environments).toEqual({ 'test.env': { test: 'config ' } });
+    });
 
-      it('adds values to an environment in gasketConfig', () => {
-        gasketConfig.addEnvironment('test.env', { test: 'config' });
-        gasketConfig.addEnvironment('test.env', { test2: 'config 2' });
-        expect(gasketConfig.fields.environments).toEqual({ 'test.env': { test: 'config', test2: 'config 2' } });
-      });
+    it('adds values to an environment in gasketConfig', () => {
+      gasketConfig.addEnvironment('test.env', { test: 'config ' });
+      gasketConfig.addEnvironment('test.env', { test2: 'config 2' });
+      expect(gasketConfig.fields.environments).toEqual({ 'test.env': { test: 'config ', test2: 'config 2' } });
+    });
 
-      it('adds array values to an environment in gasketConfig', () => {
-        gasketConfig.addEnvironment('test.env', { dynamicPlugins: ['pluginOne'] });
-        gasketConfig.addEnvironment('test.env', { dynamicPlugins: ['pluginTwo'] });
-        expect(gasketConfig.fields.environments).toEqual({ 'test.env': { dynamicPlugins: ['pluginOne', 'pluginTwo'] } });
-      });
+    it('adds array values to an environment in gasketConfig', () => {
+      gasketConfig.addEnvironment('test.env', { dynamicPlugins: ['pluginOne'] });
+      gasketConfig.addEnvironment('test.env', { dynamicPlugins: ['pluginTwo'] });
+      expect(gasketConfig.fields.environments).toEqual({ 'test.env': { dynamicPlugins: ['pluginOne', 'pluginTwo'] } });
+    });
 
-      it('adds multiple environments to gasketConfig', () => {
-        gasketConfig.addEnvironment('test.env', { test: 'config ' });
-        gasketConfig.addEnvironment('prod.env', { prod: 'config ' });
-        expect(gasketConfig.fields.environments).toEqual({
-          'test.env': { test: 'config ' },
-          'prod.env': { prod: 'config ' }
-        });
+    it('adds multiple environments to gasketConfig', () => {
+      gasketConfig.addEnvironment('test.env', { test: 'config ' });
+      gasketConfig.addEnvironment('prod.env', { prod: 'config ' });
+      expect(gasketConfig.fields.environments).toEqual({
+        'test.env': { test: 'config ' },
+        'prod.env': { prod: 'config ' }
       });
     });
   });

--- a/packages/create-gasket-app/test/unit/scaffold/config-builder.test.js
+++ b/packages/create-gasket-app/test/unit/scaffold/config-builder.test.js
@@ -512,30 +512,44 @@ describe('ConfigBuilder', () => {
     });
   });
 
-
-  describe('.addEnvironment', () => {
+  describe('gasketConfig', () => {
     let gasketConfig;
     beforeEach(() => {
       gasketConfig = new ConfigBuilder();
     });
 
-    it('adds an environment to gasketConfig', () => {
-      gasketConfig.addEnvironment('test.env', { test: 'config ' });
-      expect(gasketConfig.fields.environments).toEqual({ 'test.env': { test: 'config ' } });
+    describe('.addDynamicPlugin', () => {
+      it('adds a dynamic plugin to gasketConfig', () => {
+        gasketConfig.addDynamicPlugin('pluginOne');
+        expect(gasketConfig.fields.dynamicPlugins).toEqual(['pluginOne']);
+      });
+
+      it('adds multiple dynamic plugins to gasketConfig', () => {
+        gasketConfig.addDynamicPlugin('pluginOne');
+        gasketConfig.addDynamicPlugin('pluginTwo');
+        expect(gasketConfig.fields.dynamicPlugins).toEqual(['pluginOne', 'pluginTwo']);
+      });
     });
 
-    it('adds values to an environment in gasketConfig', () => {
-      gasketConfig.addEnvironment('test.env', { test: 'config ' });
-      gasketConfig.addEnvironment('test.env', { test2: 'config 2' });
-      expect(gasketConfig.fields.environments).toEqual({ 'test.env': { test: 'config ', test2: 'config 2' } });
-    });
+    describe('.addEnvironment', () => {
+      it('adds an environment to gasketConfig', () => {
+        gasketConfig.addEnvironment('test.env', { test: 'config ' });
+        expect(gasketConfig.fields.environments).toEqual({ 'test.env': { test: 'config ' } });
+      });
 
-    it('adds multiple environments to gasketConfig', () => {
-      gasketConfig.addEnvironment('test.env', { test: 'config ' });
-      gasketConfig.addEnvironment('prod.env', { prod: 'config ' });
-      expect(gasketConfig.fields.environments).toEqual({
-        'test.env': { test: 'config ' },
-        'prod.env': { prod: 'config ' }
+      it('adds values to an environment in gasketConfig', () => {
+        gasketConfig.addEnvironment('test.env', { test: 'config ' });
+        gasketConfig.addEnvironment('test.env', { test2: 'config 2' });
+        expect(gasketConfig.fields.environments).toEqual({ 'test.env': { test: 'config ', test2: 'config 2' } });
+      });
+
+      it('adds multiple environments to gasketConfig', () => {
+        gasketConfig.addEnvironment('test.env', { test: 'config ' });
+        gasketConfig.addEnvironment('prod.env', { prod: 'config ' });
+        expect(gasketConfig.fields.environments).toEqual({
+          'test.env': { test: 'config ' },
+          'prod.env': { prod: 'config ' }
+        });
       });
     });
   });

--- a/packages/create-gasket-app/test/unit/scaffold/config-builder.test.js
+++ b/packages/create-gasket-app/test/unit/scaffold/config-builder.test.js
@@ -518,19 +518,6 @@ describe('ConfigBuilder', () => {
       gasketConfig = new ConfigBuilder();
     });
 
-    describe('.addDynamicPlugin', () => {
-      it('adds a dynamic plugin to gasketConfig', () => {
-        gasketConfig.addDynamicPlugin('pluginOne');
-        expect(gasketConfig.fields.dynamicPlugins).toEqual(['pluginOne']);
-      });
-
-      it('adds multiple dynamic plugins to gasketConfig', () => {
-        gasketConfig.addDynamicPlugin('pluginOne');
-        gasketConfig.addDynamicPlugin('pluginTwo');
-        expect(gasketConfig.fields.dynamicPlugins).toEqual(['pluginOne', 'pluginTwo']);
-      });
-    });
-
     describe('.addEnvironment', () => {
       it('adds an environment to gasketConfig', () => {
         gasketConfig.addEnvironment('test.env', { test: 'config ' });
@@ -538,9 +525,15 @@ describe('ConfigBuilder', () => {
       });
 
       it('adds values to an environment in gasketConfig', () => {
-        gasketConfig.addEnvironment('test.env', { test: 'config ' });
+        gasketConfig.addEnvironment('test.env', { test: 'config' });
         gasketConfig.addEnvironment('test.env', { test2: 'config 2' });
-        expect(gasketConfig.fields.environments).toEqual({ 'test.env': { test: 'config ', test2: 'config 2' } });
+        expect(gasketConfig.fields.environments).toEqual({ 'test.env': { test: 'config', test2: 'config 2' } });
+      });
+
+      it('adds array values to an environment in gasketConfig', () => {
+        gasketConfig.addEnvironment('test.env', { dynamicPlugins: ['pluginOne'] });
+        gasketConfig.addEnvironment('test.env', { dynamicPlugins: ['pluginTwo'] });
+        expect(gasketConfig.fields.environments).toEqual({ 'test.env': { dynamicPlugins: ['pluginOne', 'pluginTwo'] } });
       });
 
       it('adds multiple environments to gasketConfig', () => {

--- a/packages/gasket-plugin-analyze/CHANGELOG.md
+++ b/packages/gasket-plugin-analyze/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `@gasket/plugin-analyze`
 
+- Update create to use environment config ([#1010])
+  - Fix for ANALYZE env var check with support for analyze in Gasket env check
+
 ### 7.1.0
 
 - Aligned version releases across all packages
@@ -84,3 +87,4 @@
 [#670]: https://github.com/godaddy/gasket/pull/670
 [#695]: https://github.com/godaddy/gasket/pull/695
 [#810]: https://github.com/godaddy/gasket/pull/810
+[#1010]: https://github.com/godaddy/gasket/pull/1010

--- a/packages/gasket-plugin-analyze/README.md
+++ b/packages/gasket-plugin-analyze/README.md
@@ -71,15 +71,15 @@ for each type of bundle (browser and server).
 
 ## NPM script
 
-### analyze
+### Environment Variable
 
 The npm script `analyze` will execute the following:
 
 ```bash
-ANALYZE=true next build
+ANALYZE=1 next build
 ```
 
-When this script is run, the `@gasket/plugin-analyse` will add the
+When this script is run, the `@gasket/plugin-analyze` will add the
 [webpack-bundle-analyzer] to the webpack config.
 
 Reports for both browser and server-side rendering will be generated, with the
@@ -88,7 +88,7 @@ following output:
 - `reports/browser-bundles.html`
 - `reports/server-bundles.html`
 
-Only when `ANALYZE=true` is set in the environment, will the analyzer plugin be
+Only when `process.env.ANALYZE` is set will the analyzer plugin be
 added to Webpack, ensuring that the bundle analyzer is used specifically for
 this analysis task.
 
@@ -103,6 +103,45 @@ npm run analyze
 The **browser** report will be most critical for analyzing bundle size
 optimizations, ensuring that the app is optimized for download efficiency from
 the user's perspective.
+
+### Gasket Environment
+
+An alternative way to configure and enable the bundle analyzer is to loading the
+plugin dynamically, and use a sub environment.
+
+```diff
+// gasket.js
+
++ import pluginDynamicPlugins from '@gasket/plugin-dynamic-plugins';
+
+export default makeGasket({
+  plugins: [
++   pluginDynamicPlugins
+  ],
+  dynamicPlugins: {
+    'local.analyze': {
+      plugins: [
+        '@gasket/plugin-analyze'
+      ]
+    }
+  }
+});
+```
+
+In your package.json, update the analyze npm script
+
+```diff
+{
+  "scripts": {
+-    "analyze": "ANALYZE=1 next build"
++    "analyze": "GASKET_ENV=local.analyze next build"
+  }
+}
+```
+
+This can server as an optimization so that the plugin will only be loaded for
+the `local.analyze` environment, and will allow you to change `@gasket/plugin-analyze`
+to be a dev dependency.
 
 ## License
 

--- a/packages/gasket-plugin-analyze/lib/create.js
+++ b/packages/gasket-plugin-analyze/lib/create.js
@@ -17,6 +17,6 @@ module.exports = function create(gasket, { pkg, gasketConfig }) {
   });
 
   pkg.add('scripts', {
-    analyze: 'GASKET_ENV=local.analyze ANALYZE=1 next build'
+    analyze: 'GASKET_ENV=local.analyze next build'
   });
 };

--- a/packages/gasket-plugin-analyze/lib/create.js
+++ b/packages/gasket-plugin-analyze/lib/create.js
@@ -6,13 +6,17 @@ const { name, version } = require('../package.json');
  * @type {import('@gasket/core').HookHandler<'create'>}
  */
 module.exports = function create(gasket, { pkg, gasketConfig }) {
-  gasketConfig.addPlugin('pluginAnalyze', name);
+  gasketConfig.addEnvironment('local.analyze', {
+    dynamicPlugins: [
+      '@gasket/plugin-analyze'
+    ]
+  });
 
   pkg.add('devDependencies', {
     [name]: `^${version}`
   });
 
   pkg.add('scripts', {
-    analyze: 'ANALYZE=true next build'
+    analyze: 'GASKET_ENV=local.analyze ANALYZE=1 next build'
   });
 };

--- a/packages/gasket-plugin-analyze/lib/webpack-config.js
+++ b/packages/gasket-plugin-analyze/lib/webpack-config.js
@@ -5,16 +5,19 @@
  * @type {import('@gasket/core').HookHandler<'webpackConfig'>}
  */
 module.exports = function webpackConfigHook(gasket, webpackConfig, context) {
+  // eslint-disable-next-line no-process-env
+  const { ANALYZE } = process.env;
   const {
-    config: { bundleAnalyzerConfig: userConfig = {} }
+    config: {
+      env,
+      bundleAnalyzerConfig: userConfig = {}
+    }
   } = gasket;
 
-  if (process.env.ANALYZE === 'true') {
-    console.warn("Deprecation Warning: Using 'true' for the ANALYZE environment variable is deprecated. Please use '1' instead.");
-  }
-  // Run the analyzer plugin if the ANALYZE flag is true or 1
-  // @deprecated: 'true' will be removed in a future release
-  if (process.env.ANALYZE === 'true' || process.env.ANALYZE === '1') {
+  const enabled = env.endsWith('analyze') || (ANALYZE && !['false', '0'].some(v => v === ANALYZE));
+
+  // Only add the analyzer plugin if enabled
+  if (enabled) {
     const merge = require('deepmerge');
     const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
     const defaultConfig = require('./default-config');

--- a/packages/gasket-plugin-analyze/lib/webpack-config.js
+++ b/packages/gasket-plugin-analyze/lib/webpack-config.js
@@ -9,8 +9,12 @@ module.exports = function webpackConfigHook(gasket, webpackConfig, context) {
     config: { bundleAnalyzerConfig: userConfig = {} }
   } = gasket;
 
-  // Only add the analyzer plugin if ANALYZE flag is true
   if (process.env.ANALYZE === 'true') {
+    console.warn("Deprecation Warning: Using 'true' for the ANALYZE environment variable is deprecated. Please use '1' instead.");
+  }
+
+  // Only add the analyzer plugin if ANALYZE flag is true
+  if (process.env.ANALYZE === 'true' || process.env.ANALYZE === '1') {
     const merge = require('deepmerge');
     const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
     const defaultConfig = require('./default-config');

--- a/packages/gasket-plugin-analyze/lib/webpack-config.js
+++ b/packages/gasket-plugin-analyze/lib/webpack-config.js
@@ -12,8 +12,8 @@ module.exports = function webpackConfigHook(gasket, webpackConfig, context) {
   if (process.env.ANALYZE === 'true') {
     console.warn("Deprecation Warning: Using 'true' for the ANALYZE environment variable is deprecated. Please use '1' instead.");
   }
-
-  // Only add the analyzer plugin if ANALYZE flag is true
+  // Run the analyzer plugin if the ANALYZE flag is true or 1
+  // @deprecated: 'true' will be removed in a future release
   if (process.env.ANALYZE === 'true' || process.env.ANALYZE === '1') {
     const merge = require('deepmerge');
     const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');

--- a/packages/gasket-plugin-analyze/test/create.spec.js
+++ b/packages/gasket-plugin-analyze/test/create.spec.js
@@ -11,7 +11,7 @@ describe('create', () => {
       [name]: `^${version}`
     }]);
     expect(add.mock.calls[1]).toEqual(['scripts', {
-      analyze: 'GASKET_ENV=local.analyze ANALYZE=1 next build'
+      analyze: 'GASKET_ENV=local.analyze next build'
     }]);
     expect(addEnvironment).toHaveBeenCalledWith('local.analyze', {
       dynamicPlugins: [

--- a/packages/gasket-plugin-analyze/test/create.spec.js
+++ b/packages/gasket-plugin-analyze/test/create.spec.js
@@ -5,14 +5,18 @@ describe('create', () => {
 
   it('adds the analyze script and adds the plugin', async () => {
     const add = jest.fn();
-    const addPlugin = jest.fn();
-    await create({}, { pkg: { add }, gasketConfig: { addPlugin } });
+    const addEnvironment = jest.fn();
+    await create({}, { pkg: { add }, gasketConfig: { addEnvironment } });
     expect(add.mock.calls[0]).toEqual(['devDependencies', {
       [name]: `^${version}`
     }]);
     expect(add.mock.calls[1]).toEqual(['scripts', {
-      analyze: 'ANALYZE=true next build'
+      analyze: 'GASKET_ENV=local.analyze ANALYZE=1 next build'
     }]);
-    expect(addPlugin.mock.calls[0]).toEqual(['pluginAnalyze', name]);
+    expect(addEnvironment).toHaveBeenCalledWith('local.analyze', {
+      dynamicPlugins: [
+        '@gasket/plugin-analyze'
+      ]
+    });
   });
 });

--- a/packages/gasket-plugin-analyze/test/webpack-config.spec.js
+++ b/packages/gasket-plugin-analyze/test/webpack-config.spec.js
@@ -10,10 +10,15 @@ describe('webpackConfig', () => {
 
   beforeEach(() => {
     mockGasket = {
-      config: {}
+      config: {
+        env: 'test'
+      }
     };
     mockWebpackConfig = { plugins: [] };
-    process.env.ANALYZE = 'true';
+  });
+
+  afterEach(() => {
+    delete process.env.ANALYZE;
   });
 
   it('returns updated webpack config object', () => {
@@ -23,19 +28,53 @@ describe('webpackConfig', () => {
     expect(results).toHaveProperty('plugins', expect.any(Array));
   });
 
-  it('adds BundleAnalyzerPlugin to plugins', () => {
+  it('adds BundleAnalyzerPlugin to plugins when Gasket sub env is analyze', () => {
+    mockGasket.config.env = 'test.analyze';
     results = webpack(mockGasket, mockWebpackConfig, mockNextData);
     const expectedPlugin = results.plugins[results.plugins.length - 1];
     expect(expectedPlugin).toBeInstanceOf(BundleAnalyzerPlugin);
   });
 
-  it('does not add BundleAnalyzerPlugin if not analyze script', () => {
-    process.env.ANALYZE = 'bogus';
+  it('adds BundleAnalyzerPlugin to plugins when process.env.ANALYZE=1', () => {
+    process.env.ANALYZE = '1';
+    results = webpack(mockGasket, mockWebpackConfig, mockNextData);
+    const expectedPlugin = results.plugins[results.plugins.length - 1];
+    expect(expectedPlugin).toBeInstanceOf(BundleAnalyzerPlugin);
+  });
+
+  it('adds BundleAnalyzerPlugin to plugins when process.env.ANALYZE=true', () => {
+    process.env.ANALYZE = 'true';
+    results = webpack(mockGasket, mockWebpackConfig, mockNextData);
+    const expectedPlugin = results.plugins[results.plugins.length - 1];
+    expect(expectedPlugin).toBeInstanceOf(BundleAnalyzerPlugin);
+  });
+
+  it('does not add BundleAnalyzerPlugin if no Gasket sub env analyze', () => {
+    mockGasket.config.env = 'test.only';
+    results = webpack(mockGasket, mockWebpackConfig, mockNextData);
+    expect(results).toBe(mockWebpackConfig);
+  });
+
+  it('does not add BundleAnalyzerPlugin if no ANALYZE', () => {
+    delete process.env.ANALYZE;
+    results = webpack(mockGasket, mockWebpackConfig, mockNextData);
+    expect(results).toBe(mockWebpackConfig);
+  });
+
+  it('does not add BundleAnalyzerPlugin if ANALYZE=false', () => {
+    process.env.ANALYZE = 'false';
+    results = webpack(mockGasket, mockWebpackConfig, mockNextData);
+    expect(results).toBe(mockWebpackConfig);
+  });
+
+  it('does not add BundleAnalyzerPlugin if ANALYZE=0', () => {
+    process.env.ANALYZE = '0';
     results = webpack(mockGasket, mockWebpackConfig, mockNextData);
     expect(results).toBe(mockWebpackConfig);
   });
 
   it('uses bundleAnalyzerConfig options from gasket.config', () => {
+    mockGasket.config.env = 'test.analyze';
     mockGasket.config.bundleAnalyzerConfig = {
       browser: {
         reportFilename: 'bogus.html'
@@ -47,18 +86,21 @@ describe('webpackConfig', () => {
   });
 
   it('defaults analyzerMode=static', () => {
+    mockGasket.config.env = 'test.analyze';
     results = webpack(mockGasket, mockWebpackConfig, mockNextData);
     const expectedPlugin = results.plugins[results.plugins.length - 1];
     expect(expectedPlugin.opts).toHaveProperty('analyzerMode', 'static');
   });
 
   it('defaults output to reports dir', () => {
+    mockGasket.config.env = 'test.analyze';
     results = webpack(mockGasket, mockWebpackConfig, mockNextData);
     const expectedPlugin = results.plugins[results.plugins.length - 1];
     expect(expectedPlugin.opts).toHaveProperty('reportFilename', expect.stringContaining('/reports'));
   });
 
   it('allows browser config overrides', () => {
+    mockGasket.config.env = 'test.analyze';
     mockGasket.config.bundleAnalyzerConfig = {
       browser: {
         analyzerMode: 'server'
@@ -70,6 +112,7 @@ describe('webpackConfig', () => {
   });
 
   it('allows server config overrides', () => {
+    mockGasket.config.env = 'test.analyze';
     mockGasket.config.bundleAnalyzerConfig = {
       server: {
         analyzerMode: 'server'

--- a/packages/gasket-plugin-dynamic-plugins/CHANGELOG.md
+++ b/packages/gasket-plugin-dynamic-plugins/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/plugin-dynamic-plugins`
 
+- Add to config during create ([#1010])
+
 ### 7.2.0
 
 - Set timing before commands plugins to allow dynamic plugins to register commands ([#1016])
@@ -16,5 +18,6 @@
 
 [#970]: https://github.com/godaddy/gasket/pull/970
 [#991]: https://github.com/godaddy/gasket/pull/991
+[#1010]: https://github.com/godaddy/gasket/pull/1010
 [#1015]: https://github.com/godaddy/gasket/pull/1015
 [#1016]: https://github.com/godaddy/gasket/pull/1016

--- a/packages/gasket-plugin-dynamic-plugins/lib/create.js
+++ b/packages/gasket-plugin-dynamic-plugins/lib/create.js
@@ -1,0 +1,13 @@
+/// <reference types="create-gasket-app" />
+
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { name, version } = require('../package.json');
+
+/** @type {import('@gasket/core').HookHandler<'create'>} */
+export default function create(gasket, { pkg, gasketConfig }) {
+  gasketConfig.addPlugin('pluginDynamicPlugins', name);
+  pkg.add('dependencies', {
+    [name]: `^${version}`
+  });
+}

--- a/packages/gasket-plugin-dynamic-plugins/lib/index.js
+++ b/packages/gasket-plugin-dynamic-plugins/lib/index.js
@@ -1,5 +1,6 @@
 /// <reference types="@gasket/plugin-metadata" />
 
+import create from './create.js';
 import prepare from './prepare.js';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
@@ -10,6 +11,7 @@ export default {
   name,
   version,
   hooks: {
+    create,
     prepare,
     metadata(gasket, meta) {
       return {

--- a/packages/gasket-plugin-dynamic-plugins/test/create.test.js
+++ b/packages/gasket-plugin-dynamic-plugins/test/create.test.js
@@ -1,0 +1,36 @@
+import { jest } from '@jest/globals';
+import create from '../lib/create.js';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { name, version } = require('../package.json');
+
+describe('create', () => {
+  let mockContext;
+
+  beforeEach(() => {
+    mockContext = {
+      pkg: {
+        add: jest.fn()
+      },
+      gasketConfig: {
+        addPlugin: jest.fn()
+      }
+    };
+  });
+
+  it('should be a function', () => {
+    expect(create).toEqual(expect.any(Function));
+  });
+
+  it('should add pluginDynamicPlugins to gasketConfig', () => {
+    create({}, mockContext);
+    expect(mockContext.gasketConfig.addPlugin).toHaveBeenCalledWith('pluginDynamicPlugins', name);
+  });
+
+  it('should add dependency to pkg', () => {
+    create({}, mockContext);
+    expect(mockContext.pkg.add).toHaveBeenCalledWith('dependencies', {
+      [name]: `^${version}`
+    });
+  });
+});

--- a/packages/gasket-plugin-dynamic-plugins/test/index.test.js
+++ b/packages/gasket-plugin-dynamic-plugins/test/index.test.js
@@ -16,6 +16,7 @@ describe('Plugin', () => {
 
   it('has expected hooks', () => {
     const expected = [
+      'create',
       'prepare',
       'metadata'
     ];


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Add a convenient method for adding environment-specific configurations during the `create` lifecycle.

This also updates @gasket/plugin-analyze to utilize it.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

**create-gasket-app**
- Add `addEnvironment` method for create context

**@gasket/plugin-analyze**
- Update create to use environment config
- Fix for ANALYZE env var check with support for analyze in Gasket env check

**@gasket/plugin-dynamic-plugins**
- Add to config during create


<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

Tested with local create-gasket-app

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
