### PR TITLE
Allow partial configs in environment overrides

### DIFF
--- a/packages/create-gasket-app/lib/commands/create.js
+++ b/packages/create-gasket-app/lib/commands/create.js
@@ -118,7 +118,7 @@ createCommand.action = async function run(appname, options, command) {
 
     const pluginGasket = makeGasket({
       ...context.presetConfig,
-      plugins: context.presets.concat(context.presetConfig.plugins)
+      plugins: context.presetConfig.plugins.concat(context.presets)
     });
 
     await promptHooks({ gasket: pluginGasket, context });

--- a/packages/gasket-core/CHANGELOG.md
+++ b/packages/gasket-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/core`
 
+- Fix configuration options so they allow partial environment overrides ([#1026])
+
 ### 7.2.0
 
 - Adjust types GasketTrace

--- a/packages/gasket-core/lib/gasket.js
+++ b/packages/gasket-core/lib/gasket.js
@@ -38,7 +38,7 @@ export class Gasket {
     // prune nullish and/or empty plugins
     config.plugins = config.plugins
       .filter(Boolean)
-      .map(plugin => plugin.default || plugin) // quality of life for cjs apps
+      .map(plugin => 'default' in plugin ? plugin.default : plugin) // quality of life for cjs apps
       .filter(plugin => Boolean(plugin.name) || Boolean(plugin.hooks));
 
     // start the engine

--- a/packages/gasket-core/lib/index.d.ts
+++ b/packages/gasket-core/lib/index.d.ts
@@ -65,7 +65,7 @@ declare module '@gasket/core' {
 
   // This is the config
   export interface GasketConfig {
-    plugins: Array<Plugin>;
+    plugins: Array<Plugin | { default: Plugin }>;
     root: string;
     env: string;
   }

--- a/packages/gasket-core/lib/index.d.ts
+++ b/packages/gasket-core/lib/index.d.ts
@@ -133,10 +133,16 @@ declare module '@gasket/core' {
     ? { [K in keyof T]?: PartialRecursive<T[K]> } | undefined
     : T | undefined;
 
+  // Allow nested merging of most config
+  type ConfigKeysRequiringFullEnvConfig = 'plugins';
+  type EnvironmentOverrides =
+    & PartialRecursive<Omit<GasketConfigDefinition, ConfigKeysRequiringFullEnvConfig>>
+    & Partial<Pick<GasketConfigDefinition, ConfigKeysRequiringFullEnvConfig>>;
+
   export type GasketConfigDefinition = Omit<GasketConfig, 'root' | 'env' | 'command'> & {
     root?: string
     env?: string
-    environments?: Record<string, Partial<GasketConfigDefinition>>
+    environments?: Record<string, EnvironmentOverrides>
     commands?: Record<string, Partial<GasketConfigDefinition>>
   }
 

--- a/packages/gasket-core/lib/index.d.ts
+++ b/packages/gasket-core/lib/index.d.ts
@@ -65,9 +65,13 @@ declare module '@gasket/core' {
 
   // This is the config
   export interface GasketConfig {
-    plugins: Array<Plugin | { default: Plugin }>;
+    plugins: Array<Plugin>;
     root: string;
     env: string;
+  }
+
+  export type PreNormalizedGasketConfig = Omit<GasketConfig, 'plugins'> & {
+    plugins: Array<Plugin | { default: Plugin }>;
   }
 
   export class GasketEngine {
@@ -135,15 +139,15 @@ declare module '@gasket/core' {
 
   // Allow nested merging of most config
   type ConfigKeysRequiringFullEnvConfig = 'plugins';
-  type EnvironmentOverrides =
+  type GasketConfigOverrides =
     & PartialRecursive<Omit<GasketConfigDefinition, ConfigKeysRequiringFullEnvConfig>>
     & Partial<Pick<GasketConfigDefinition, ConfigKeysRequiringFullEnvConfig>>;
 
-  export type GasketConfigDefinition = Omit<GasketConfig, 'root' | 'env' | 'command'> & {
+  export type GasketConfigDefinition = Omit<PreNormalizedGasketConfig, 'root' | 'env' | 'command'> & {
     root?: string
     env?: string
-    environments?: Record<string, EnvironmentOverrides>
-    commands?: Record<string, Partial<GasketConfigDefinition>>
+    environments?: Record<string, GasketConfigOverrides>
+    commands?: Record<string, GasketConfigOverrides>
   }
 
   /**

--- a/packages/gasket-typescript-tests/test/core.spec.ts
+++ b/packages/gasket-typescript-tests/test/core.spec.ts
@@ -7,7 +7,7 @@ declare module '@gasket/core' {
   }
 
   interface GasketConfig {
-    someConfigSection: {
+    someConfigSection?: {
       foo: string;
       bar: number;
     }

--- a/packages/gasket-typescript-tests/test/core.spec.ts
+++ b/packages/gasket-typescript-tests/test/core.spec.ts
@@ -5,6 +5,13 @@ declare module '@gasket/core' {
   interface HookExecTypes {
     example(str: string, num: number, bool: boolean): MaybeAsync<boolean>
   }
+
+  interface GasketConfig {
+    someConfigSection: {
+      foo: string;
+      bar: number;
+    }
+  }
 }
 
 const PluginExample = {
@@ -21,19 +28,35 @@ const PluginExample = {
 describe('@gasket/core', () => {
   it('exposes the constructor interface', () => {
     // eslint-disable-next-line no-new
-    makeGasket({ plugins: [PluginExample] });
+    makeGasket({
+      plugins: [PluginExample],
+      someConfigSection: {
+        foo: 'foo',
+        bar: 123
+      }
+    });
   });
 
   it('checks constructor arguments', () => {
     // eslint-disable-next-line no-new
     makeGasket({
-      plugins: [PluginExample]
+      plugins: [PluginExample],
+      someConfigSection: {
+        foo: 'foo',
+        bar: 123
+      }
     // @ts-expect-error
     }, 'extra');
   });
 
   it('should infer the types of lifecycle parameters', async function () {
-    const gasket = makeGasket({ plugins: [PluginExample] });
+    const gasket = makeGasket({
+      plugins: [PluginExample],
+      someConfigSection: {
+        foo: 'foo',
+        bar: 123
+      }
+    });
 
     await gasket.execApply('example', async function (plugin, handler) {
       handler('a string', 123, true);
@@ -60,7 +83,13 @@ describe('@gasket/core', () => {
   });
 
   it('type checks the hook method', () => {
-    const gasket = makeGasket({ plugins: [PluginExample] });
+    const gasket = makeGasket({
+      plugins: [PluginExample],
+      someConfigSection: {
+        foo: 'foo',
+        bar: 123
+      }
+    });
 
     // Valid
     gasket.hook({
@@ -89,7 +118,13 @@ describe('@gasket/core', () => {
   });
 
   it('exposes the running command on the Gasket interface', () => {
-    const gasket = makeGasket({ plugins: [PluginExample] });
+    const gasket = makeGasket({
+      plugins: [PluginExample],
+      someConfigSection: {
+        foo: 'foo',
+        bar: 123
+      }
+    });
 
     // Valid
     gasket.hook({
@@ -112,6 +147,23 @@ describe('@gasket/core', () => {
             // @ts-expect-error
             { name: 'missing-hooks' }
           ]
+        }
+      }
+    };
+  });
+
+  it('allows partial environment config overrides', () => {
+    const config: GasketConfigDefinition = {
+      plugins: [PluginExample],
+      someConfigSection: {
+        foo: 'foo',
+        bar: 123
+      },
+      environments: {
+        dev: {
+          someConfigSection: {
+            foo: 'dev-foo'
+          }
         }
       }
     };

--- a/packages/gasket-typescript-tests/test/utils.spec.ts
+++ b/packages/gasket-typescript-tests/test/utils.spec.ts
@@ -1,11 +1,11 @@
 import { applyConfigOverrides, runShellCommand } from '@gasket/utils';
-import { GasketConfig, GasketConfigDefinition } from '@gasket/core';
+import { GasketConfig } from '@gasket/core';
 
 describe('@gasket/utils', function () {
   const perform = false;
 
   describe('applyConfigOverrides', function () {
-    const config: GasketConfigDefinition = {
+    const config: GasketConfig = {
       plugins: [{ name: 'example', version: '', description: '', hooks: {} }],
       root: '/',
       env: 'debug'
@@ -13,7 +13,7 @@ describe('@gasket/utils', function () {
 
     it('has expected API', function () {
       if (perform) {
-        let result:GasketConfig;
+        let result: GasketConfig;
         result = applyConfigOverrides(config, { env: 'test' });
         result = applyConfigOverrides(config, { env: 'test', commandId: 'test' });
 

--- a/packages/gasket-utils/CHANGELOG.md
+++ b/packages/gasket-utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@gasket/utils`
 
+- Fix type of environment overrides ([#1026])
+
 ### 7.1.2
 
 - Ensure non-plain objects are copied instead of merge ([#1002])


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Fix the TypeScript types so that you don't have to do a full set of config keys in environment overrides to avoid TypeScript errors.

## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry. See this project's CHANGELOG.md
for an example.
-->

## Test Plan

Added type test
