### PR TITLE
FIX: Update isExpressApp function to check for function type

### DIFF
--- a/.changeset/tidy-bees-walk.md
+++ b/.changeset/tidy-bees-walk.md
@@ -1,0 +1,5 @@
+---
+"@gasket/plugin-nextjs": patch
+---
+
+Fixed isExpressApp function to check for the correct "function" type.

--- a/packages/gasket-plugin-nextjs/lib/utils/setup-next-app.js
+++ b/packages/gasket-plugin-nextjs/lib/utils/setup-next-app.js
@@ -46,7 +46,7 @@ function isDevServer() {
  */
 function isExpressApp(app) {
   return app != null &&
-    typeof app === 'object' &&
+    typeof app === 'function' &&
     typeof /** @type {any} */ (app).use === 'function' &&
     typeof /** @type {any} */ (app).set === 'function';
 }

--- a/packages/gasket-plugin-nextjs/test/index.test.js
+++ b/packages/gasket-plugin-nextjs/test/index.test.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-sync, max-statements */
-const expressApp = {
+const expressApp = Object.assign(jest.fn(), {
   set: jest.fn(),
   use: jest.fn(),
   all: jest.fn()
-};
+});
 
 const nextHandler = jest.fn();
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
The type check for `isExpressApp` was incorrect, as express() returns a [function](https://expressjs.com/en/5x/api.html#app.listen), not an object. This was caught by the Gasket Testing Tool (Thank you testing tool!).

## Test Plan

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
Updated.