### PR TITLE
Update Headers type for RequestLike

### DIFF
--- a/.changeset/little-lemons-change.md
+++ b/.changeset/little-lemons-change.md
@@ -1,0 +1,5 @@
+---
+"@gasket/request": patch
+---
+
+Expand the RequestLike headers shape

--- a/packages/gasket-request/lib/index.d.ts
+++ b/packages/gasket-request/lib/index.d.ts
@@ -1,4 +1,5 @@
 import type { Gasket, MaybeAsync } from '@gasket/core';
+import { IncomingHttpHeaders } from 'http';
 
 interface Cookie {
   domain: string;
@@ -40,12 +41,17 @@ interface CookieStore {
 }
 
 /**
+ * Represents potential headers shapes in a request-like objects.
+ */
+export type HeadersLike = Headers | IncomingHttpHeaders | Record<string, string> & {
+    entries?: Function;
+}
+
+/**
  * Represents a request-like object for Gasket.
  */
 export type RequestLike = {
-  headers: Headers | Record<string, string> & {
-    entries?: Function;
-  };
+  headers: HeadersLike;
   cookies?: CookieStore | Record<string, string>;
   query?: URLSearchParams | Record<string, string | string[]>;
   url?: string;

--- a/packages/gasket-request/lib/request.js
+++ b/packages/gasket-request/lib/request.js
@@ -16,7 +16,7 @@ export class GasketRequest {
 
 /**
  * Weak reference cache for request headers
- * @type {import('@gasket/request').WeakPromiseKeeper<Headers|Record<string,string>, GasketRequest>}
+ * @type {import('@gasket/request').WeakPromiseKeeper<import('@gasket/request').HeadersLike, GasketRequest>}
  */
 const keeper = new WeakPromiseKeeper();
 
@@ -62,7 +62,9 @@ export async function makeGasketRequest(requestLike) {
     const normalize = async () => {
 
       // handle Headers objects
-      const headers = 'entries' in rawHeaders ? Object.fromEntries(rawHeaders.entries()) : rawHeaders;
+      const headers = 'entries' in rawHeaders && typeof rawHeaders.entries === 'function' ?
+        Object.fromEntries(rawHeaders.entries()) :
+        rawHeaders;
 
       // handle when header values are arrays
       // https://nodejs.org/api/http.html#messageheadersdistinct


### PR DESCRIPTION


## Summary

While we had a test for handling `IncomingHttpHeaders`, we had not encountered type issues around it. This PR adds a HeaderLike type which allows for it.

## Test Plan

Tested locally in app

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
