### PR TITLE
Fix to only exec apmTransaction lifecycle once per request

### DIFF
--- a/.changeset/slick-cameras-scream.md
+++ b/.changeset/slick-cameras-scream.md
@@ -1,0 +1,5 @@
+---
+"@gasket/plugin-elastic-apm": patch
+---
+
+Fix to only exec apmTransaction lifecycle once per request

--- a/packages/gasket-plugin-elastic-apm/lib/actions.js
+++ b/packages/gasket-plugin-elastic-apm/lib/actions.js
@@ -1,7 +1,7 @@
-const { withGasketRequest } = require('@gasket/request');
+const { withGasketRequestCache } = require('@gasket/request');
 
 /** @type {import('@gasket/core').ActionHandler<'getApmTransaction'>} */
-const getApmTransaction = withGasketRequest(
+const getApmTransaction = withGasketRequestCache(
   async function getApmTransaction(gasket, req) {
     const apm = require('elastic-apm-node');
 

--- a/packages/gasket-plugin-elastic-apm/test/actions.test.js
+++ b/packages/gasket-plugin-elastic-apm/test/actions.test.js
@@ -45,6 +45,17 @@ describe('actions', () => {
     );
   });
 
+  it('only executes the apmTransaction lifecycle once per request', async () => {
+    await actions.getApmTransaction(mockGasket, mockReq);
+    await actions.getApmTransaction(mockGasket, mockReq);
+    expect(mockGasket.exec).toHaveBeenCalledTimes(1);
+
+    const anotherReq = { ...mockReq, headers: {} };
+    await actions.getApmTransaction(mockGasket, anotherReq);
+    await actions.getApmTransaction(mockGasket, anotherReq);
+    expect(mockGasket.exec).toHaveBeenCalledTimes(2);
+  });
+
   it('returns undefined if no transaction', async () => {
     // eslint-disable-next-line no-undefined
     apm.currentTransaction = undefined;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Fix to only exec apmTransaction lifecycle once per request to avoid unnecessary repeated actions and lifecycles to be called.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Test Plan

NA

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
