### PR TITLE
Export default for type module pkg

### DIFF
--- a/packages/gasket-plugin-dynamic-plugins/lib/index.d.ts
+++ b/packages/gasket-plugin-dynamic-plugins/lib/index.d.ts
@@ -11,4 +11,4 @@ const plugin: Plugin = {
   hooks: {}
 };
 
-export = plugin;
+export default plugin;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

```
TS1192: Module
'/path/to/node_modules/@gasket/plugin-dynamic-plugins/lib/index'
has no default export.
```
