### PR TITLE
Webpack exclude gasket.mjs by default

### DIFF
--- a/packages/gasket-plugin-nextjs/lib/webpack-config.js
+++ b/packages/gasket-plugin-nextjs/lib/webpack-config.js
@@ -53,6 +53,8 @@ function webpackConfigHook(gasket, webpackConfig, { webpack, isServer }) {
     if (!isServer) {
       exclude('./gasket.js');
       exclude('./src/gasket.js');
+      exclude('./gasket.mjs');
+      exclude('./src/gasket.mjs');
       exclude('./gasket.ts');
       exclude('./src/gasket.ts');
       exclude('./dist/gasket.js');

--- a/packages/gasket-plugin-nextjs/test/webpack-config.test.js
+++ b/packages/gasket-plugin-nextjs/test/webpack-config.test.js
@@ -10,6 +10,8 @@ describe('webpackConfigHook', () => {
   let mockGasket, mockWebpackConfig, mockContext;
 
   beforeEach(() => {
+    tryResolve.mockImplementation((moduleName) => moduleName);
+
     mockGasket = {
       config: {
         root: '/path/to/app'
@@ -46,10 +48,24 @@ describe('webpackConfigHook', () => {
     expect(result.resolve.alias).toEqual(expect.objectContaining({ [target]: false }));
   });
 
-  it('adds empty alias for gasket file in client', () => {
+  it('adds empty alias for gasket.js file in client', () => {
     tryResolve.mockReturnValue(mockFilename);
     const result = webpackConfig(mockGasket, mockWebpackConfig, mockContext);
     expect(result.resolve.alias).toEqual(expect.objectContaining({ [mockFilename]: false }));
+  });
+
+  it('adds empty alias for expected default filenames', () => {
+    const mjsFilename = '/path/to/app/gasket.mjs';
+    tryResolve.mockReturnValue(mjsFilename);
+    const result = webpackConfig(mockGasket, mockWebpackConfig, mockContext);
+    expect(result.resolve.alias).toEqual(expect.objectContaining({ [mjsFilename]: false }));
+  });
+
+  it('adds empty alias for gasket.ts file in client', () => {
+    const tsFilename = '/path/to/app/gasket.ts';
+    tryResolve.mockReturnValue(tsFilename);
+    const result = webpackConfig(mockGasket, mockWebpackConfig, mockContext);
+    expect(result.resolve.alias).toEqual(expect.objectContaining({ [tsFilename]: false }));
   });
 
   it('adds validateNoGasketCore to externals for client', () => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Fixes import trace for requested module errors from webpack bundling when using the `gasket.mjs` extension.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

@gasket/plugin-nextjs
- Auto exclude `gasket.mjs` files from webpack bundle

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->

Tested in local app