### PR TITLE
Fix usage of middleware regex

### DIFF
--- a/.changeset/sweet-pets-report.md
+++ b/.changeset/sweet-pets-report.md
@@ -1,0 +1,5 @@
+---
+"@gasket/plugin-middleware": patch
+---
+
+Fix usage of middlewareInclusionRegex

--- a/packages/gasket-plugin-middleware/lib/utils.js
+++ b/packages/gasket-plugin-middleware/lib/utils.js
@@ -63,8 +63,10 @@ function applyMiddlewaresToApp(app, middlewares, middlewarePattern) {
     const { paths } = layer;
     if (paths) {
       app.use(paths, layer);
+    } else if (middlewarePattern) {
+      app.use(middlewarePattern, layer);
     } else {
-      app.use(middlewarePattern || layer);
+      app.use(layer);
     }
   });
 }

--- a/packages/gasket-plugin-middleware/test/utils.test.js
+++ b/packages/gasket-plugin-middleware/test/utils.test.js
@@ -122,6 +122,17 @@ describe('utils', function () {
 
       expect(app.use).not.toHaveBeenCalledWith([]);
     });
+
+    it('gates middleware between an inclusion regex', async function () {
+      const mockMiddlewares = [function () { }, function () { }];
+      middlewarePattern = /^\/gaskety\/routes\//;
+      gasket.config.express = { middlewareInclusionRegex: middlewarePattern };
+      mockMwPlugins = [{ name: 'middleware-1' }, mockMiddlewares];
+
+      await executeMiddlewareLifecycle(gasket, app, middlewarePattern);
+
+      expect(app.use).toHaveBeenCalledWith(middlewarePattern, mockMiddlewares);
+    });
   });
 
   /**


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Fix how the middleware regex is passed into `app.use` in an express app. See the [support thread](https://godaddy.slack.com/archives/CABCTNQ5P/p1742860594266349) for details.

## Test Plan

Added unit test. Asked customer to do manual testing to confirm, but this code change does match the lts branch.