### PR TITLE
Fix broken intl.js imports when locales are in a subdir

### DIFF
--- a/.changeset/upset-games-sneeze.md
+++ b/.changeset/upset-games-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@gasket/plugin-intl": patch
+---
+
+Fix broken intl.js locale paths when locales are in a subdir

--- a/packages/gasket-plugin-intl/lib/build-manifest.js
+++ b/packages/gasket-plugin-intl/lib/build-manifest.js
@@ -47,14 +47,12 @@ module.exports = async function buildManifest(gasket, options = {}) {
   const imports = (
     files.map((file) => {
       const managerDir = path.dirname(path.join(tgtRoot, ...managerFilename.split('/')));
-      const relativePath = path.relative(managerDir, tgtLocalesDir);
-      const importName = path.join('.', relativePath, file).replace(/\\/g, '/');
-      console.log('importName', importName);
-      console.log('managerDir', managerDir);
-      console.log('relativePath', relativePath);
+      const relativePath = path.relative(managerDir, tgtLocalesDir) ?? '.';
+      let importName = path.join(relativePath, file).replace(/\\/g, '/');
+      importName = importName.startsWith('.') ? importName : `./${importName}`;
       const keyName = importName
         .replace(/\.json$/, '')
-        .replace('./', '');
+        .replace(/^[./]+/, '');
       if (gasket.config.intl.experimentalImportAttributes) {
         return { [keyName]: `%() => import('${importName}', { with: { type: 'json' } })%` };
       }

--- a/packages/gasket-plugin-intl/lib/build-manifest.js
+++ b/packages/gasket-plugin-intl/lib/build-manifest.js
@@ -46,8 +46,12 @@ module.exports = async function buildManifest(gasket, options = {}) {
   // generate a content hash for each file
   const imports = (
     files.map((file) => {
-      const relativePath = path.relative(tgtRoot, tgtLocalesDir);
-      const importName = ['.', relativePath, file].join('/');
+      const managerDir = path.dirname(path.join(tgtRoot, ...managerFilename.split('/')));
+      const relativePath = path.relative(managerDir, tgtLocalesDir);
+      const importName = path.join('.', relativePath, file).replace(/\\/g, '/');
+      console.log('importName', importName);
+      console.log('managerDir', managerDir);
+      console.log('relativePath', relativePath);
       const keyName = importName
         .replace(/\.json$/, '')
         .replace('./', '');

--- a/packages/gasket-plugin-intl/lib/build-manifest.js
+++ b/packages/gasket-plugin-intl/lib/build-manifest.js
@@ -46,7 +46,8 @@ module.exports = async function buildManifest(gasket, options = {}) {
   // generate a content hash for each file
   const imports = (
     files.map((file) => {
-      const importName = ['.', path.basename(localesDir), file].join('/');
+      const relativePath = path.relative(tgtRoot, tgtLocalesDir);
+      const importName = ['.', relativePath, file].join('/');
       const keyName = importName
         .replace(/\.json$/, '')
         .replace('./', '');

--- a/packages/gasket-plugin-intl/test/build-manifest.test.js
+++ b/packages/gasket-plugin-intl/test/build-manifest.test.js
@@ -169,4 +169,14 @@ describe('buildManifest', function () {
     const expected = `import type { LocaleManifest } from '@gasket/intl';`;
     expect(getOutput()).toContain(expected);
   });
+
+  it('allows for subdirectories', async function () {
+    mockGasket.config.intl.localesDir = './src/locales';
+    mockGasket.config.intl.defaultLocaleFilePath = './src/locales';
+    await buildManifest(mockGasket);
+    expect(mockWriteFileStub).toHaveBeenCalled();
+    expect(mockWriteFileStub.mock.calls[0][0]).toContain(path.join('fixtures', 'intl.js'));
+    expect(mockWriteFileStub.mock.calls[0][1]).toContain(path.join('src', 'locales', 'en-US.json'));
+    expect(mockWriteFileStub.mock.calls[0][1]).toContain(path.join('src', 'locales', 'fr-FR.json'));
+  });
 });

--- a/packages/gasket-plugin-intl/test/build-manifest.test.js
+++ b/packages/gasket-plugin-intl/test/build-manifest.test.js
@@ -115,10 +115,22 @@ describe('buildManifest', function () {
     await buildManifest(mockGasket);
     const output = getOutput();
     expect(output).toContain(
-      `'locales/en-US': () => import('locales/en-US.json')`
+      `'locales/en-US': () => import('./locales/en-US.json')`
     );
     expect(output).toContain(
-      `'locales/fr-FR': () => import('locales/fr-FR.json')`
+      `'locales/fr-FR': () => import('./locales/fr-FR.json')`
+    );
+  });
+
+  it('associates locale file keys to imports relative to manifest', async function () {
+    mockGasket.config.intl.managerFilename = 'deep/custom/intl-manager.js';
+    await buildManifest(mockGasket);
+    const output = getOutput();
+    expect(output).toContain(
+      `'locales/en-US': () => import('../../locales/en-US.json')`
+    );
+    expect(output).toContain(
+      `'locales/fr-FR': () => import('../../locales/fr-FR.json')`
     );
   });
 
@@ -127,10 +139,10 @@ describe('buildManifest', function () {
     await buildManifest(mockGasket);
     const output = getOutput();
     expect(output).toContain(
-      `'locales/en-US': () => import('locales/en-US.json', { with: { type: 'json' } })`
+      `'locales/en-US': () => import('./locales/en-US.json', { with: { type: 'json' } })`
     );
     expect(output).toContain(
-      `'locales/fr-FR': () => import('locales/fr-FR.json', { with: { type: 'json' } })`
+      `'locales/fr-FR': () => import('./locales/fr-FR.json', { with: { type: 'json' } })`
     );
   });
 
@@ -138,10 +150,10 @@ describe('buildManifest', function () {
     await buildManifest(mockGasket);
     const output = getOutput();
     expect(output).toContain(
-      `'locales/extra/en-US': () => import('locales/extra/en-US.json')`
+      `'locales/extra/en-US': () => import('./locales/extra/en-US.json')`
     );
     expect(output).toContain(
-      `'locales/extra/fr-FR': () => import('locales/extra/fr-FR.json')`
+      `'locales/extra/fr-FR': () => import('./locales/extra/fr-FR.json')`
     );
   });
 
@@ -149,10 +161,10 @@ describe('buildManifest', function () {
     await buildManifest(mockGasket);
     const output = getOutput();
     expect(output).toContain(
-      `'locales/en-US/grouped': () => import('locales/en-US/grouped.json')`
+      `'locales/en-US/grouped': () => import('./locales/en-US/grouped.json')`
     );
     expect(output).toContain(
-      `'locales/fr-FR/grouped': () => import('locales/fr-FR/grouped.json')`
+      `'locales/fr-FR/grouped': () => import('./locales/fr-FR/grouped.json')`
     );
   });
 

--- a/packages/gasket-plugin-intl/test/build-manifest.test.js
+++ b/packages/gasket-plugin-intl/test/build-manifest.test.js
@@ -115,10 +115,10 @@ describe('buildManifest', function () {
     await buildManifest(mockGasket);
     const output = getOutput();
     expect(output).toContain(
-      `'locales/en-US': () => import('./locales/en-US.json')`
+      `'locales/en-US': () => import('locales/en-US.json')`
     );
     expect(output).toContain(
-      `'locales/fr-FR': () => import('./locales/fr-FR.json')`
+      `'locales/fr-FR': () => import('locales/fr-FR.json')`
     );
   });
 
@@ -127,10 +127,10 @@ describe('buildManifest', function () {
     await buildManifest(mockGasket);
     const output = getOutput();
     expect(output).toContain(
-      `'locales/en-US': () => import('./locales/en-US.json', { with: { type: 'json' } })`
+      `'locales/en-US': () => import('locales/en-US.json', { with: { type: 'json' } })`
     );
     expect(output).toContain(
-      `'locales/fr-FR': () => import('./locales/fr-FR.json', { with: { type: 'json' } })`
+      `'locales/fr-FR': () => import('locales/fr-FR.json', { with: { type: 'json' } })`
     );
   });
 
@@ -138,10 +138,10 @@ describe('buildManifest', function () {
     await buildManifest(mockGasket);
     const output = getOutput();
     expect(output).toContain(
-      `'locales/extra/en-US': () => import('./locales/extra/en-US.json')`
+      `'locales/extra/en-US': () => import('locales/extra/en-US.json')`
     );
     expect(output).toContain(
-      `'locales/extra/fr-FR': () => import('./locales/extra/fr-FR.json')`
+      `'locales/extra/fr-FR': () => import('locales/extra/fr-FR.json')`
     );
   });
 
@@ -149,10 +149,10 @@ describe('buildManifest', function () {
     await buildManifest(mockGasket);
     const output = getOutput();
     expect(output).toContain(
-      `'locales/en-US/grouped': () => import('./locales/en-US/grouped.json')`
+      `'locales/en-US/grouped': () => import('locales/en-US/grouped.json')`
     );
     expect(output).toContain(
-      `'locales/fr-FR/grouped': () => import('./locales/fr-FR/grouped.json')`
+      `'locales/fr-FR/grouped': () => import('locales/fr-FR/grouped.json')`
     );
   });
 

--- a/packages/gasket-plugin-intl/test/fixtures/src/locales/en-US.json
+++ b/packages/gasket-plugin-intl/test/fixtures/src/locales/en-US.json
@@ -1,0 +1,4 @@
+{
+  "gasket_welcome": "Hello!",
+  "gasket_learn": "Learn Gasket"
+}

--- a/packages/gasket-plugin-intl/test/fixtures/src/locales/fr-FR.json
+++ b/packages/gasket-plugin-intl/test/fixtures/src/locales/fr-FR.json
@@ -1,0 +1,4 @@
+{
+  "gasket_welcome": "Bonjour!",
+  "gasket_learn": "Apprendre Gasket"
+}


### PR DESCRIPTION
fix issue where intl.js locale imports are broken when locales are in a subdir

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
- fix issue where intl.js locale imports are broken when locales are in a subdir
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Test Plan
Updated
<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
