### PR TITLE
Fix module import for Edge Runtime

### DIFF
--- a/.changeset/four-boxes-repeat.md
+++ b/.changeset/four-boxes-repeat.md
@@ -1,0 +1,9 @@
+---
+"@gasket/plugin-nextjs": patch
+"@gasket/plugin-docs": patch
+"create-gasket-app": patch
+"@gasket/request": patch
+"@gasket/utils": patch
+---
+
+Adjustments to types

--- a/.changeset/olive-rice-tap.md
+++ b/.changeset/olive-rice-tap.md
@@ -1,0 +1,5 @@
+---
+"@gasket/core": patch
+---
+
+Fix to not import from node module package

--- a/.changeset/real-buses-jump.md
+++ b/.changeset/real-buses-jump.md
@@ -1,0 +1,6 @@
+---
+"@gasket/plugin-nextjs": patch
+"@gasket/request": patch
+---
+
+Fix GasketRequest does not export a url prop

--- a/packages/create-gasket-app/lib/commands/create.js
+++ b/packages/create-gasket-app/lib/commands/create.js
@@ -22,7 +22,7 @@ import printReport from '../scaffold/actions/print-report.js';
 
 /**
  * Parses comma separated option input to array
- * @type {import('../internal').commasToArray}
+ * @type {import('../internal.js').commasToArray}
  */
 const commasToArray = input => input.split(',').map(name => name.trim());
 
@@ -92,7 +92,7 @@ const createCommand = {
 
 /**
  * createCommand action
- * @type {import('../index').createCommandAction}
+ * @type {import('../index.js').createCommandAction}
  */
 createCommand.action = async function run(appname, options, command) {
   // eslint-disable-next-line no-process-env

--- a/packages/create-gasket-app/lib/scaffold/actions/create-hooks.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/create-hooks.js
@@ -6,7 +6,7 @@ import Readme from '../readme.js';
 /**
  * Executes the `create` hook for all registered plugins.
  * Adds `files` to context for plugins to add their files and templates.
- * @type {import('../../internal').createHooks}
+ * @type {import('../../internal.js').createHooks}
  */
 async function createHooks({ gasket, context }) {
   const { warnings } = context;

--- a/packages/create-gasket-app/lib/scaffold/actions/generate-files.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/generate-files.js
@@ -20,7 +20,7 @@ const splitSep = pthStr => pthStr.split(reSep);
  * Find all duplicate target files and reduce to single descriptor.
  * Keeps track of overrides.
  * Last in wins.
- * @type {import('../../internal').reduceDescriptors}
+ * @type {import('../../internal.js').reduceDescriptors}
  */
 function reduceDescriptors(descriptors) {
   const reduced = descriptors.reduce((acc, desc) => {
@@ -41,7 +41,7 @@ function reduceDescriptors(descriptors) {
 
 /**
  * Assemble the description objects from glob results
- * @type {import('../../internal').assembleDescriptors}
+ * @type {import('../../internal.js').assembleDescriptors}
  */
 function assembleDescriptors(dest, from, pattern, srcPaths) {
   const output = joinSep(splitSep(dest));
@@ -64,7 +64,7 @@ function assembleDescriptors(dest, from, pattern, srcPaths) {
 
 /**
  * Build a list of descriptions of all files we want to generate
- * @type {import('../../internal').getDescriptors}
+ * @type {import('../../internal.js').getDescriptors}
  */
 async function getDescriptors(context) {
   const { dest, files } = context;
@@ -85,7 +85,7 @@ async function getDescriptors(context) {
 
 /**
  * Read file content, apply templating, then write out target file.
- * @type {import('../../internal').performGenerate}
+ * @type {import('../../internal.js').performGenerate}
  */
 async function performGenerate(context, descriptors) {
   const { warnings, errors, generatedFiles } = context;
@@ -151,7 +151,7 @@ async function performGenerate(context, descriptors) {
 
 /**
  * Generate the app files and templates using context
- * @type {import('../../internal').generateFiles}
+ * @type {import('../../internal.js').generateFiles}
  */
 async function generateFiles({ context, spinner }) {
   const { files } = context;

--- a/packages/create-gasket-app/lib/scaffold/actions/global-prompts.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/global-prompts.js
@@ -3,7 +3,7 @@ import { withSpinner } from '../with-spinner.js';
 
 /**
  * What is your app description?
- * @type {import('../../internal').chooseAppDescription}
+ * @type {import('../../internal.js').chooseAppDescription}
  */
 async function chooseAppDescription(context, prompt) {
   if (!('appDescription' in context)) {
@@ -22,7 +22,7 @@ async function chooseAppDescription(context, prompt) {
 
 /**
  * What package manager do you want to use?
- * @type {import('../../internal').choosePackageManager}
+ * @type {import('../../internal.js').choosePackageManager}
  */
 async function choosePackageManager(context, prompt) {
   const packageManager =
@@ -56,7 +56,7 @@ async function choosePackageManager(context, prompt) {
 
 /**
  * Choose your unit test suite and integration test suite
- * @type {import('../../internal').chooseTestPlugins}
+ * @type {import('../../internal.js').chooseTestPlugins}
  */
 async function chooseTestPlugins(context, prompt) {
   const knownTestPlugins = {
@@ -96,7 +96,7 @@ async function chooseTestPlugins(context, prompt) {
 
 /**
  *
- * @type {import('../../internal').promptForTestPlugin}
+ * @type {import('../../internal.js').promptForTestPlugin}
  */
 async function promptForTestPlugin(prompt, message, choices) {
   const { testPlugin } = await prompt([
@@ -114,7 +114,7 @@ async function promptForTestPlugin(prompt, message, choices) {
 /**
  * Given that gasket is creating in an already existing directory, it should
  * confirm with the user that it's intentionally overwriting that directory
- * @type {import('../../internal').allowExtantOverwriting}
+ * @type {import('../../internal.js').allowExtantOverwriting}
  */
 async function allowExtantOverwriting(context, prompt) {
   const { dest, extant } = context;
@@ -141,7 +141,7 @@ export const questions = [
 
 /**
  * Fire off prompts for user input
- * @type {import('../../internal').globalPrompts}
+ * @type {import('../../internal.js').globalPrompts}
  */
 async function globalPrompts({ context }) {
   const prompt = context.prompts ? inquirer.createPromptModule() : () => ({});

--- a/packages/create-gasket-app/lib/scaffold/actions/install-modules.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/install-modules.js
@@ -2,7 +2,7 @@ import { withSpinner } from '../with-spinner.js';
 
 /**
  * Installs node_modules using the selected package manager
- * @type {import('../../internal').installModules}
+ * @type {import('../../internal.js').installModules}
  */
 async function installModules({ context }) {
   const { pkgManager } = context;

--- a/packages/create-gasket-app/lib/scaffold/actions/link-modules.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/link-modules.js
@@ -2,7 +2,7 @@ import { withSpinner } from '../with-spinner.js';
 
 /**
  * Links local packages using the selected package manager
- * @type {import('../../internal').linkModules}
+ * @type {import('../../internal.js').linkModules}
  */
 async function linkModules({ context, spinner }) {
   const { pkgLinks, pkgManager } = context;

--- a/packages/create-gasket-app/lib/scaffold/actions/load-preset.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/load-preset.js
@@ -9,7 +9,7 @@ const hasVersionOrTag = /@([\^~]?\d+\.\d+\.\d+(?:-[\d\w.-]+)?|[\^~]?\d+\.\d+\.\d
 
 /**
  * loadPresets - Load presets to temp directory
- * @type {import('../../internal').loadPresets}
+ * @type {import('../../internal.js').loadPresets}
  */
 async function loadPresets({ context }) {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), `gasket-create-${context.appName}`));

--- a/packages/create-gasket-app/lib/scaffold/actions/mkdir.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/mkdir.js
@@ -5,7 +5,7 @@ import { withSpinner } from '../with-spinner.js';
  * Validates this instance can execute without common blockers:
  * - Target destination on disk is available. Validate by acquiring
  * a lock through `mkdir`.
- * @type {import('../../internal').mkDir}
+ * @type {import('../../internal.js').mkDir}
  */
 async function mkDir({ context, spinner }) {
   const { dest, relDest, extant, destOverride } = context;

--- a/packages/create-gasket-app/lib/scaffold/actions/post-create-hooks.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/post-create-hooks.js
@@ -3,7 +3,7 @@ import { runShellCommand } from '@gasket/utils';
 
 /**
  * Executes the `postCreate` hook for all registered plugins.
- * @type {import('../../internal').postCreateHooks}
+ * @type {import('../../internal.js').postCreateHooks}
  */
 async function postCreateHooks({ gasket, context }) {
   const { dest, packageManager } = context;

--- a/packages/create-gasket-app/lib/scaffold/actions/preset-config-hooks.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/preset-config-hooks.js
@@ -2,7 +2,7 @@ import { withGasketSpinner } from '../with-spinner.js';
 
 /**
  * presetConfigHooks - exec `presetConfig` hook
- * @type {import('../../internal').presetConfigHooks}
+ * @type {import('../../internal.js').presetConfigHooks}
  */
 async function presetConfigHooks({ gasket, context }) {
   const config = await gasket.execWaterfall('presetConfig', context);

--- a/packages/create-gasket-app/lib/scaffold/actions/preset-prompt-hooks.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/preset-prompt-hooks.js
@@ -3,7 +3,7 @@ import { withGasketSpinner } from '../with-spinner.js';
 
 /**
  * presetPromptHooks - exec `presetPrompt` hook
- * @type {import('../../internal').presetPromptHooks}
+ * @type {import('../../internal.js').presetPromptHooks}
  */
 async function presetPromptHooks({ gasket, context }) {
   const prompt = context.prompts ? inquirer.createPromptModule() : () => ({});

--- a/packages/create-gasket-app/lib/scaffold/actions/print-report.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/print-report.js
@@ -24,7 +24,7 @@ const toSpaceCase = str => str.replace(/([A-Z])/g, ' $1')
 
 /**
  * Builds the report object from context
- * @type {import('../../internal').buildReport}
+ * @type {import('../../internal.js').buildReport}
  * @private
  */
 function buildReport(context) {
@@ -53,7 +53,7 @@ function buildReport(context) {
 
 /**
  * Outputs create command details to the console
- * @type {import('../../internal').printReport}
+ * @type {import('../../internal.js').printReport}
  */
 async function printReport({ context }) {
   const report = buildReport(context);

--- a/packages/create-gasket-app/lib/scaffold/actions/prompt-hooks.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/prompt-hooks.js
@@ -4,7 +4,7 @@ import { withGasketSpinner } from '../with-spinner.js';
 /**
  * Initializes engine with provide preset and plugins
  * to execute their prompt lifecycle hooks.
- * @type {import('../../internal').execPluginPrompts}
+ * @type {import('../../internal.js').execPluginPrompts}
  */
 async function execPluginPrompts(gasket, context) {
   //
@@ -21,7 +21,7 @@ async function execPluginPrompts(gasket, context) {
 /**
  * Executes the `prompt` hook for all registered plugins.
  * Adds `prompt` util function for prompting features.
- * @type {import('../../internal').promptHooks}
+ * @type {import('../../internal.js').promptHooks}
  */
 async function promptHooks({ gasket, context }) {
   //

--- a/packages/create-gasket-app/lib/scaffold/actions/setup-pkg.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/setup-pkg.js
@@ -7,7 +7,7 @@ const { dependencies } = require('../../../package.json');
 
 /**
  * Initializes the ConfigBuilder builder and adds to context.
- * @type {import('../../internal').setupPkg}
+ * @type {import('../../internal.js').setupPkg}
  */
 async function setupPkg({ context }) {
   const { appName, appDescription, warnings } = context;

--- a/packages/create-gasket-app/lib/scaffold/actions/write-gasket-config.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/write-gasket-config.js
@@ -5,7 +5,7 @@ import { withSpinner } from '../with-spinner.js';
 
 /**
  * writePluginImports - Write string imports as value(s)
- * @type {import('../../internal').writePluginImports}
+ * @type {import('../../internal.js').writePluginImports}
  */
 function writePluginImports(plugins) {
   return plugins.reduce((acc, cur, index) => {
@@ -16,7 +16,7 @@ function writePluginImports(plugins) {
 
 /**
  * writeImports - Write imports to file using key value pairs
- * @type {import('../../internal').writeImports}
+ * @type {import('../../internal.js').writeImports}
  */
 function writeImports(imports) {
   if (!imports) return '';
@@ -25,7 +25,7 @@ function writeImports(imports) {
 
 /**
  * createInjectionAssignments - replace object path with a temp string value
- * @type {import('../../internal').createInjectionAssignments}
+ * @type {import('../../internal.js').createInjectionAssignments}
  */
 function createInjectionAssignments(config, assignments) {
   if (!assignments) return '';
@@ -44,7 +44,7 @@ function createInjectionAssignments(config, assignments) {
 
 /**
  * replaceInjectionAssignments - replace temp string value with actual value
- * @type {import('../../internal').replaceInjectionAssignments}
+ * @type {import('../../internal.js').replaceInjectionAssignments}
  */
 function replaceInjectionAssignments(content, assignments) {
   if (!assignments) return content;
@@ -57,7 +57,7 @@ function replaceInjectionAssignments(content, assignments) {
 
 /**
  * writeExpressions - Write expressions to file
- * @type {import('../../internal').writeExpressions}
+ * @type {import('../../internal.js').writeExpressions}
  */
 function writeExpressions(expressions) {
   if (!expressions) return '';
@@ -66,7 +66,7 @@ function writeExpressions(expressions) {
 
 /**
  * cleanupFields - Remove fields from config object
- * @type {import('../../internal').cleanupFields}
+ * @type {import('../../internal.js').cleanupFields}
  */
 function cleanupFields(config) {
   delete config.fields.imports;
@@ -77,7 +77,7 @@ function cleanupFields(config) {
 
 /**
  * Writes the contents of `pkg` to the app's package.json.
- * @type {import('../../internal').writeGasketConfig}
+ * @type {import('../../internal.js').writeGasketConfig}
  */
 async function writeGasketConfig({ context }) {
   const { dest, gasketConfig, generatedFiles, typescript } = context;

--- a/packages/create-gasket-app/lib/scaffold/actions/write-pkg.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/write-pkg.js
@@ -4,7 +4,7 @@ import { withSpinner } from '../with-spinner.js';
 
 /**
  * Writes the contents of `pkg` to the app's package.json.
- * @type {import('../../internal').writePkg}
+ * @type {import('../../internal.js').writePkg}
  */
 async function writePkg({ context }) {
   const { dest, pkg, generatedFiles } = context;

--- a/packages/create-gasket-app/lib/scaffold/config-builder.js
+++ b/packages/create-gasket-app/lib/scaffold/config-builder.js
@@ -52,7 +52,7 @@ function isValidVersion(v) {
 /**
  * ConfigBuilder is an extensible data structure for **specifically**
  * managing `package.json` data.
- * @type {import('../index').ConfigBuilder}
+ * @type {import('../index.js').ConfigBuilder}
  */
 export class ConfigBuilder {
   /**

--- a/packages/create-gasket-app/lib/scaffold/create-context.js
+++ b/packages/create-gasket-app/lib/scaffold/create-context.js
@@ -7,7 +7,7 @@ import { readConfig } from '../scaffold/utils.js';
  * The CreateRuntime represents a shallow proxy to a CreateContext
  * that automatically adds transactional information for providing
  * CLI users with blame information in the event of conflicts.
- * @type {import('../internal').makeCreateRuntime}
+ * @type {import('../internal.js').makeCreateRuntime}
  */
 function makeCreateRuntime(context, source) {
   //
@@ -38,6 +38,7 @@ function makeCreateRuntime(context, source) {
     }
   };
 
+  // @ts-ignore - Proxy for CreateContext
   return new Proxy(context, {
     get(obj, key) {
       if (overrides[key]) return overrides[key];
@@ -62,11 +63,12 @@ export class CreateContext {
   }
 
   runWith(plugin) {
+    // @ts-ignore - partial context at this point
     return makeCreateRuntime(this, plugin);
   }
 }
 
-/** @type {import('../internal').makeCreateContext} */
+/** @type {import('../internal.js').makeCreateContext} */
 export function makeCreateContext(argv = [], options = {}) {
   const appName = argv[0] || 'templated-app';
   const {
@@ -92,8 +94,9 @@ export function makeCreateContext(argv = [], options = {}) {
 
   /**
    * Input context which will be appended by prompts and passed to create hooks
-   * @type {import('../internal').PartialCreateContext}
+   * @type {import('../index.js').CreateContext}
    */
+  // @ts-ignore - some properties not defined in constructor will be added later
   const context = new CreateContext({
     destOverride: true,
     cwd,

--- a/packages/create-gasket-app/lib/scaffold/dump-error-context.js
+++ b/packages/create-gasket-app/lib/scaffold/dump-error-context.js
@@ -4,7 +4,7 @@ import { writeFile } from 'fs/promises';
 /**
  * If an error occurs during create, dump the context for debugging.
  * The error which cause the exit is also included in the log.
- * @type {import('../internal').dumpErrorContext}
+ * @type {import('../internal.js').dumpErrorContext}
  */
 export async function dumpErrorContext(context, error) {
   const { cwd } = context;

--- a/packages/create-gasket-app/lib/scaffold/files.js
+++ b/packages/create-gasket-app/lib/scaffold/files.js
@@ -1,6 +1,6 @@
 /**
  * Utility for plugins to add files and templates for generating
- * @type {import('../index').Files}
+ * @type {import('../index.js').Files}
  */
 export class Files {
   constructor() {

--- a/packages/create-gasket-app/lib/scaffold/readme.js
+++ b/packages/create-gasket-app/lib/scaffold/readme.js
@@ -1,6 +1,6 @@
 import { readFile } from 'fs/promises';
 
-/** @type {import('../index').Readme} */
+/** @type {import('../index.js').Readme} */
 export default class Readme {
   constructor() {
     this.markdown = [];

--- a/packages/create-gasket-app/lib/scaffold/utils.js
+++ b/packages/create-gasket-app/lib/scaffold/utils.js
@@ -2,7 +2,7 @@ import path from 'path';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 
-/** @type {import('../internal').readConfig} */
+/** @type {import('../internal.js').readConfig} */
 export function readConfig(context, { config, configFile }) {
   if (config) {
     const parsedConfig = JSON.parse(config);

--- a/packages/create-gasket-app/lib/scaffold/with-spinner.js
+++ b/packages/create-gasket-app/lib/scaffold/with-spinner.js
@@ -2,10 +2,10 @@ import ora from 'ora';
 
 /**
  * Base function to handle spinner logic
- * @type {import('../internal').wrapWithSpinner}
+ * @type {import('../internal.js').wrapWithSpinner}
  */
 function wrapWithSpinner(label, task, { startSpinner = true } = {}) {
-  /** @type {import('../internal').execute} */
+  /** @type {import('../internal.js').execute} */
   async function execute(context) {
     const spinner = ora(label);
     if (startSpinner) spinner.start();
@@ -27,7 +27,7 @@ function wrapWithSpinner(label, task, { startSpinner = true } = {}) {
 
 /**
  * Wrap a task with a spinner, including gasket and context.
- * @type {import('../internal').withGasketSpinner}
+ * @type {import('../internal.js').withGasketSpinner}
  */
 export function withGasketSpinner(label, task, options) {
   return wrapWithSpinner(label, ({ gasket, context, spinner }) =>
@@ -38,7 +38,7 @@ export function withGasketSpinner(label, task, options) {
 
 /**
  * Wrap a task with a spinner, using only context.
- * @type {import('../internal').withSpinner}
+ * @type {import('../internal.js').withSpinner}
  */
 export function withSpinner(label, task, options) {
   return wrapWithSpinner(label, ({ context, spinner }) =>

--- a/packages/create-gasket-app/lib/utils/create-option.js
+++ b/packages/create-gasket-app/lib/utils/create-option.js
@@ -2,7 +2,7 @@ import { Option } from 'commander';
 
 /**
  * createOption - Create a commander option
- * @type {import('../internal').createOption}
+ * @type {import('../internal.js').createOption}
  */
 export function createOption(definition) {
   const option = new Option(...definition.options);

--- a/packages/create-gasket-app/lib/utils/process-args.js
+++ b/packages/create-gasket-app/lib/utils/process-args.js
@@ -1,6 +1,6 @@
 /**
  * isValidArg - Validates the argument configuration
- * @type {import('../internal').isValidArg}
+ * @type {import('../internal.js').isValidArg}
  */
 function isValidArg(arg) {
   const keys = Object.keys(arg);
@@ -12,7 +12,7 @@ function isValidArg(arg) {
 
 /**
  * processArgs - Process the arguments configuration
- * @type {import('../internal').processArgs}
+ * @type {import('../internal.js').processArgs}
  */
 export function processArgs(args) {
   if (!Array.isArray(args) || !args.every(isValidArg)) throw new Error('Invalid argument(s) configuration');

--- a/packages/create-gasket-app/lib/utils/process-command.js
+++ b/packages/create-gasket-app/lib/utils/process-command.js
@@ -6,7 +6,7 @@ const program = new Command();
 
 /**
  * isValidCommand - Validates the command configuration
- * @type {import('../internal').isValidCommand}
+ * @type {import('../internal.js').isValidCommand}
  */
 function isValidCommand(command) {
   const keys = Object.keys(command);
@@ -21,7 +21,7 @@ function isValidCommand(command) {
 
 /**
  * processCommand - Process the command configuration
- * @type {import('../internal').processCommand}
+ * @type {import('../internal.js').processCommand}
  */
 export function processCommand(command) {
   if (!isValidCommand(command)) throw new Error('Invalid command configuration');

--- a/packages/create-gasket-app/lib/utils/process-options.js
+++ b/packages/create-gasket-app/lib/utils/process-options.js
@@ -1,6 +1,6 @@
 /**
  * isValidOption - Validate the option
- * @type {import('../internal').isValidOption}
+ * @type {import('../internal.js').isValidOption}
  */
 function isValidOption(option) {
   const keys = Object.keys(option);
@@ -12,7 +12,7 @@ function isValidOption(option) {
 
 /**
  * processOptions - Process the options configuration
- * @type {import('../internal').processOptions}
+ * @type {import('../internal.js').processOptions}
  */
 export function processOptions(options) {
   if (!Array.isArray(options) || !options.every(isValidOption)) throw new Error('Invalid option(s) configuration');

--- a/packages/create-gasket-app/package.json
+++ b/packages/create-gasket-app/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "pnpm run lint --fix",
-    "posttest": "pnpm run lint",
+    "posttest": "pnpm run lint && pnpm run typecheck",
     "test": "cross-env NODE_OPTIONS='--unhandled-rejections=strict --experimental-vm-modules' jest",
     "test:coverage": "jest --coverage",
     "test:watch": "pnpm run test --watch",

--- a/packages/gasket-core/lib/gasket.js
+++ b/packages/gasket-core/lib/gasket.js
@@ -2,11 +2,7 @@
 
 import { GasketEngine, lifecycleMethods } from './engine.js';
 import { makeTraceBranch } from './trace.js';
-
-
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-const { applyConfigOverrides } = require('@gasket/utils/config');
+import { applyConfigOverrides } from '@gasket/utils/config';
 
 /**
  * Get the environment to use for the gasket instance.

--- a/packages/gasket-plugin-docs/lib/internal.d.ts
+++ b/packages/gasket-plugin-docs/lib/internal.d.ts
@@ -125,7 +125,7 @@ export interface LifecycleDocsConfig extends DetailDocsConfig {
  */
 export interface DocsConfigSet extends PluginData {
   /** Name of the documentation */
-  name: string;
+  name?: string;
   /** Configuration for the app */
   app: ModuleDocsConfig;
   /** Root directory of the documentation */

--- a/packages/gasket-plugin-nextjs/lib/apm-transaction.js
+++ b/packages/gasket-plugin-nextjs/lib/apm-transaction.js
@@ -10,7 +10,7 @@ module.exports = async function apmTransaction(gasket, transaction, { req }) {
 
   transaction.name = route.page;
 
-  const match = route.namedRegex.exec(req.url.replace(/\?.*$/, ''));
+  const match = route.namedRegex.exec(req.path.replace(/\?.*$/, ''));
   const groups = match && match.groups;
 
   if (!groups) {

--- a/packages/gasket-plugin-nextjs/test/apm-transaction.test.js
+++ b/packages/gasket-plugin-nextjs/test/apm-transaction.test.js
@@ -28,7 +28,7 @@ describe('The apmTransaction hook', () => {
       namedRegex: /^\/customer\/(?<id>[^/]+)(?:\/)?$/
     });
     const req = {
-      url: '/customer/123'
+      path: '/customer/123'
     };
 
     await apmTransaction(mockGasket, transaction, { req });
@@ -48,7 +48,7 @@ describe('The apmTransaction hook', () => {
       namedRegex: /^\/cohorts\/(?<cohortId>[^/]+)(?:\/)?$/
     });
     const req = {
-      url: '/cohorts/Rad%20People'
+      path: '/cohorts/Rad%20People'
     };
 
     await apmTransaction(mockGasket, transaction, { req });
@@ -62,7 +62,7 @@ describe('The apmTransaction hook', () => {
       namedRegex: /^\/cohorts\/(?<cohortId>[^/]+)(?:\/)?$/
     });
     const req = {
-      url: '/cohorts/TopTen%'
+      path: '/cohorts/TopTen%'
     };
 
     await apmTransaction(mockGasket, transaction, { req });
@@ -76,7 +76,8 @@ describe('The apmTransaction hook', () => {
       namedRegex: /^\/cohorts\/(?<cohortId>[^/]+)(?:\/)?$/
     });
     const req = {
-      url: '/cohorts/Rad%20People?utm_source=TDFS_DASLNC&utm_medium=parkedpages&utm_campaign=x_corp_tdfs-daslnc_base&traffic_type=TDFS_DASLNC&traffic_id=daslnc&sayfa=20&act=ul&listurun=12&sublastcat=&subcat=61&marka=&sort=2&catname=Realistik%20Belden%20Ba%F0lamal%FD'
+      // path should never contain a query but this is a safety check
+      path: '/cohorts/Rad%20People?utm_source=TDFS_DASLNC&utm_medium=parkedpages&utm_campaign=x_corp_tdfs-daslnc_base&traffic_type=TDFS_DASLNC&traffic_id=daslnc&sayfa=20&act=ul&listurun=12&sublastcat=&subcat=61&marka=&sort=2&catname=Realistik%20Belden%20Ba%F0lamal%FD'
     };
 
     await apmTransaction(mockGasket, transaction, { req });

--- a/packages/gasket-plugin-nextjs/test/next-route.test.js
+++ b/packages/gasket-plugin-nextjs/test/next-route.test.js
@@ -64,7 +64,6 @@ describe('req.getNextRoute()', () => {
 
     it('returns valid static route if url has query param', async () => {
       req.path = '/plans/cohorts/US%20Only';
-      req.url = '/plans/cohorts/US%20Only?addon=addon1';
 
       const route = await getNextRoute(gasket, req);
 

--- a/packages/gasket-request/lib/index.d.ts
+++ b/packages/gasket-request/lib/index.d.ts
@@ -57,7 +57,7 @@ export type RequestLike = {
  * @see https://developer.mozilla.org/en-US/docs/Web/API/CookieStore/getAll
  */
 export function objectFromCookieStore(
-  cookieStore: CookieStore
+  cookieStore: Partial<CookieStore> | CookieStore
 ): Promise<Record<string, string>>;
 
 /**
@@ -81,7 +81,6 @@ export class GasketRequest {
   cookies: Record<string, string>;
   query: Record<string, string>;
   path: string;
-  url: string;
 }
 
 /**

--- a/packages/gasket-utils/lib/config.d.ts
+++ b/packages/gasket-utils/lib/config.d.ts
@@ -1,0 +1,2 @@
+import { applyConfigOverrides } from './';
+export { applyConfigOverrides };

--- a/packages/gasket-utils/lib/index.d.ts
+++ b/packages/gasket-utils/lib/index.d.ts
@@ -11,7 +11,7 @@ export interface PackageManagerOptions {
 /**
  * Wrapper class for executing commands for a given package manager
  */
-export interface PackageManager {
+export class PackageManager {
   constructor(options: PackageManagerOptions): void;
 
   /** Name of manager, either `npm` (default) or `yarn` */


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

To ensure Next Edge Runtime compatability, we cannot import from the node 'module' package.

This seems to have been changed to get around some TS issues. I've done some additional types tuning as a result.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Test Plan

Tested in local canary app

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
