### PR TITLE
Fix to refresh messages after load

### DIFF
--- a/packages/gasket-intl/lib/locale-handler.js
+++ b/packages/gasket-intl/lib/locale-handler.js
@@ -24,12 +24,32 @@ export function lowestStatus(statuses) {
  * @type {import('./index.d.ts').LocaleHandler}
  */
 export class LocaleHandler {
-  /** @type {import('./internal.d.ts').LocaleFileKey[] } */
+
+  /**
+   * This keeps track of all the locale keys that have been loaded
+   * and includes both static and dynamic loads.
+   * @type {import('./internal.d.ts').LocaleFileKey[] }
+   */
   handledKeys = [];
-  /** @type {import('./internal.d.ts').LocaleFileKey[] } */
+
+  /**
+   * This keeps track of all the messages that have been loaded statically
+   * @type {import('./internal.d.ts').LocaleFileKey[] }
+   */
   staticKeys = [];
-  /** @type {import('./internal.d.ts').MessagesRegister } */
+
+  /**
+   * All statically loaded localeFileKeys and their messages
+   * @type {import('./internal.d.ts').MessagesRegister }
+   */
   staticsRegister;
+
+  /**
+   * All loaded messages combined
+   * @type {import('./internal.d.ts').LocaleMessages }
+   */
+  messages;
+
   handledDirty = true;
   staticsDirty = true;
 

--- a/packages/gasket-intl/lib/locale-handler.js
+++ b/packages/gasket-intl/lib/locale-handler.js
@@ -62,13 +62,13 @@ export class LocaleHandler {
   async load(...localeFilePaths) {
     const list = safePaths(localeFilePaths, this.manager.defaultLocaleFilePath);
 
-    return Promise.allSettled(list.map((localeFilePath) => {
+    return Promise.allSettled(list.map(async (localeFilePath) => {
       const localeFileKey = this.getLocaleFileKey(localeFilePath);
       if (!this.handledKeys.includes(localeFileKey)) {
+        await this.manager.load(localeFileKey);
         this.handledDirty = true;
         this.handledKeys.push(localeFileKey);
       }
-      return this.manager.load(localeFileKey);
     }));
   }
 

--- a/packages/gasket-intl/test/locale-handler.test.js
+++ b/packages/gasket-intl/test/locale-handler.test.js
@@ -121,10 +121,15 @@ describe('LocaleHandler', () => {
       expect(managerLoadSpy).toHaveBeenCalledWith('locales/en-US/grouped');
     });
 
-    it('marks localeFileKeys as handled', () => {
+    it('marks localeFileKeys as handled after load', async () => {
       const handler = new LocaleHandler(manager, 'en-US');
-      handler.load('locales', 'locales/nested', 'locales/:locale/grouped');
 
+      // check not handled before load (no await)
+      const promise = handler.load('locales', 'locales/nested', 'locales/:locale/grouped');
+      expect(handler.handledKeys).toEqual([]);
+
+      // check for handled after load (with await)
+      await promise;
       expect(handler.handledKeys).toEqual(['locales/en-US', 'locales/nested/en-US', 'locales/en-US/grouped']);
     });
   });
@@ -187,9 +192,9 @@ describe('LocaleHandler', () => {
       expect(handler.staticKeys).toEqual(['locales/en-US', 'locales/nested/en-US', 'locales/en-US/grouped']);
     });
 
-    it('marks localeFileKeys as handled and preloaded', () => {
+    it('marks localeFileKeys as handled and preloaded', async () => {
       const handler = new LocaleHandler(manager, 'en-US');
-      handler.loadStatics('locales', 'locales/nested', 'locales/:locale/grouped');
+      await handler.loadStatics('locales', 'locales/nested', 'locales/:locale/grouped');
 
       expect(handler.handledKeys).toEqual(['locales/en-US', 'locales/nested/en-US', 'locales/en-US/grouped']);
       expect(handler.staticKeys).toEqual(['locales/en-US', 'locales/nested/en-US', 'locales/en-US/grouped']);
@@ -295,9 +300,9 @@ describe('LocaleHandler', () => {
     });
 
     // eslint-disable-next-line max-statements
-    it('gets least priority multiple path status', () => {
+    it('gets least priority multiple path status', async () => {
       const handler = new LocaleHandler(manager, 'en-US');
-      handler.load('locales', 'locales/nested', 'locales/:locale/grouped');
+      await handler.load('locales', 'locales/nested', 'locales/:locale/grouped');
 
       let status = handler.getStatus('locales', 'locales/nested', 'locales/:locale/grouped');
       expect(status).toEqual(LocaleFileStatus.error);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

We were encountering a strange race condition where locale files were being loaded, but their messages were not available for rendering. Turns out we were refreshing the messages object too soon because locale files were prematurely marked as handled before they were actually loaded.

## Test Plan

- Tested locally in app presenting the bug
