### PR TITLE
Fix getPublicGasketData caching

### DIFF
--- a/.changeset/sixty-frogs-live.md
+++ b/.changeset/sixty-frogs-live.md
@@ -1,0 +1,5 @@
+---
+"@gasket/plugin-data": patch
+---
+
+Fix getPublicGasketData caching

--- a/packages/gasket-plugin-data/README.md
+++ b/packages/gasket-plugin-data/README.md
@@ -107,6 +107,10 @@ PageComponent.getInitialProps = async function({ isServer, req }) {
 }
 ```
 
+When this action is called, it will trigger the `publicGasketData` lifecycle to
+allow plugins to inject request-specific data. The results are cached for the
+lifetime of the request.
+
 ### Browser Access
 
 If you need access to config values in client-side code, this can be done

--- a/packages/gasket-plugin-data/lib/actions.js
+++ b/packages/gasket-plugin-data/lib/actions.js
@@ -26,7 +26,7 @@ async function getGasketData(gasket) {
 }
 
 /** @type {import('@gasket/core', { with: { "resolution-mode": "import" } }).ActionHandler<'getPublicGasketData'>} */
-async function getPublicGasketData(gasket, req) {
+const getPublicGasketData = withGasketRequestCache(async (gasket, req) => {
   const basePublicData = (await gasket.actions.getGasketData()).public ?? {};
 
   const userPublicData = await gasket.execWaterfall(
@@ -42,7 +42,7 @@ async function getPublicGasketData(gasket, req) {
   }
 
   return userPublicData;
-}
+});
 
 // Export the base functions for testing
 module.exports = {

--- a/packages/gasket-plugin-data/lib/actions.js
+++ b/packages/gasket-plugin-data/lib/actions.js
@@ -1,11 +1,12 @@
 /// <reference types="@gasket/core" />
+const { withGasketRequestCache } = require('@gasket/request');
 
 const deepClone = json => JSON.parse(JSON.stringify(json));
 
 const baseDataMap = new WeakMap();
 const adjustedDataMap = new WeakMap();
 
-/** @type {import('@gasket/core', { with: { "resolution-mode": "import" } }).ActionHandler<'getGasketData'>} */
+/** @type {import('@gasket/core').ActionHandler<'getGasketData'>} */
 async function getGasketData(gasket) {
   const key = gasket.symbol;
   if (!adjustedDataMap.has(key)) {
@@ -25,7 +26,7 @@ async function getGasketData(gasket) {
   return adjustedDataMap.get(key);
 }
 
-/** @type {import('@gasket/core', { with: { "resolution-mode": "import" } }).ActionHandler<'getPublicGasketData'>} */
+/** @type {import('@gasket/core').ActionHandler<'getPublicGasketData'>} */
 const getPublicGasketData = withGasketRequestCache(async (gasket, req) => {
   const basePublicData = (await gasket.actions.getGasketData()).public ?? {};
 

--- a/packages/gasket-plugin-data/lib/configure.js
+++ b/packages/gasket-plugin-data/lib/configure.js
@@ -5,7 +5,7 @@ const { applyConfigOverrides } = require('@gasket/utils');
 const { baseDataMap } = require('./actions');
 
 /**
- * @type {import('@gasket/core', { with: { "resolution-mode": "import" } }).HookHandler<'configure'>}
+ * @type {import('@gasket/core').HookHandler<'configure'>}
  */
 function configure(gasket, baseConfig) {
   const { config: { env, command } } = gasket;

--- a/packages/gasket-plugin-data/lib/create.js
+++ b/packages/gasket-plugin-data/lib/create.js
@@ -4,7 +4,7 @@
 const { name, version, devDependencies } = require('../package.json');
 
 /**
- * @type {import('@gasket/core', { with: { "resolution-mode": "import" } }).HookHandler<'create'>}
+ * @type {import('@gasket/core').HookHandler<'create'>}
  */
 async function create(gasket, {
   pkg,

--- a/packages/gasket-plugin-data/lib/index.js
+++ b/packages/gasket-plugin-data/lib/index.js
@@ -8,7 +8,7 @@ const initReduxState = require('./init-redux-state');
 const metadata = require('./metadata');
 
 /**
- * @type {import('@gasket/core', { with: { "resolution-mode": "import" } }).Plugin}
+ * @type {import('@gasket/core').Plugin}
  */
 module.exports = {
   name,

--- a/packages/gasket-plugin-data/lib/init-redux-state.js
+++ b/packages/gasket-plugin-data/lib/init-redux-state.js
@@ -2,7 +2,7 @@
 /// <reference types="@gasket/plugin-redux" />
 
 /**
- * @type {import('@gasket/core', { with: { "resolution-mode": "import" } }).HookHandler<'initReduxState'>}
+ * @type {import('@gasket/core').HookHandler<'initReduxState'>}
  */
 async function initReduxState(gasket, state, { req }) {
   /** @type {import('.').ReduxState} */

--- a/packages/gasket-plugin-data/lib/metadata.js
+++ b/packages/gasket-plugin-data/lib/metadata.js
@@ -3,7 +3,7 @@
 
 const { name, version, description } = require('../package.json');
 
-/** @type {import('@gasket/core', { with: { "resolution-mode": "import" } }).HookHandler<'metadata'>} */
+/** @type {import('@gasket/core').HookHandler<'metadata'>} */
 async function metadata(gasket, meta) {
   return {
     ...meta,


### PR DESCRIPTION
## Summary

Fix caching issue where getPublicGasketData results were not being properly
cached per request.

## Test Plan

Corrected and updated unit tests