### PR TITLE
Fix to only adjust .cjs extension for relative imports

### DIFF
--- a/.changeset/new-parents-draw.md
+++ b/.changeset/new-parents-draw.md
@@ -1,0 +1,5 @@
+---
+"@gasket/cjs": patch
+---
+
+Fix to only adjust .cjs for relative imports


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

Updated to only replace js and .mjs imports that are local or relative. For example `./next/index.js`, but not `next/document.js` should get the .cjs treatment.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Test Plan

- Added unit tests
- Verified in packages
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
