### PR TITLE
feat(plugin-swagger): add openapi runtime mode for Fastify

### DIFF
--- a/packages/gasket-plugin-swagger/README.md
+++ b/packages/gasket-plugin-swagger/README.md
@@ -35,7 +35,8 @@ export default makeGasket({
     supported.
   - **`ui`** - (object) Optional custom UI options. See
     [swagger-ui-express] options for what is supported.
-  - **`uiConfig`** - (object) Optional custom UI options. Only for use with Fastify. See [@fastify/swagger-ui] options for what is supported.
+  - **`uiOptions`** - (object) Optional custom UI options. Only for use with Fastify. See [@fastify/swagger-ui] options for what is supported.
+  - **`openapi`** - (object) OpenAPI spec object for runtime route introspection (Fastify only). When set, routes are discovered automatically and the `definitionFile` is not used.
 
 #### Example from JSDocs
 
@@ -88,7 +89,7 @@ export default makeGasket({
       apis: ['api.js'] // Glob path to API Docs
     },
     definitionFile: 'swagger.json', // Default
-    apiDocs: '/api-docs'            // Default
+    apiDocsRoute: '/api-docs'       // Default
   }
 });
 ```
@@ -107,6 +108,29 @@ export default makeGasket({
   }
 });
 ```
+
+#### Example with OpenAPI (Fastify)
+
+For Fastify apps using TypeBox or other schema providers, set the `openapi`
+option to enable runtime route introspection. Routes are discovered
+automatically — no definition file or JSDocs needed.
+
+```js
+// gasket.js
+
+export default makeGasket({
+  swagger: {
+    openapi: {
+      info: {
+        title: 'My API',
+        version: '1.0.0'
+      }
+    }
+  }
+});
+```
+
+> In Gasket, all `fastify` lifecycle hooks receive the same root Fastify instance, and `@fastify/swagger` uses Fastify's `onRoute` hook to collect routes — including routes registered before the swagger plugin. Route ordering does not affect discovery.
 
 ## License
 

--- a/packages/gasket-plugin-swagger/lib/index.d.ts
+++ b/packages/gasket-plugin-swagger/lib/index.d.ts
@@ -32,6 +32,14 @@ type SwaggerOptions = {
    * supported.
    */
   uiOptions?: FastifySwaggerUiOptions
+
+  /**
+   * OpenAPI spec object for runtime route introspection (Fastify only).
+   * When set, @fastify/swagger discovers routes automatically and the
+   * static definitionFile is not used. Accepts an OpenAPI 3.x document
+   * object (info, components, security, etc.).
+   */
+  openapi?: Record<string, unknown>
 }
 
 declare module '@gasket/core' {

--- a/packages/gasket-plugin-swagger/lib/index.js
+++ b/packages/gasket-plugin-swagger/lib/index.js
@@ -61,15 +61,25 @@ const plugin = {
       return baseConfig;
     },
     async build(gasket) {
-      await buildSwaggerDefinition(gasket, {});
+      const { swagger = {} } = gasket.config;
+      if (!swagger.openapi) {
+        await buildSwaggerDefinition(gasket, {});
+      }
     },
     express: {
       timing: {
         before: ['@gasket/plugin-nextjs']
       },
       handler: async function express(gasket, app) {
-        const swaggerUi = await import('swagger-ui-express');
         const { swagger, root } = gasket.config;
+        const { openapi } = swagger;
+
+        if (openapi) {
+          gasket.logger.warn('swagger.openapi is only supported with Fastify. Skipping Express Swagger UI setup.');
+          return;
+        }
+
+        const swaggerUi = await import('swagger-ui-express');
         const { ui = {}, apiDocsRoute, definitionFile } = swagger;
 
         const swaggerSpec = await loadSwaggerSpec(
@@ -87,24 +97,23 @@ const plugin = {
     },
     fastify: {
       timing: {
-        before: ['@gasket/plugin-nextjs']
+        first: true
       },
       handler: async function fastify(gasket, app) {
-        const { swagger, root } = gasket.config;
-        const { uiOptions = {}, apiDocsRoute = '/api-docs', definitionFile } = swagger;
-
-        const swaggerSpec = await loadSwaggerSpec(
-          root,
-          definitionFile,
-          gasket.logger
-        );
+        const { swagger } = gasket.config;
+        const { uiOptions = {}, apiDocsRoute = '/api-docs', openapi } = swagger;
 
         const fastifySwagger = await import('@fastify/swagger');
         const fastifySwaggerUi = await import('@fastify/swagger-ui');
 
-        await app.register(fastifySwagger.default, {
-          swagger: swaggerSpec
-        });
+        if (openapi) {
+          await app.register(fastifySwagger.default, { openapi });
+        } else {
+          const { root } = gasket.config;
+          const { definitionFile } = swagger;
+          const swaggerSpec = await loadSwaggerSpec(root, definitionFile, gasket.logger);
+          await app.register(fastifySwagger.default, { swagger: swaggerSpec });
+        }
 
         await app.register(fastifySwaggerUi.default, {
           routePrefix: apiDocsRoute,
@@ -147,6 +156,12 @@ const plugin = {
             name: 'swagger.ui',
             link: 'README.md#configuration',
             description: 'Optional custom UI options',
+            type: 'object'
+          },
+          {
+            name: 'swagger.openapi',
+            link: 'README.md#configuration',
+            description: 'OpenAPI spec object for runtime route introspection (Fastify only). When set, the static definitionFile is not used.',
             type: 'object'
           }
         ]

--- a/packages/gasket-plugin-swagger/test/index.test.js
+++ b/packages/gasket-plugin-swagger/test/index.test.js
@@ -119,12 +119,18 @@ describe('Swagger Plugin', function () {
     let mockGasket;
 
     beforeEach(function () {
-      mockGasket = {};
+      mockGasket = { config: { swagger: {} } };
     });
 
     it('sets up swagger spec', async function () {
       await plugin.hooks.build(mockGasket);
       expect(mockBuildSwaggerDefinition).toHaveBeenCalled();
+    });
+
+    it('skips buildSwaggerDefinition when openapi is set', async function () {
+      mockGasket.config.swagger.openapi = { info: { title: 'Test', version: '1.0.0' } };
+      await plugin.hooks.build(mockGasket);
+      expect(mockBuildSwaggerDefinition).not.toHaveBeenCalled();
     });
   });
 
@@ -135,7 +141,8 @@ describe('Swagger Plugin', function () {
       mockGasket = {
         logger: {
           info: vi.fn(),
-          error: vi.fn()
+          error: vi.fn(),
+          warn: vi.fn()
         },
         config: {
           root: '/path/to/app',
@@ -194,6 +201,15 @@ describe('Swagger Plugin', function () {
       await plugin.hooks.express.handler(mockGasket, mockApp);
       expect(mockApp.use.mock.calls[0][0]).toEqual('/api-docs');
     });
+
+    it('logs warning and skips when openapi is set', async function () {
+      mockGasket.config.swagger.openapi = { info: { title: 'Test', version: '1.0.0' } };
+      await plugin.hooks.express.handler(mockGasket, mockApp);
+      expect(mockGasket.logger.warn).toHaveBeenCalledWith(
+        'swagger.openapi is only supported with Fastify. Skipping Express Swagger UI setup.'
+      );
+      expect(mockApp.use).not.toHaveBeenCalled();
+    });
   });
 
   describe('fastify hook', function () {
@@ -203,7 +219,8 @@ describe('Swagger Plugin', function () {
       mockGasket = {
         logger: {
           info: vi.fn(),
-          error: vi.fn()
+          error: vi.fn(),
+          warn: vi.fn()
         },
         config: {
           root: '/path/to/app',
@@ -264,6 +281,37 @@ describe('Swagger Plugin', function () {
       expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), {
         swagger: undefined
       });
+    });
+
+    it('registers @fastify/swagger with openapi config when openapi is set', async function () {
+      const openapi = { info: { title: 'Test API', version: '1.0.0' } };
+      mockGasket.config.swagger.openapi = openapi;
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { openapi });
+    });
+
+    it('does not load swagger spec file when openapi is set', async function () {
+      mockGasket.config.swagger.openapi = { info: { title: 'Test API', version: '1.0.0' } };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockAccessStub).not.toHaveBeenCalled();
+      expect(mockReadFileStub).not.toHaveBeenCalled();
+    });
+
+    it('still registers @fastify/swagger-ui with apiDocsRoute when openapi is set', async function () {
+      mockGasket.config.swagger.openapi = { info: { title: 'Test API', version: '1.0.0' } };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), {
+        routePrefix: '/api-docs'
+      });
+    });
+
+    it('openapi takes precedence when both openapi and definitionFile are set', async function () {
+      const openapi = { info: { title: 'Test API', version: '1.0.0' } };
+      mockGasket.config.swagger.openapi = openapi;
+      mockGasket.config.swagger.definitionFile = 'swagger.json';
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { openapi });
+      expect(mockAccessStub).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `swagger.openapi` config option to enable runtime route introspection via `@fastify/swagger` — no static definition file or JSDocs needed
- When `openapi` is set: build step is skipped, Express warns and exits early, Fastify registers in openapi mode with `timing: { first: true }` so routes are always discovered regardless of plugin registration order
- Fixes `uiConfig` → `uiOptions` naming drift in README and `apiDocs` → `apiDocsRoute` in the JSDocs example

## Test plan

- [ ] New fastify hook tests: openapi mode registers with `{ openapi }`, skips file loading, still mounts Swagger UI, openapi takes precedence over `definitionFile`
- [ ] New express hook test: warns and skips `app.use` when `openapi` is set
- [ ] New build hook test: skips `buildSwaggerDefinition` when `openapi` is set
- [ ] Run `pnpm test` in `packages/gasket-plugin-swagger`

Made with [Cursor](https://cursor.com)