### PR TITLE
Throw if hook returns promise for sync exec method

### DIFF
--- a/.changeset/neat-vans-think.md
+++ b/.changeset/neat-vans-think.md
@@ -1,0 +1,5 @@
+---
+"@gasket/core": minor
+---
+
+Throw if hooks return promises for sync exec methods

--- a/packages/gasket-core/lib/index.d.ts
+++ b/packages/gasket-core/lib/index.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-use-before-define */
+/* eslint-disable no-use-before-define, jsdoc/require-param, jsdoc/require-returns */
 declare module '@gasket/core' {
   /**
    * Allows a type to be a single value or an array of that type.

--- a/packages/gasket-core/test/engine/exec-sync.test.js
+++ b/packages/gasket-core/test/engine/exec-sync.test.js
@@ -81,4 +81,19 @@ describe('The execSync method', () => {
       ['  ↪ pluginB:eventA']
     ]);
   });
+
+  it('throws for async hooks', () => {
+    const pluginBad = {
+      name: 'pluginBad',
+      hooks: {
+        async eventA(gasket, value) {
+          return value * 10;
+        }
+      }
+    };
+    mockGasket = new Gasket({ plugins: [pluginA, pluginB, pluginBad] });
+    expect(() => mockGasket.execSync('eventA', 5)).toThrow(
+      'execSync cannot be used with async hook (eventA) of plugin (pluginBad)'
+    );
+  });
 });

--- a/packages/gasket-core/test/engine/exec-waterfall-sync.test.js
+++ b/packages/gasket-core/test/engine/exec-waterfall-sync.test.js
@@ -98,4 +98,19 @@ describe('The execWaterfallSync method', () => {
 
     expect(result).toEqual(null);
   });
+
+  it('throws for async hooks', () => {
+    const pluginBad = {
+      name: 'pluginBad',
+      hooks: {
+        async eventA(gasket, value) {
+          return value * 10;
+        }
+      }
+    };
+    mockGasket = new Gasket({ plugins: [pluginA, pluginB, pluginBad] });
+    expect(() => mockGasket.execWaterfallSync('eventA', 5)).toThrow(
+      'execWaterfallSync cannot be used with async hook (eventA) of plugin (pluginBad)'
+    );
+  });
 });

--- a/packages/gasket-plugin-winston/lib/index.js
+++ b/packages/gasket-plugin-winston/lib/index.js
@@ -16,7 +16,7 @@ const plugin = {
   version,
   description,
   hooks: {
-    async create(gasket, { pkg, gasketConfig }) {
+    create(gasket, { pkg, gasketConfig }) {
       gasketConfig.addPlugin('pluginWinston', '@gasket/plugin-winston');
       pkg.add('dependencies', {
         [name]: `^${version}`,

--- a/packages/gasket-typescript-tests/package.json
+++ b/packages/gasket-typescript-tests/package.json
@@ -90,6 +90,7 @@
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.3",
     "vitest": "^3.0.7",
+    "winston-transport": "^4.9.0",
     "workbox-build": "^4.3.1"
   },
   "eslintConfig": {

--- a/packages/gasket-typescript-tests/test/core.spec.ts
+++ b/packages/gasket-typescript-tests/test/core.spec.ts
@@ -63,7 +63,7 @@ describe('@gasket/core', () => {
     });
 
     // eslint-disable-next-line no-sync
-    gasket.execApplySync('example', async function (plugin, handler) {
+    gasket.execApplySync('example', function (plugin, handler) {
       handler('a string', 123, true);
     });
   });

--- a/packages/gasket-typescript-tests/test/plugin-winston.spec.ts
+++ b/packages/gasket-typescript-tests/test/plugin-winston.spec.ts
@@ -1,7 +1,8 @@
 import { GasketConfigDefinition, Hook, Gasket } from '@gasket/core';
 import '@gasket/plugin-winston';
+import TransportStream from 'winston-transport';
 
-const fakeTransport = (options: any) => void 0;
+const fakeTransport = new TransportStream()
 
 describe('@gasket/plugin-winston', () => {
   it('adds a winston config section', () => {
@@ -43,9 +44,9 @@ describe('@gasket/plugin-winston', () => {
     config.winston.format = false;
   });
 
-  // it('defines the winstonTransports lifecycle', async () => {
-  //   const hook: Hook<'winstonTransports'> = (gasket: Gasket) => {
-  //     return fakeTransport;
-  //   };
-  // });
+  it('defines the winstonTransports lifecycle', async () => {
+    const hook: Hook<'winstonTransports'> = (gasket: Gasket) => {
+      return fakeTransport;
+    };
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3178,6 +3178,9 @@ importers:
       vitest:
         specifier: ^3.0.7
         version: 3.0.7(@types/debug@4.1.12)(@types/node@20.17.19)(jiti@1.21.7)(jsdom@20.0.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      winston-transport:
+        specifier: ^4.9.0
+        version: 4.9.0
       workbox-build:
         specifier: ^4.3.1
         version: 4.3.1
@@ -13869,7 +13872,7 @@ snapshots:
       '@babel/traverse': 7.26.9
       '@babel/types': 7.26.9
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -14683,7 +14686,7 @@ snapshots:
       '@babel/parser': 7.26.9
       '@babel/template': 7.26.9
       '@babel/types': 7.26.9
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -16902,7 +16905,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -17043,7 +17046,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -18387,7 +18390,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -18407,7 +18410,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -18425,7 +18428,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.7.3
@@ -18446,7 +18449,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       eslint: 8.57.1
       tsutils: 3.21.0(typescript@5.7.3)
     optionalDependencies:
@@ -18458,7 +18461,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       eslint: 8.57.1
       ts-api-utils: 1.4.3(typescript@5.7.3)
     optionalDependencies:
@@ -18474,7 +18477,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.1
@@ -18488,7 +18491,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -18766,7 +18769,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -20240,6 +20243,10 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.0(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -20905,7 +20912,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.46.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       escape-string-regexp: 4.0.0
       eslint: 8.57.1
       espree: 10.3.0
@@ -21034,7 +21041,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -22083,7 +22090,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -22123,7 +22130,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -22527,7 +22534,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -26836,7 +26843,7 @@ snapshots:
   vite-node@3.0.7(@types/node@20.17.19)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
       vite: 6.1.1(@types/node@20.17.19)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -26877,7 +26884,7 @@ snapshots:
       '@vitest/spy': 3.0.7
       '@vitest/utils': 3.0.7
       chai: 5.2.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       expect-type: 1.1.0
       magic-string: 0.30.17
       pathe: 2.0.3


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Now and then, we will have an app with plugin hooks that are async when they shouldn't be. This tends to pop up most with the `configure` lifecycle. To help us catch and debug sooner, we will throw when promises are returned for sync methods.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Test Plan

Updated unit tests

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
