### PR TITLE
[PFX-982] - create-gasket-app template support

### DIFF
--- a/packages/create-gasket-app/EXAMPLES.md
+++ b/packages/create-gasket-app/EXAMPLES.md
@@ -25,3 +25,24 @@ npx create-gasket-app@latest my-app --config-file ./create-config.json
 # Skip prompts (for CI)
 npx create-gasket-app@latest my-app --presets @gasket/preset-nextjs --no-prompts
 ```
+
+## Templates
+
+Templates provide complete Gasket applications ready to use:
+
+```bash
+# Use an npm template package
+npx create-gasket-app@latest my-app --template @gasket/template-nextjs-pages-js
+
+# Use a versioned template
+npx create-gasket-app@latest my-app --template @gasket/template-api@^2.0.0
+
+# Use a tagged template
+npx create-gasket-app@latest my-app --template @gasket/template-nextjs@beta
+
+# Use a local template during development
+npx create-gasket-app@latest my-app --template-path ./my-gasket-template
+
+# Use local template with absolute path
+npx create-gasket-app@latest my-app --template-path /path/to/my-template
+```

--- a/packages/create-gasket-app/README.md
+++ b/packages/create-gasket-app/README.md
@@ -43,6 +43,10 @@ Options:
   -p, --presets [presets]              Initial Gasket preset(s) to use.
         Can be set as short name with version (e.g. --presets nextjs@^1.0.0)
         Or other (multiple) custom presets (e.g. --presets my-gasket-preset@1.0.0.beta-1,nextjs@^1.0.0)
+  --template [template]                Selects which template you would like to use during
+        installation. (e.g. --template @gasket/template-nextjs-pages-js)
+  --template-path [template-path]      (INTERNAL) Path to a local template package. Can be absolute
+        or relative to the current working directory.
   --package-manager [package-manager]  Selects which package manager you would like to use during
         installation. (e.g. --package-manager yarn)
   -r, --require [require]              Require module(s) before Gasket is initialized
@@ -50,6 +54,48 @@ Options:
   --config-file [config-file]          Path to a JSON file that provides the values for any interactive prompts
   -h, --help                           display help for command
 ```
+
+#### Templates
+
+Templates provide a complete Gasket application ready to use, unlike presets which build apps through a plugin-based creation process.
+
+##### Using Templates
+
+```bash
+# Use an official template from npm
+npx create-gasket-app@latest my-app --template @gasket/template-nextjs-pages-js
+
+# Use a versioned template
+npx create-gasket-app@latest my-app --template @gasket/template-api@^2.0.0
+
+# Use a local template (development)
+npx create-gasket-app@latest my-app --template-path ./path/to/my-template
+
+# Use a template with tag
+npx create-gasket-app@latest my-app --template @gasket/template-nextjs-pages-js@beta
+```
+
+##### Template Structure
+
+Templates are npm packages that follow this structure:
+
+```
+@gasket/template-example/
+├── package.json
+├── template/
+│   ├── package.json      # App's package.json
+│   ├── gasket.js         # App's gasket config
+│   ├── src/              # App source files
+│   └── ...               # Other app files
+└── README.md
+```
+
+When using templates:
+- The entire `template/` directory is copied to your new app
+- Template dependencies are installed with `npm ci`  
+- No preset processing or plugin creation flows are run
+
+**Note:** Templates currently require npm as they come with `package-lock.json` files.
 
 #### Package Managers
 

--- a/packages/create-gasket-app/lib/commands/create.js
+++ b/packages/create-gasket-app/lib/commands/create.js
@@ -6,6 +6,7 @@ import { rm } from 'fs/promises';
 import { makeGasket } from '@gasket/core';
 import globalPrompts from '../scaffold/actions/global-prompts.js';
 import loadPreset from '../scaffold/actions/load-preset.js';
+import loadTemplate from '../scaffold/actions/load-template.js';
 import presetPromptHooks from '../scaffold/actions/preset-prompt-hooks.js';
 import presetConfigHooks from '../scaffold/actions/preset-config-hooks.js';
 import promptHooks from '../scaffold/actions/prompt-hooks.js';
@@ -44,6 +45,17 @@ const createCommand = {
       Can be set as short name with version (e.g. --presets nextjs@^1.0.0)
       Or other (multiple) custom presets (e.g. --presets my-gasket-preset@1.0.0.beta-1,nextjs@^1.0.0)`,
       parse: commasToArray
+    },
+    {
+      name: 'template',
+      description: `Selects which template you would like to use during
+      installation. (e.g. --template @gasket/template-nextjs-pages-js)`
+    },
+    {
+      name: 'template-path',
+      description: `(INTERNAL) Path to a local template package. Can be absolute
+      or relative to the current working directory.`,
+      hidden: true
     },
     {
       name: 'package-manager',
@@ -101,6 +113,15 @@ createCommand.action = async function run(appname, options, command) {
   const { rawPresets, localPresets } = context;
 
   try {
+    // If template is provided, use simplified template path
+    if (context.template || context.templatePath) {
+      await mkDir({ context });
+      await loadTemplate({ context });
+      printReport({ context });
+      return;
+    }
+
+    // Original preset-based creation path
     await globalPrompts({ context });
 
     if (rawPresets.length || localPresets.length) {

--- a/packages/create-gasket-app/lib/index.d.ts
+++ b/packages/create-gasket-app/lib/index.d.ts
@@ -47,6 +47,8 @@ interface CommandOption {
 
 export interface CreateCommandOptions {
   presets?: string[];
+  template?: string;
+  templatePath?: string;
   npmLink?: string[];
   presetPath?: string[];
   packageManager?: string;
@@ -458,6 +460,12 @@ export interface CreateContext {
 
   /** temporary directory */
   tmpDir: string;
+
+  /** template to use for app creation */
+  template?: string;
+
+  /** path to local template package */
+  templatePath?: string;
 
   /** Default to object w/empty plugins array to be populated by `presetConfig` hook */
   presetConfig: GasketConfigDefinition;

--- a/packages/create-gasket-app/lib/internal.d.ts
+++ b/packages/create-gasket-app/lib/internal.d.ts
@@ -104,6 +104,7 @@ export function promptForTestPlugin(
 export function allowExtantOverwriting(context: PartialCreateContext, prompt: CreatePrompt): Promise<void>;
 export function globalPrompts(params: { context: PartialCreateContext }): Promise<void>;
 export function loadPresets(params: { context: PartialCreateContext }): Promise<void>;
+export function loadTemplate(params: { context: PartialCreateContext }): Promise<void>;
 export function presetPromptHooks(params: { gasket?: Gasket; context: PartialCreateContext }): Promise<void>;
 export function presetConfigHooks(params: { gasket?: Gasket; context: PartialCreateContext }): Promise<void>;
 export function promptHooks(params: { gasket?: Gasket; context: PartialCreateContext }): Promise<void>;

--- a/packages/create-gasket-app/lib/scaffold/actions/load-template.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/load-template.js
@@ -1,0 +1,114 @@
+import path from 'path';
+import os from 'os';
+import { withSpinner } from '../with-spinner.js';
+import { PackageManager } from '@gasket/utils';
+import { mkdtemp, cp, readdir, rm } from 'fs/promises';
+
+const hasVersionOrTag = /@([\^~]?\d+\.\d+\.\d+(?:-[\d\w.-]+)?|[\^~]?\d+\.\d+\.\d+|[a-zA-Z]+|file:.+)$/;
+
+/**
+ * validateTemplateName - Validate the template name
+ * @param {string} template - The template name
+ * @returns {void}
+ */
+function validateTemplateName(template) {
+  const isValidName = template.includes('/gasket-template-') || template.includes('@gasket/template-');
+  const isMispelled = template.endsWith('-template');
+
+  if (isMispelled) {
+    throw new Error(`Invalid template name: ${template}. Please check the name and try again.`);
+  }
+
+  if (!isValidName) {
+    throw new Error(`Invalid template name: ${template}. Templates must follow naming convention.`);
+  }
+}
+
+async function loadTemplate({ context }) {
+  if (!context.template && !context.templatePath) return;
+
+  try {
+    let templateDir;
+    let templateName;
+
+    if (context.templatePath) {
+      // Handle local template path
+      templateDir = path.resolve(context.templatePath, 'template');
+      templateName = `local template at ${templateDir}`;
+    } else {
+      // Handle remote template package
+      const tmpDir = await mkdtemp(path.join(os.tmpdir(), `gasket-template-${context.appName}`));
+      const modPath = path.join(tmpDir, 'node_modules');
+      const pkgManager = new PackageManager({
+        packageManager: 'npm',
+        dest: tmpDir
+      });
+
+      const template = context.template;
+      validateTemplateName(template);
+
+      const parts = hasVersionOrTag.test(template) && template.split('@').filter(Boolean);
+      const name = parts ? `@${parts[0]}` : template;
+      const version = parts ? `@${parts[1]}` : '@latest';
+
+      try {
+        // Install the template package
+        await pkgManager.exec('install', [`${name}${version}`]);
+        templateDir = path.join(modPath, name, 'template');
+        templateName = `${name}${version}`;
+
+        // Clean up will happen after copying
+        context._templateTmpDir = tmpDir;
+      } catch (err) {
+        // Clean up on error
+        await rm(tmpDir, { recursive: true });
+
+        const errorMessage = err.stderr || err.message;
+        if (err.stderr && err.stderr.includes('is not in this registry')) {
+          throw new Error(`Template not found in registry: ${name}${version}. Use npm_config_registry=<registry> to use privately scoped templates.`);
+        }
+        throw new Error(`Failed to install template ${name}${version}: ${errorMessage}`);
+      }
+    }
+
+    // Copy entire template directory to destination (excluding node_modules)
+    const entries = await readdir(templateDir, { withFileTypes: true });
+    const filesToCopy = entries.filter(entry =>
+      entry.name !== 'node_modules'
+    );
+
+    for (const entry of filesToCopy) {
+      const sourcePath = path.join(templateDir, entry.name);
+      const destPath = path.join(context.dest, entry.name);
+      await cp(sourcePath, destPath, { recursive: true });
+      context.generatedFiles.add(path.relative(context.cwd, destPath));
+    }
+
+    // Clean up template temp directory if it was created
+    if (context._templateTmpDir) {
+      await rm(context._templateTmpDir, { recursive: true });
+    }
+
+    // Run npm ci in the destination directory to install dependencies
+    const destPkgManager = new PackageManager({
+      packageManager: 'npm',
+      dest: context.dest
+    });
+    await destPkgManager.exec('ci');
+
+    context.messages.push(`Template ${templateName} installed and dependencies resolved`);
+
+  } catch (err) {
+    // Clean up on error
+    if (context._templateTmpDir) {
+      try {
+        await rm(context._templateTmpDir, { recursive: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+    throw err;
+  }
+}
+
+export default withSpinner('Load template', loadTemplate);

--- a/packages/create-gasket-app/lib/scaffold/create-context.js
+++ b/packages/create-gasket-app/lib/scaffold/create-context.js
@@ -74,6 +74,8 @@ export function makeCreateContext(argv = [], options = {}) {
   const appName = argv[0] || 'templated-app';
   const {
     presets = [],
+    template,
+    templatePath,
     npmLink = [],
     presetPath = [],
     packageManager,
@@ -107,6 +109,8 @@ export function makeCreateContext(argv = [], options = {}) {
     pkgLinks,
     localPresets,
     rawPresets,
+    template,
+    templatePath,
     messages: [],
     warnings: [],
     errors: [],

--- a/packages/create-gasket-app/test/__mocks__/@gasket/template-test/package.json
+++ b/packages/create-gasket-app/test/__mocks__/@gasket/template-test/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@gasket/template-test",
+  "version": "1.0.0",
+  "description": "Test template for Gasket applications",
+  "main": "index.js",
+  "keywords": ["gasket", "template"],
+  "author": "Gasket Team",
+  "license": "MIT",
+  "gasket": {
+    "metadata": {
+      "name": "Test Template",
+      "description": "A test template for Gasket applications"
+    }
+  }
+}
+

--- a/packages/create-gasket-app/test/__mocks__/@gasket/template-test/template/README.md
+++ b/packages/create-gasket-app/test/__mocks__/@gasket/template-test/template/README.md
@@ -1,0 +1,12 @@
+# Test App
+
+This is a test application generated from a Gasket template.
+
+## Getting Started
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+

--- a/packages/create-gasket-app/test/__mocks__/@gasket/template-test/template/gasket.js
+++ b/packages/create-gasket-app/test/__mocks__/@gasket/template-test/template/gasket.js
@@ -1,0 +1,11 @@
+import { makeGasket } from '@gasket/core';
+import pluginLogger from '@gasket/plugin-logger';
+import pluginNextjs from '@gasket/plugin-nextjs';
+
+export default makeGasket({
+  plugins: [
+    pluginLogger,
+    pluginNextjs
+  ]
+});
+

--- a/packages/create-gasket-app/test/__mocks__/@gasket/template-test/template/package.json
+++ b/packages/create-gasket-app/test/__mocks__/@gasket/template-test/template/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "test-app",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.0.0",
+    "typescript": "^5.0.0"
+  }
+}
+

--- a/packages/create-gasket-app/test/unit/scaffold/actions/load-template.test.js
+++ b/packages/create-gasket-app/test/unit/scaffold/actions/load-template.test.js
@@ -1,0 +1,451 @@
+const {
+  mockPackageManagerConstructor,
+  mockPackageManagerExec,
+  mockMkdtemp,
+  mockCp,
+  mockReaddir,
+  mockRm,
+  mockPathJoin,
+  mockPathResolve,
+  mockTmpdir
+} = vi.hoisted(() => ({
+  mockPackageManagerConstructor: vi.fn(),
+  mockPackageManagerExec: vi.fn(),
+  mockMkdtemp: vi.fn(),
+  mockCp: vi.fn(),
+  mockReaddir: vi.fn(),
+  mockRm: vi.fn(),
+  mockPathJoin: vi.fn().mockImplementation((...args) => args.join('/')),
+  mockPathResolve: vi.fn().mockImplementation((...args) => args.join('/').replace(/\/+/g, '/')),
+  mockTmpdir: vi.fn()
+}));
+
+vi.mock('@gasket/utils', () => ({
+  PackageManager: class MockPackageManager {
+    constructor(options) {
+      mockPackageManagerConstructor(options);
+    }
+    async exec() {
+      return mockPackageManagerExec(...arguments);
+    }
+  }
+}));
+
+vi.mock('fs/promises', () => ({
+  mkdtemp: mockMkdtemp,
+  cp: mockCp,
+  readdir: mockReaddir,
+  rm: mockRm
+}));
+
+vi.mock('path', () => ({
+  default: {
+    join: mockPathJoin,
+    resolve: mockPathResolve,
+    relative: vi.fn().mockImplementation((from, to) => {
+      // Simple relative path calculation for testing
+      if (from === '/current/dir' && to.startsWith('/path/to/app/')) {
+        return '../' + to.replace('/path/to/app/', '');
+      }
+      return to.replace(from, '');
+    })
+  }
+}));
+
+vi.mock('os', () => ({
+  default: {
+    tmpdir: mockTmpdir
+  }
+}));
+
+// __dirname not used in this test file
+
+// Set up mock defaults
+mockTmpdir.mockReturnValue('/tmp');
+mockMkdtemp.mockResolvedValue('/tmp/gasket-template-test-123');
+mockReaddir.mockResolvedValue([
+  { name: 'gasket.js', isDirectory: () => false },
+  { name: 'package.json', isDirectory: () => false },
+  { name: 'README.md', isDirectory: () => false },
+  { name: 'node_modules', isDirectory: () => true }
+]);
+mockCp.mockResolvedValue();
+mockRm.mockResolvedValue();
+mockPackageManagerExec.mockResolvedValue();
+
+const loadTemplate = (await import('../../../../lib/scaffold/actions/load-template.js')).default;
+
+describe('loadTemplate', () => {
+  let mockContext;
+
+  beforeEach(() => {
+    mockContext = {
+      appName: 'test-app',
+      dest: '/path/to/app',
+      cwd: '/current/dir',
+      generatedFiles: new Set(),
+      messages: []
+    };
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is decorated action', () => {
+    expect(loadTemplate).toHaveProperty('wrapped');
+  });
+
+  describe('early return conditions', () => {
+    it('returns early if no template or templatePath provided', async () => {
+      await loadTemplate({ context: mockContext });
+
+      expect(mockMkdtemp).not.toHaveBeenCalled();
+      expect(mockPackageManagerConstructor).not.toHaveBeenCalled();
+    });
+
+    it('proceeds if template is provided', async () => {
+      mockContext.template = '@gasket/template-test';
+
+      await loadTemplate({ context: mockContext });
+
+      expect(mockMkdtemp).toHaveBeenCalled();
+      expect(mockPackageManagerConstructor).toHaveBeenCalled();
+    });
+
+    it('proceeds if templatePath is provided', async () => {
+      mockContext.templatePath = '/path/to/local/template';
+
+      await loadTemplate({ context: mockContext });
+
+      expect(mockCp).toHaveBeenCalled();
+    });
+  });
+
+  describe('validateTemplateName', () => {
+    it('accepts valid template names with /gasket-template-', async () => {
+      mockContext.template = 'org/gasket-template-nextjs';
+
+      await expect(loadTemplate({ context: mockContext })).resolves.not.toThrow();
+    });
+
+    it('accepts valid template names with @gasket/template-', async () => {
+      mockContext.template = '@gasket/template-nextjs';
+
+      await expect(loadTemplate({ context: mockContext })).resolves.not.toThrow();
+    });
+
+    it('rejects template names ending with -template', async () => {
+      mockContext.template = '@gasket/nextjs-template';
+
+      await expect(loadTemplate({ context: mockContext })).rejects.toThrow(
+        'Invalid template name: @gasket/nextjs-template. Please check the name and try again.'
+      );
+    });
+
+    it('rejects template names that do not follow naming convention', async () => {
+      mockContext.template = 'some-random-package';
+
+      await expect(loadTemplate({ context: mockContext })).rejects.toThrow(
+        'Invalid template name: some-random-package. Templates must follow naming convention.'
+      );
+    });
+  });
+
+  describe('local template path', () => {
+    beforeEach(() => {
+      mockContext.templatePath = '/path/to/local/template';
+    });
+
+    it('uses resolved template path', async () => {
+      await loadTemplate({ context: mockContext });
+
+      expect(mockPathResolve).toHaveBeenCalledWith('/path/to/local/template', 'template');
+      expect(mockReaddir).toHaveBeenCalledWith(
+        '/path/to/local/template/template',
+        { withFileTypes: true }
+      );
+    });
+
+    it('copies all files except node_modules', async () => {
+      await loadTemplate({ context: mockContext });
+
+      expect(mockCp).toHaveBeenCalledTimes(3);
+      expect(mockCp).toHaveBeenCalledWith(
+        '/path/to/local/template/template/gasket.js',
+        '/path/to/app/gasket.js',
+        { recursive: true }
+      );
+      expect(mockCp).toHaveBeenCalledWith(
+        '/path/to/local/template/template/package.json',
+        '/path/to/app/package.json',
+        { recursive: true }
+      );
+      expect(mockCp).toHaveBeenCalledWith(
+        '/path/to/local/template/template/README.md',
+        '/path/to/app/README.md',
+        { recursive: true }
+      );
+    });
+
+    it('adds generated files to context', async () => {
+      await loadTemplate({ context: mockContext });
+
+      expect(mockContext.generatedFiles.has('../gasket.js')).toBe(true);
+      expect(mockContext.generatedFiles.has('../package.json')).toBe(true);
+      expect(mockContext.generatedFiles.has('../README.md')).toBe(true);
+    });
+
+    it('runs npm ci in destination directory', async () => {
+      await loadTemplate({ context: mockContext });
+
+      expect(mockPackageManagerConstructor).toHaveBeenCalledWith({
+        packageManager: 'npm',
+        dest: '/path/to/app'
+      });
+      expect(mockPackageManagerExec).toHaveBeenCalledWith('ci');
+    });
+
+    it('adds success message', async () => {
+      await loadTemplate({ context: mockContext });
+
+      expect(mockContext.messages).toContain(
+        'Template local template at /path/to/local/template/template installed and dependencies resolved'
+      );
+    });
+  });
+
+  describe('remote template package', () => {
+    beforeEach(() => {
+      mockContext.template = '@gasket/template-nextjs';
+    });
+
+    it('creates temporary directory', async () => {
+      await loadTemplate({ context: mockContext });
+
+      expect(mockMkdtemp).toHaveBeenCalledWith('/tmp/gasket-template-test-app');
+    });
+
+    it('creates PackageManager for temporary directory', async () => {
+      await loadTemplate({ context: mockContext });
+
+      expect(mockPackageManagerConstructor).toHaveBeenCalledWith({
+        packageManager: 'npm',
+        dest: '/tmp/gasket-template-test-123'
+      });
+    });
+
+    it('installs template package without version', async () => {
+      await loadTemplate({ context: mockContext });
+
+      expect(mockPackageManagerExec).toHaveBeenNthCalledWith(1, 'install', ['@gasket/template-nextjs@latest']);
+    });
+
+    it('installs template package with version', async () => {
+      mockContext.template = '@gasket/template-nextjs@^1.0.0';
+
+      await loadTemplate({ context: mockContext });
+
+      expect(mockPackageManagerExec).toHaveBeenNthCalledWith(1, 'install', ['@gasket/template-nextjs@^1.0.0']);
+    });
+
+    it('installs template package with tag', async () => {
+      mockContext.template = '@gasket/template-nextjs@canary';
+
+      await loadTemplate({ context: mockContext });
+
+      expect(mockPackageManagerExec).toHaveBeenNthCalledWith(1, 'install', ['@gasket/template-nextjs@canary']);
+    });
+
+    it('handles file: versions', async () => {
+      mockContext.template = '@gasket/template-nextjs@file:./local/path';
+
+      await loadTemplate({ context: mockContext });
+
+      expect(mockPackageManagerExec).toHaveBeenNthCalledWith(1, 'install', ['@gasket/template-nextjs@file:./local/path']);
+    });
+
+    it('copies template files from node_modules', async () => {
+      await loadTemplate({ context: mockContext });
+
+      const templatePath = '/tmp/gasket-template-test-123/node_modules/@gasket/template-nextjs/template';
+      expect(mockReaddir).toHaveBeenCalledWith(templatePath, { withFileTypes: true });
+      expect(mockCp).toHaveBeenCalledTimes(3);
+    });
+
+    it('cleans up temporary directory after successful installation', async () => {
+      await loadTemplate({ context: mockContext });
+
+      expect(mockRm).toHaveBeenNthCalledWith(1, '/tmp/gasket-template-test-123', { recursive: true });
+    });
+
+    it('runs npm ci in destination directory after copying', async () => {
+      await loadTemplate({ context: mockContext });
+
+      // First call is for template installation, second is for app dependencies
+      expect(mockPackageManagerExec).toHaveBeenNthCalledWith(2, 'ci');
+      expect(mockPackageManagerConstructor).toHaveBeenNthCalledWith(2, {
+        packageManager: 'npm',
+        dest: '/path/to/app'
+      });
+    });
+
+    it('adds success message with template name and version', async () => {
+      await loadTemplate({ context: mockContext });
+
+      expect(mockContext.messages).toContain('Template @gasket/template-nextjs@latest installed and dependencies resolved');
+    });
+
+    describe('error handling for remote templates', () => {
+      it('cleans up temporary directory on install error', async () => {
+        const error = new Error('Installation failed');
+        mockPackageManagerExec.mockRejectedValueOnce(error);
+
+        await expect(loadTemplate({ context: mockContext })).rejects.toThrow(
+          'Failed to install template @gasket/template-nextjs@latest: Installation failed'
+        );
+
+        expect(mockRm).toHaveBeenCalledWith('/tmp/gasket-template-test-123', { recursive: true });
+      });
+
+      it('provides specific error for registry not found', async () => {
+        const error = new Error('npm error');
+        error.stderr = "'@gasket/template-notfound' is not in this registry.";
+        mockPackageManagerExec.mockRejectedValueOnce(error);
+
+        const expectedError = 'Template not found in registry: @gasket/template-nextjs@latest. ' +
+          'Use npm_config_registry=<registry> to use privately scoped templates.';
+        await expect(loadTemplate({ context: mockContext })).rejects.toThrow(expectedError);
+      });
+
+      it('sets _templateTmpDir on context for cleanup', async () => {
+        await loadTemplate({ context: mockContext });
+
+        expect(mockContext._templateTmpDir).toBe('/tmp/gasket-template-test-123');
+      });
+
+      it('cleans up temporary directory on general error', async () => {
+        mockCp.mockRejectedValueOnce(new Error('Copy failed'));
+
+        await expect(loadTemplate({ context: mockContext })).rejects.toThrow('Copy failed');
+
+        expect(mockRm).toHaveBeenCalledWith('/tmp/gasket-template-test-123', { recursive: true });
+      });
+
+      it('ignores cleanup errors during error handling', async () => {
+        mockCp.mockRejectedValueOnce(new Error('Copy failed'));
+        mockRm.mockRejectedValueOnce(new Error('Cleanup failed'));
+
+        await expect(loadTemplate({ context: mockContext })).rejects.toThrow('Copy failed');
+
+        // Should still attempt cleanup even if it fails
+        expect(mockRm).toHaveBeenCalledWith('/tmp/gasket-template-test-123', { recursive: true });
+      });
+    });
+  });
+
+  describe('version and tag parsing', () => {
+    const testCases = [
+      {
+        input: '@gasket/template-nextjs@1.0.0',
+        expectedName: '@gasket/template-nextjs',
+        expectedVersion: '@1.0.0'
+      },
+      {
+        input: '@gasket/template-nextjs@^1.0.0',
+        expectedName: '@gasket/template-nextjs',
+        expectedVersion: '@^1.0.0'
+      },
+      {
+        input: '@gasket/template-nextjs@~1.2.3',
+        expectedName: '@gasket/template-nextjs',
+        expectedVersion: '@~1.2.3'
+      },
+      {
+        input: '@gasket/template-nextjs@1.0.0-beta.1',
+        expectedName: '@gasket/template-nextjs',
+        expectedVersion: '@1.0.0-beta.1'
+      },
+      {
+        input: '@gasket/template-nextjs@canary',
+        expectedName: '@gasket/template-nextjs',
+        expectedVersion: '@canary'
+      },
+      {
+        input: '@gasket/template-nextjs@file:./local/path',
+        expectedName: '@gasket/template-nextjs',
+        expectedVersion: '@file:./local/path'
+      },
+      {
+        input: '@gasket/template-nextjs',
+        expectedName: '@gasket/template-nextjs',
+        expectedVersion: '@latest'
+      }
+    ];
+
+    testCases.forEach(({ input, expectedName, expectedVersion }) => {
+      it(`correctly parses ${input}`, async () => {
+        mockContext.template = input;
+
+        await loadTemplate({ context: mockContext });
+
+        expect(mockPackageManagerExec).toHaveBeenNthCalledWith(1, 'install', [`${expectedName}${expectedVersion}`]);
+        expect(mockContext.messages).toContain(`Template ${expectedName}${expectedVersion} installed and dependencies resolved`);
+      });
+    });
+  });
+
+  describe('file operations', () => {
+    beforeEach(() => {
+      mockContext.template = '@gasket/template-test';
+    });
+
+    it('filters out node_modules from copying', async () => {
+      mockReaddir.mockResolvedValueOnce([
+        { name: 'gasket.js', isDirectory: () => false },
+        { name: 'node_modules', isDirectory: () => true },
+        { name: 'src', isDirectory: () => true },
+        { name: 'package.json', isDirectory: () => false }
+      ]);
+
+      await loadTemplate({ context: mockContext });
+
+      expect(mockCp).toHaveBeenCalledTimes(3);
+      const templateBase = '/tmp/gasket-template-test-123/node_modules/@gasket/template-test/template';
+      expect(mockCp).toHaveBeenCalledWith(
+        `${templateBase}/gasket.js`,
+        '/path/to/app/gasket.js',
+        { recursive: true }
+      );
+      expect(mockCp).toHaveBeenCalledWith(
+        `${templateBase}/src`,
+        '/path/to/app/src',
+        { recursive: true }
+      );
+      expect(mockCp).toHaveBeenCalledWith(
+        `${templateBase}/package.json`,
+        '/path/to/app/package.json',
+        { recursive: true }
+      );
+    });
+
+    it('uses recursive copy for all files', async () => {
+      await loadTemplate({ context: mockContext });
+
+      expect(mockCp).toHaveBeenCalledWith(expect.any(String), expect.any(String), { recursive: true });
+    });
+
+    it('tracks generated files relative to cwd', async () => {
+      await loadTemplate({ context: mockContext });
+
+      expect(mockContext.generatedFiles.size).toBe(3);
+      expect([...mockContext.generatedFiles]).toEqual(expect.arrayContaining([
+        '../gasket.js',
+        '../package.json',
+        '../README.md'
+      ]));
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Add Template Loading Support to create-gasket-app

### Summary
Added comprehensive template loading functionality to `create-gasket-app`, enabling users to bootstrap new Gasket applications using predefined templates from npm packages or local file paths.

### Changes Made

#### 🆕 New Features
- **Template Loading Action** (`lib/scaffold/actions/load-template.js`)
  - Supports remote npm packages (`@gasket/template-nextjs`, `org/gasket-template-api`)
  - Supports local template paths (`--template-path ./my-template`)  
  - Validates template naming conventions
  - Handles versioned packages (`@1.0.0`, `@canary`, `@file:./path`)
  - Automatic dependency installation with `npm ci`
  - Proper cleanup of temporary directories on errors

#### 🧪 Testing Infrastructure  
- **Comprehensive Test Suite** (`test/unit/scaffold/actions/load-template.test.js`)
  - 38 test cases covering all scenarios
  - Template name validation tests
  - Local vs remote template handling  
  - Error handling and cleanup verification
  - Version/tag parsing validation
  - File operation testing

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
