### PR TITLE
Add Node.js 24.x to CI workflow matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Summary

Adds Node.js 24.x to CI workflow matrix for future compatibility testing.

## Test Plan

- CI workflow will now run against Node.js versions: 20.x, 22.x, and 24.x
- All existing tests should pass across all Node.js versions
- No code changes were required, only CI configuration updates