### PR TITLE
feat(plugin-swagger): add OpenAPI runtime mode for Fastify

### DIFF
--- a/.changeset/eleven-cooks-exist.md
+++ b/.changeset/eleven-cooks-exist.md
@@ -1,0 +1,5 @@
+---
+"@gasket/plugin-swagger": patch
+---
+
+Add openapi option for fastify

--- a/packages/gasket-plugin-swagger/README.md
+++ b/packages/gasket-plugin-swagger/README.md
@@ -35,7 +35,8 @@ export default makeGasket({
     supported.
   - **`ui`** - (object) Optional custom UI options. See
     [swagger-ui-express] options for what is supported.
-  - **`uiConfig`** - (object) Optional custom UI options. Only for use with Fastify. See [@fastify/swagger-ui] options for what is supported.
+  - **`uiOptions`** - (object) Optional custom UI options. Only for use with Fastify. See [@fastify/swagger-ui] options for what is supported.
+  - **`openapi`** - (object) OpenAPI spec object for runtime route introspection (Fastify only). When set, routes are discovered automatically and the `definitionFile` is not used.
 
 #### Example from JSDocs
 
@@ -88,7 +89,7 @@ export default makeGasket({
       apis: ['api.js'] // Glob path to API Docs
     },
     definitionFile: 'swagger.json', // Default
-    apiDocs: '/api-docs'            // Default
+    apiDocsRoute: '/api-docs'       // Default
   }
 });
 ```
@@ -107,6 +108,29 @@ export default makeGasket({
   }
 });
 ```
+
+#### Example with OpenAPI (Fastify)
+
+For Fastify apps using TypeBox or other schema providers, set the `openapi`
+option to enable runtime route introspection. Routes are discovered
+automatically — no definition file or JSDocs needed.
+
+```js
+// gasket.js
+
+export default makeGasket({
+  swagger: {
+    openapi: {
+      info: {
+        title: 'My API',
+        version: '1.0.0'
+      }
+    }
+  }
+});
+```
+
+> In Gasket, all `fastify` lifecycle hooks receive the same root Fastify instance, and `@fastify/swagger` uses Fastify's `onRoute` hook to collect routes — including routes registered before the swagger plugin. Route ordering does not affect discovery.
 
 ## License
 

--- a/packages/gasket-plugin-swagger/README.md
+++ b/packages/gasket-plugin-swagger/README.md
@@ -27,16 +27,31 @@ export default makeGasket({
 ## Configuration
 
 - **`swagger`** - (object) The base gasket.config object.
+  - **`mode`** - (string) `'static'` (default) or `'introspect'`. Controls how the API spec is produced. See [Modes](#modes) below.
   - **`definitionFile`** - (string) Target swagger spec file, either json or
     yaml. (Default: `'swagger.json'`)
   - **`apiDocsRoute`** - (string) Route to Swagger UI (Default: `'/api-docs'`)
   - **`jsdoc`** - (object) If set, the definitionFile will be generated based on
     JSDocs in the configured files. See the [swagger-jsdocs] options for what is
-    supported.
+    supported. Ignored when `mode` is `'introspect'`.
   - **`ui`** - (object) Optional custom UI options. See
     [swagger-ui-express] options for what is supported.
   - **`uiOptions`** - (object) Optional custom UI options. Only for use with Fastify. See [@fastify/swagger-ui] options for what is supported.
-  - **`openapi`** - (object) OpenAPI spec object for runtime route introspection (Fastify only). When set, routes are discovered automatically and the `definitionFile` is not used.
+  - **`spec`** - (object) Base metadata for introspect mode (info, components, security, servers, etc.). Ignored when `mode` is `'static'`. The output format is auto-detected from the spec content: if `spec.swagger` is present, Swagger 2.0 output is used; otherwise OpenAPI 3.x is the default.
+
+## Modes
+
+### `static` (default)
+
+Serves a pre-built definition file. Compatible with both Express and Fastify. All existing apps use this mode automatically — no config change needed.
+
+The output format is auto-detected from the loaded file: if the file has an `openapi` key, it is served as OpenAPI 3.x; otherwise Swagger 2.0 is assumed.
+
+### `introspect` (Fastify only)
+
+`@fastify/swagger` discovers your routes automatically via its `onRoute` hook. No definition file is built or loaded. The `spec` property provides base metadata (title, version, security schemes, etc.).
+
+The output format is auto-detected from `spec` content: if `spec.swagger` is set, Swagger 2.0 output is produced; otherwise OpenAPI 3.x is used (the default).
 
 #### Example from JSDocs
 
@@ -109,18 +124,21 @@ export default makeGasket({
 });
 ```
 
-#### Example with OpenAPI (Fastify)
+#### Example with introspect mode (Fastify)
 
-For Fastify apps using TypeBox or other schema providers, set the `openapi`
-option to enable runtime route introspection. Routes are discovered
-automatically — no definition file or JSDocs needed.
+For Fastify apps using TypeBox or other schema providers, set `mode: 'introspect'`
+to enable runtime route introspection. Routes are discovered automatically —
+no definition file or JSDocs needed.
+
+Output defaults to OpenAPI 3.x. Pass `spec.swagger: '2.0'` to produce Swagger 2.0 output instead.
 
 ```js
 // gasket.js
 
 export default makeGasket({
   swagger: {
-    openapi: {
+    mode: 'introspect',
+    spec: {
       info: {
         title: 'My API',
         version: '1.0.0'

--- a/packages/gasket-plugin-swagger/README.md
+++ b/packages/gasket-plugin-swagger/README.md
@@ -27,31 +27,30 @@ export default makeGasket({
 ## Configuration
 
 - **`swagger`** - (object) The base gasket.config object.
-  - **`mode`** - (string) `'static'` (default) or `'introspect'`. Controls how the API spec is produced. See [Modes](#modes) below.
+  - **`introspect`** - (object) When set, enables Fastify route introspection via `@fastify/swagger`. Routes are discovered automatically via the `onRoute` hook — no definition file is built or loaded. The object provides base metadata (info, components, security, servers, etc.). Format is auto-detected: if `introspect.swagger` is present, Swagger 2.0 output is produced; otherwise OpenAPI 3.x is the default. **Fastify only.**
   - **`definitionFile`** - (string) Target swagger spec file, either json or
     yaml. (Default: `'swagger.json'`)
   - **`apiDocsRoute`** - (string) Route to Swagger UI (Default: `'/api-docs'`)
   - **`jsdoc`** - (object) If set, the definitionFile will be generated based on
     JSDocs in the configured files. See the [swagger-jsdocs] options for what is
-    supported. Ignored when `mode` is `'introspect'`.
+    supported. Ignored when `introspect` is set.
   - **`ui`** - (object) Optional custom UI options. See
     [swagger-ui-express] options for what is supported.
   - **`uiOptions`** - (object) Optional custom UI options. Only for use with Fastify. See [@fastify/swagger-ui] options for what is supported.
-  - **`spec`** - (object) Base metadata for introspect mode (info, components, security, servers, etc.). Ignored when `mode` is `'static'`. The output format is auto-detected from the spec content: if `spec.swagger` is present, Swagger 2.0 output is used; otherwise OpenAPI 3.x is the default.
 
 ## Modes
 
-### `static` (default)
+### Static (default)
 
 Serves a pre-built definition file. Compatible with both Express and Fastify. All existing apps use this mode automatically — no config change needed.
 
 The output format is auto-detected from the loaded file: if the file has an `openapi` key, it is served as OpenAPI 3.x; otherwise Swagger 2.0 is assumed.
 
-### `introspect` (Fastify only)
+### Introspect (Fastify only)
 
-`@fastify/swagger` discovers your routes automatically via its `onRoute` hook. No definition file is built or loaded. The `spec` property provides base metadata (title, version, security schemes, etc.).
+Set `swagger.introspect` to an object to enable runtime route introspection. `@fastify/swagger` discovers your routes automatically via its `onRoute` hook — no definition file or JSDocs needed.
 
-The output format is auto-detected from `spec` content: if `spec.swagger` is set, Swagger 2.0 output is produced; otherwise OpenAPI 3.x is used (the default).
+The output format is auto-detected from the object: if `introspect.swagger` is set, Swagger 2.0 output is produced; otherwise OpenAPI 3.x is used (the default).
 
 #### Example from JSDocs
 
@@ -126,19 +125,18 @@ export default makeGasket({
 
 #### Example with introspect mode (Fastify)
 
-For Fastify apps using TypeBox or other schema providers, set `mode: 'introspect'`
+For Fastify apps using TypeBox or other schema providers, set `swagger.introspect`
 to enable runtime route introspection. Routes are discovered automatically —
 no definition file or JSDocs needed.
 
-Output defaults to OpenAPI 3.x. Pass `spec.swagger: '2.0'` to produce Swagger 2.0 output instead.
+Output defaults to OpenAPI 3.x. Set `introspect.swagger: '2.0'` to produce Swagger 2.0 output instead.
 
 ```js
 // gasket.js
 
 export default makeGasket({
   swagger: {
-    mode: 'introspect',
-    spec: {
+    introspect: {
       info: {
         title: 'My API',
         version: '1.0.0'

--- a/packages/gasket-plugin-swagger/lib/index.d.ts
+++ b/packages/gasket-plugin-swagger/lib/index.d.ts
@@ -34,21 +34,28 @@ type SwaggerOptions = {
   uiOptions?: FastifySwaggerUiOptions
 
   /**
-   * Selects the documentation mode.
-   * - "static" (default): serves a pre-built definition file (swagger.json / swagger.yaml).
-   *   Compatible with both Express and Fastify. All existing apps use this mode automatically.
-   * - "introspect": Fastify only. @fastify/swagger discovers routes automatically via its
-   *   onRoute hook. No definition file is built or loaded.
-   */
-  mode?: 'static' | 'introspect'
-
-  /**
-   * Base metadata for introspect mode (info, components, security, servers, etc.).
-   * Ignored when mode is "static".
-   * Format is auto-detected from content: if spec.swagger is present, Swagger 2.0
+   * When set, enables Fastify route introspection. The `@fastify/swagger` plugin discovers
+   * routes automatically via its onRoute hook — no definition file is built or loaded.
+   * The object provides base metadata (info, components, security, servers, etc.).
+   * Format is auto-detected from content: if introspect.swagger is present, Swagger 2.0
    * output is produced; otherwise OpenAPI 3.x is used (the default).
+   *
+   * Use `routes` inside this object to filter which routes appear in the generated spec.
+   * - `routes.include`: show only routes whose URL starts with one of these prefixes.
+   * - `routes.exclude`: hide routes whose URL starts with one of these prefixes.
+   * A route must satisfy both conditions when both are set.
+   * @example
+   * introspect: { routes: { include: ['/api/v1'] }, info: { ... } }
+   * introspect: { routes: { exclude: ['/internal'] }, info: { ... } }
    */
-  spec?: Record<string, unknown>
+  introspect?: {
+    routes?: {
+      include?: string[];
+      exclude?: string[];
+    };
+    [key: string]: unknown;
+  }
+
 }
 
 declare module '@gasket/core' {

--- a/packages/gasket-plugin-swagger/lib/index.d.ts
+++ b/packages/gasket-plugin-swagger/lib/index.d.ts
@@ -34,12 +34,21 @@ type SwaggerOptions = {
   uiOptions?: FastifySwaggerUiOptions
 
   /**
-   * OpenAPI spec object for runtime route introspection (Fastify only).
-   * When set, @fastify/swagger discovers routes automatically and the
-   * static definitionFile is not used. Accepts an OpenAPI 3.x document
-   * object (info, components, security, etc.).
+   * Selects the documentation mode.
+   * - "static" (default): serves a pre-built definition file (swagger.json / swagger.yaml).
+   *   Compatible with both Express and Fastify. All existing apps use this mode automatically.
+   * - "introspect": Fastify only. @fastify/swagger discovers routes automatically via its
+   *   onRoute hook. No definition file is built or loaded.
    */
-  openapi?: Record<string, unknown>
+  mode?: 'static' | 'introspect'
+
+  /**
+   * Base metadata for introspect mode (info, components, security, servers, etc.).
+   * Ignored when mode is "static".
+   * Format is auto-detected from content: if spec.swagger is present, Swagger 2.0
+   * output is produced; otherwise OpenAPI 3.x is used (the default).
+   */
+  spec?: Record<string, unknown>
 }
 
 declare module '@gasket/core' {

--- a/packages/gasket-plugin-swagger/lib/index.d.ts
+++ b/packages/gasket-plugin-swagger/lib/index.d.ts
@@ -32,6 +32,14 @@ type SwaggerOptions = {
    * supported.
    */
   uiOptions?: FastifySwaggerUiOptions
+
+  /**
+   * OpenAPI spec object for runtime route introspection (Fastify only).
+   * When set, @fastify/swagger discovers routes automatically and the
+   * static definitionFile is not used. Accepts an OpenAPI 3.x document
+   * object (info, components, security, etc.).
+   */
+  openapi?: Record<string, unknown>
 }
 
 declare module '@gasket/core' {

--- a/packages/gasket-plugin-swagger/lib/index.js
+++ b/packages/gasket-plugin-swagger/lib/index.js
@@ -64,15 +64,25 @@ const plugin = {
       return baseConfig;
     },
     async build(gasket) {
-      await buildSwaggerDefinition(gasket, {});
+      const { swagger = {} } = gasket.config;
+      if (!swagger.openapi) {
+        await buildSwaggerDefinition(gasket, {});
+      }
     },
     express: {
       timing: {
         before: ['@gasket/plugin-nextjs']
       },
       handler: async function express(gasket, app) {
-        const swaggerUi = await import('swagger-ui-express');
         const { swagger, root } = gasket.config;
+        const { openapi } = swagger;
+
+        if (openapi) {
+          gasket.logger.warn('swagger.openapi is only supported with Fastify. Skipping Express Swagger UI setup.');
+          return;
+        }
+
+        const swaggerUi = await import('swagger-ui-express');
         const { ui = {}, apiDocsRoute, definitionFile } = swagger;
 
         const swaggerSpec = await loadSwaggerSpec(
@@ -90,24 +100,23 @@ const plugin = {
     },
     fastify: {
       timing: {
-        before: ['@gasket/plugin-nextjs']
+        first: true
       },
       handler: async function fastify(gasket, app) {
-        const { swagger, root } = gasket.config;
-        const { uiOptions = {}, apiDocsRoute = '/api-docs', definitionFile } = swagger;
-
-        const swaggerSpec = await loadSwaggerSpec(
-          root,
-          definitionFile,
-          gasket.logger
-        );
+        const { swagger } = gasket.config;
+        const { uiOptions = {}, apiDocsRoute = '/api-docs', openapi } = swagger;
 
         const fastifySwagger = await import('@fastify/swagger');
         const fastifySwaggerUi = await import('@fastify/swagger-ui');
 
-        await app.register(fastifySwagger.default, {
-          swagger: swaggerSpec
-        });
+        if (openapi) {
+          await app.register(fastifySwagger.default, { openapi });
+        } else {
+          const { root } = gasket.config;
+          const { definitionFile } = swagger;
+          const swaggerSpec = await loadSwaggerSpec(root, definitionFile, gasket.logger);
+          await app.register(fastifySwagger.default, { swagger: swaggerSpec });
+        }
 
         await app.register(fastifySwaggerUi.default, {
           routePrefix: apiDocsRoute,
@@ -187,6 +196,12 @@ const plugin = {
             name: 'swagger.ui',
             link: 'README.md#configuration',
             description: 'Optional custom UI options',
+            type: 'object'
+          },
+          {
+            name: 'swagger.openapi',
+            link: 'README.md#configuration',
+            description: 'OpenAPI spec object for runtime route introspection (Fastify only). When set, the static definitionFile is not used.',
             type: 'object'
           }
         ]

--- a/packages/gasket-plugin-swagger/lib/index.js
+++ b/packages/gasket-plugin-swagger/lib/index.js
@@ -58,6 +58,7 @@ const plugin = {
 
       baseConfig.swagger = {
         ...swagger,
+        mode: swagger.mode || 'static',
         definitionFile: swagger.definitionFile || 'swagger.json',
         apiDocsRoute: swagger.apiDocsRoute || '/api-docs'
       };
@@ -65,7 +66,7 @@ const plugin = {
     },
     async build(gasket) {
       const { swagger = {} } = gasket.config;
-      if (!swagger.openapi) {
+      if (swagger.mode !== 'introspect') {
         await buildSwaggerDefinition(gasket, {});
       }
     },
@@ -75,11 +76,20 @@ const plugin = {
       },
       handler: async function express(gasket, app) {
         const { swagger, root } = gasket.config;
-        const { openapi } = swagger;
 
-        if (openapi) {
-          gasket.logger.warn('swagger.openapi is only supported with Fastify. Skipping Express Swagger UI setup.');
+        if (swagger.mode === 'introspect') {
+          gasket.logger.warn(
+            'swagger.mode "introspect" is only supported with Fastify. ' +
+            'Skipping Swagger UI for Express. To use Swagger with Express, use mode "static".'
+          );
           return;
+        }
+
+        if (swagger.spec) {
+          gasket.logger.warn(
+            'swagger.spec is only used when swagger.mode is "introspect". ' +
+            'It has no effect in static mode.'
+          );
         }
 
         const swaggerUi = await import('swagger-ui-express');
@@ -102,20 +112,42 @@ const plugin = {
       timing: {
         first: true
       },
+      // eslint-disable-next-line max-statements
       handler: async function fastify(gasket, app) {
         const { swagger } = gasket.config;
-        const { uiOptions = {}, apiDocsRoute = '/api-docs', openapi } = swagger;
+        const { uiOptions = {}, apiDocsRoute = '/api-docs' } = swagger;
 
         const fastifySwagger = await import('@fastify/swagger');
         const fastifySwaggerUi = await import('@fastify/swagger-ui');
 
-        if (openapi) {
-          await app.register(fastifySwagger.default, { openapi });
+        if (swagger.spec && swagger.mode !== 'introspect') {
+          gasket.logger.warn(
+            'swagger.spec is only used when swagger.mode is "introspect". ' +
+            'It has no effect in static mode.'
+          );
+        }
+
+        if (swagger.mode === 'introspect') {
+          // Introspect: @fastify/swagger discovers routes via onRoute hook.
+          // swagger.spec provides base metadata (info, security, etc.) but no file is loaded.
+          // Defaults to OpenAPI 3.x; set spec.swagger to produce Swagger 2.0 output instead.
+          if (swagger.jsdoc) {
+            gasket.logger.warn(
+              'swagger.jsdoc is ignored when swagger.mode is "introspect". ' +
+              'Route introspection discovers routes automatically.'
+            );
+          }
+          const spec = swagger.spec ?? {};
+          const specKey = spec.swagger ? 'swagger' : 'openapi';
+          await app.register(fastifySwagger.default, { [specKey]: spec });
         } else {
+          // Static: load the pre-built definition file and serve it as-is.
+          // Format auto-detected from file content: openapi key → 3.x, otherwise Swagger 2.0.
           const { root } = gasket.config;
           const { definitionFile } = swagger;
           const swaggerSpec = await loadSwaggerSpec(root, definitionFile, gasket.logger);
-          await app.register(fastifySwagger.default, { swagger: swaggerSpec });
+          const specKey = swaggerSpec?.openapi ? 'openapi' : 'swagger';
+          await app.register(fastifySwagger.default, { [specKey]: swaggerSpec });
         }
 
         await app.register(fastifySwaggerUi.default, {
@@ -199,9 +231,20 @@ const plugin = {
             type: 'object'
           },
           {
-            name: 'swagger.openapi',
+            name: 'swagger.mode',
             link: 'README.md#configuration',
-            description: 'OpenAPI spec object for runtime route introspection (Fastify only). When set, the static definitionFile is not used.',
+            description:
+              'Set to "introspect" to enable Fastify route introspection. ' +
+              'Defaults to "static" for backward compatibility.',
+            type: 'string',
+            default: 'static'
+          },
+          {
+            name: 'swagger.spec',
+            link: 'README.md#configuration',
+            description:
+              'Base metadata for introspect mode. Ignored in static mode. ' +
+              'Format auto-detected: spec.swagger present means Swagger 2.0; otherwise OpenAPI 3.x.',
             type: 'object'
           }
         ]

--- a/packages/gasket-plugin-swagger/lib/index.js
+++ b/packages/gasket-plugin-swagger/lib/index.js
@@ -58,7 +58,6 @@ const plugin = {
 
       baseConfig.swagger = {
         ...swagger,
-        mode: swagger.mode || 'static',
         definitionFile: swagger.definitionFile || 'swagger.json',
         apiDocsRoute: swagger.apiDocsRoute || '/api-docs'
       };
@@ -66,7 +65,7 @@ const plugin = {
     },
     async build(gasket) {
       const { swagger = {} } = gasket.config;
-      if (swagger.mode !== 'introspect') {
+      if (!swagger.introspect) {
         await buildSwaggerDefinition(gasket, {});
       }
     },
@@ -77,19 +76,12 @@ const plugin = {
       handler: async function express(gasket, app) {
         const { swagger, root } = gasket.config;
 
-        if (swagger.mode === 'introspect') {
+        if (swagger.introspect) {
           gasket.logger.warn(
-            'swagger.mode "introspect" is only supported with Fastify. ' +
-            'Skipping Swagger UI for Express. To use Swagger with Express, use mode "static".'
+            'swagger.introspect is only supported with Fastify. ' +
+            'Skipping Swagger UI for Express. To use Swagger with Express, remove swagger.introspect.'
           );
           return;
-        }
-
-        if (swagger.spec) {
-          gasket.logger.warn(
-            'swagger.spec is only used when swagger.mode is "introspect". ' +
-            'It has no effect in static mode.'
-          );
         }
 
         const swaggerUi = await import('swagger-ui-express');
@@ -112,34 +104,51 @@ const plugin = {
       timing: {
         first: true
       },
-      // eslint-disable-next-line max-statements
+      // eslint-disable-next-line max-statements, complexity
       handler: async function fastify(gasket, app) {
         const { swagger } = gasket.config;
-        const { uiOptions = {}, apiDocsRoute = '/api-docs' } = swagger;
+        const { uiOptions = {}, apiDocsRoute } = swagger;
 
         const fastifySwagger = await import('@fastify/swagger');
         const fastifySwaggerUi = await import('@fastify/swagger-ui');
 
-        if (swagger.spec && swagger.mode !== 'introspect') {
-          gasket.logger.warn(
-            'swagger.spec is only used when swagger.mode is "introspect". ' +
-            'It has no effect in static mode.'
-          );
-        }
-
-        if (swagger.mode === 'introspect') {
+        if (swagger.introspect) {
+          if (typeof swagger.introspect !== 'object' || Array.isArray(swagger.introspect)) {
+            throw new Error('swagger.introspect must be a plain object');
+          }
           // Introspect: @fastify/swagger discovers routes via onRoute hook.
-          // swagger.spec provides base metadata (info, security, etc.) but no file is loaded.
-          // Defaults to OpenAPI 3.x; set spec.swagger to produce Swagger 2.0 output instead.
+          // swagger.introspect provides base metadata (info, security, etc.) but no file is loaded.
+          // Defaults to OpenAPI 3.x; set introspect.swagger to produce Swagger 2.0 output instead.
           if (swagger.jsdoc) {
             gasket.logger.warn(
-              'swagger.jsdoc is ignored when swagger.mode is "introspect". ' +
+              'swagger.jsdoc is ignored when swagger.introspect is set. ' +
               'Route introspection discovers routes automatically.'
             );
           }
-          const spec = swagger.spec ?? {};
-          const specKey = spec.swagger ? 'swagger' : 'openapi';
-          await app.register(fastifySwagger.default, { [specKey]: spec });
+          const { routes, ...introspectMeta } = swagger.introspect;
+          const specKey = introspectMeta.swagger ? 'swagger' : 'openapi';
+          const { include, exclude } = routes || {};
+          const warnNoSlash = (arr, field) => arr?.forEach(p => {
+            if (!p.startsWith('/')) {
+              gasket.logger.warn(
+                `swagger.introspect.routes.${field} entry "${p}" does not start with "/" ` +
+                'and will never match a Fastify route URL.'
+              );
+            }
+          });
+          warnNoSlash(include, 'include');
+          warnNoSlash(exclude, 'exclude');
+          const swaggerOptions = {
+            [specKey]: introspectMeta,
+            ...(include || exclude) && {
+              transform({ schema, url }) {
+                const included = !include || include.some(p => url.startsWith(p));
+                const excluded = exclude && exclude.some(p => url.startsWith(p));
+                return (included && !excluded) ? { schema, url } : { schema: { hide: true }, url };
+              }
+            }
+          };
+          await app.register(fastifySwagger.default, swaggerOptions);
         } else {
           // Static: load the pre-built definition file and serve it as-is.
           // Format auto-detected from file content: openapi key → 3.x, otherwise Swagger 2.0.
@@ -188,6 +197,7 @@ const plugin = {
 
       context.readme
         .subHeading('Definitions')
+        // eslint-disable-next-line max-len
         .content('Use `@swagger` JSDocs to automatically generate the [swagger.json] spec file. Visit [swagger-jsdoc] for examples.')
         .link('swagger-jsdoc', 'https://github.com/Surnet/swagger-jsdoc/')
         .link('swagger.json', '/swagger.json');
@@ -231,20 +241,22 @@ const plugin = {
             type: 'object'
           },
           {
-            name: 'swagger.mode',
+            name: 'swagger.introspect',
             link: 'README.md#configuration',
             description:
-              'Set to "introspect" to enable Fastify route introspection. ' +
-              'Defaults to "static" for backward compatibility.',
-            type: 'string',
-            default: 'static'
+              'When set, enables Fastify route introspection via @fastify/swagger. ' +
+              'The object provides base metadata (info, security, servers, etc.). ' +
+              'Format auto-detected: introspect.swagger present means Swagger 2.0; otherwise OpenAPI 3.x.',
+            type: 'object'
           },
           {
-            name: 'swagger.spec',
+            name: 'swagger.introspect.routes',
             link: 'README.md#configuration',
             description:
-              'Base metadata for introspect mode. Ignored in static mode. ' +
-              'Format auto-detected: spec.swagger present means Swagger 2.0; otherwise OpenAPI 3.x.',
+              'Filter which routes appear in the spec via include/exclude prefix arrays. ' +
+              'Nested inside swagger.introspect — only applies to introspect mode. ' +
+              'include: show only routes whose URL starts with one of these prefixes. ' +
+              'exclude: hide routes whose URL starts with one of these prefixes.',
             type: 'object'
           }
         ]

--- a/packages/gasket-plugin-swagger/test/index.test.js
+++ b/packages/gasket-plugin-swagger/test/index.test.js
@@ -121,12 +121,18 @@ describe('Swagger Plugin', function () {
     let mockGasket;
 
     beforeEach(function () {
-      mockGasket = {};
+      mockGasket = { config: { swagger: {} } };
     });
 
     it('sets up swagger spec', async function () {
       await plugin.hooks.build(mockGasket);
       expect(mockBuildSwaggerDefinition).toHaveBeenCalled();
+    });
+
+    it('skips buildSwaggerDefinition when openapi is set', async function () {
+      mockGasket.config.swagger.openapi = { info: { title: 'Test', version: '1.0.0' } };
+      await plugin.hooks.build(mockGasket);
+      expect(mockBuildSwaggerDefinition).not.toHaveBeenCalled();
     });
   });
 
@@ -137,7 +143,8 @@ describe('Swagger Plugin', function () {
       mockGasket = {
         logger: {
           info: vi.fn(),
-          error: vi.fn()
+          error: vi.fn(),
+          warn: vi.fn()
         },
         config: {
           root: '/path/to/app',
@@ -196,6 +203,15 @@ describe('Swagger Plugin', function () {
       await plugin.hooks.express.handler(mockGasket, mockApp);
       expect(mockApp.use.mock.calls[0][0]).toEqual('/api-docs');
     });
+
+    it('logs warning and skips when openapi is set', async function () {
+      mockGasket.config.swagger.openapi = { info: { title: 'Test', version: '1.0.0' } };
+      await plugin.hooks.express.handler(mockGasket, mockApp);
+      expect(mockGasket.logger.warn).toHaveBeenCalledWith(
+        'swagger.openapi is only supported with Fastify. Skipping Express Swagger UI setup.'
+      );
+      expect(mockApp.use).not.toHaveBeenCalled();
+    });
   });
 
   describe('fastify hook', function () {
@@ -205,7 +221,8 @@ describe('Swagger Plugin', function () {
       mockGasket = {
         logger: {
           info: vi.fn(),
-          error: vi.fn()
+          error: vi.fn(),
+          warn: vi.fn()
         },
         config: {
           root: '/path/to/app',
@@ -266,6 +283,37 @@ describe('Swagger Plugin', function () {
       expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), {
         swagger: undefined
       });
+    });
+
+    it('registers @fastify/swagger with openapi config when openapi is set', async function () {
+      const openapi = { info: { title: 'Test API', version: '1.0.0' } };
+      mockGasket.config.swagger.openapi = openapi;
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { openapi });
+    });
+
+    it('does not load swagger spec file when openapi is set', async function () {
+      mockGasket.config.swagger.openapi = { info: { title: 'Test API', version: '1.0.0' } };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockAccessStub).not.toHaveBeenCalled();
+      expect(mockReadFileStub).not.toHaveBeenCalled();
+    });
+
+    it('still registers @fastify/swagger-ui with apiDocsRoute when openapi is set', async function () {
+      mockGasket.config.swagger.openapi = { info: { title: 'Test API', version: '1.0.0' } };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), {
+        routePrefix: '/api-docs'
+      });
+    });
+
+    it('openapi takes precedence when both openapi and definitionFile are set', async function () {
+      const openapi = { info: { title: 'Test API', version: '1.0.0' } };
+      mockGasket.config.swagger.openapi = openapi;
+      mockGasket.config.swagger.definitionFile = 'swagger.json';
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { openapi });
+      expect(mockAccessStub).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/gasket-plugin-swagger/test/index.test.js
+++ b/packages/gasket-plugin-swagger/test/index.test.js
@@ -97,21 +97,10 @@ describe('Swagger Plugin', function () {
       const results = plugin.hooks.configure({}, {});
       expect(results).toEqual({
         swagger: {
-          mode: 'static',
           definitionFile: 'swagger.json',
           apiDocsRoute: '/api-docs'
         }
       });
-    });
-
-    it('defaults mode to "static" when not specified', function () {
-      const results = plugin.hooks.configure({}, { swagger: {} });
-      expect(results.swagger.mode).toEqual('static');
-    });
-
-    it('preserves mode when explicitly set', function () {
-      const results = plugin.hooks.configure({}, { swagger: { mode: 'introspect' } });
-      expect(results.swagger.mode).toEqual('introspect');
     });
 
     it('uses specified definitionFile', function () {
@@ -149,14 +138,13 @@ describe('Swagger Plugin', function () {
       expect(mockBuildSwaggerDefinition).toHaveBeenCalled();
     });
 
-    it('skips buildSwaggerDefinition when mode is introspect', async function () {
-      mockGasket.config.swagger.mode = 'introspect';
+    it('skips buildSwaggerDefinition when introspect is set', async function () {
+      mockGasket.config.swagger.introspect = { info: { title: 'Test', version: '1.0.0' } };
       await plugin.hooks.build(mockGasket);
       expect(mockBuildSwaggerDefinition).not.toHaveBeenCalled();
     });
 
-    it('runs buildSwaggerDefinition when mode is static', async function () {
-      mockGasket.config.swagger.mode = 'static';
+    it('runs buildSwaggerDefinition when introspect is not set', async function () {
       await plugin.hooks.build(mockGasket);
       expect(mockBuildSwaggerDefinition).toHaveBeenCalled();
     });
@@ -230,26 +218,18 @@ describe('Swagger Plugin', function () {
       expect(mockApp.use.mock.calls[0][0]).toEqual('/api-docs');
     });
 
-    it('logs warning and skips when mode is introspect', async function () {
-      mockGasket.config.swagger.mode = 'introspect';
+    it('logs warning and skips when introspect is set', async function () {
+      mockGasket.config.swagger.introspect = { info: { title: 'Test', version: '1.0.0' } };
       await plugin.hooks.express.handler(mockGasket, mockApp);
       expect(mockGasket.logger.warn).toHaveBeenCalledWith(
-        'swagger.mode "introspect" is only supported with Fastify. ' +
-        'Skipping Swagger UI for Express. To use Swagger with Express, use mode "static".'
+        'swagger.introspect is only supported with Fastify. ' +
+        'Skipping Swagger UI for Express. To use Swagger with Express, remove swagger.introspect.'
       );
       expect(mockApp.use).not.toHaveBeenCalled();
     });
-
-    it('logs warning when swagger.spec is set in static mode', async function () {
-      mockGasket.config.swagger.spec = { info: { title: 'Test', version: '1.0.0' } };
-      await plugin.hooks.express.handler(mockGasket, mockApp);
-      expect(mockGasket.logger.warn).toHaveBeenCalledWith(
-        'swagger.spec is only used when swagger.mode is "introspect". ' +
-        'It has no effect in static mode.'
-      );
-    });
   });
 
+  // eslint-disable-next-line max-statements
   describe('fastify hook', function () {
     let mockGasket, mockApp;
 
@@ -321,59 +301,188 @@ describe('Swagger Plugin', function () {
       });
     });
 
-    it('introspect mode: registers @fastify/swagger with openapi key when no version in spec', async function () {
-      mockGasket.config.swagger.mode = 'introspect';
-      const spec = { info: { title: 'Test API', version: '1.0.0' } };
-      mockGasket.config.swagger.spec = spec;
+    it('introspect: registers @fastify/swagger with openapi key when no swagger version in object', async function () {
+      const introspect = { info: { title: 'Test API', version: '1.0.0' } };
+      mockGasket.config.swagger.introspect = introspect;
       await plugin.hooks.fastify.handler(mockGasket, mockApp);
-      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { openapi: spec });
+      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { openapi: introspect });
     });
 
-    it('introspect mode: registers with empty spec object when swagger.spec is not set', async function () {
-      mockGasket.config.swagger.mode = 'introspect';
+    it('introspect: uses swagger key when introspect.swagger is set (Swagger 2.0)', async function () {
+      const introspect = { swagger: '2.0', info: { title: 'Test API', version: '1.0.0' } };
+      mockGasket.config.swagger.introspect = introspect;
       await plugin.hooks.fastify.handler(mockGasket, mockApp);
-      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { openapi: {} });
+      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { swagger: introspect });
     });
 
-    it('introspect mode: uses swagger key when spec.swagger is set (Swagger 2.0)', async function () {
-      mockGasket.config.swagger.mode = 'introspect';
-      const spec = { swagger: '2.0', info: { title: 'Test API', version: '1.0.0' } };
-      mockGasket.config.swagger.spec = spec;
-      await plugin.hooks.fastify.handler(mockGasket, mockApp);
-      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { swagger: spec });
-    });
-
-    it('introspect mode: does not load swagger spec file', async function () {
-      mockGasket.config.swagger.mode = 'introspect';
+    it('introspect: does not load swagger spec file', async function () {
+      mockGasket.config.swagger.introspect = { info: { title: 'Test API', version: '1.0.0' } };
       await plugin.hooks.fastify.handler(mockGasket, mockApp);
       expect(mockAccessStub).not.toHaveBeenCalled();
       expect(mockReadFileStub).not.toHaveBeenCalled();
     });
 
-    it('introspect mode: still registers @fastify/swagger-ui with apiDocsRoute', async function () {
-      mockGasket.config.swagger.mode = 'introspect';
+    it('introspect: still registers @fastify/swagger-ui with apiDocsRoute', async function () {
+      mockGasket.config.swagger.introspect = { info: { title: 'Test API', version: '1.0.0' } };
       await plugin.hooks.fastify.handler(mockGasket, mockApp);
       expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), {
         routePrefix: '/api-docs'
       });
     });
 
-    it('introspect mode: warns when jsdoc is also set', async function () {
-      mockGasket.config.swagger.mode = 'introspect';
+    it('introspect: warns when jsdoc is also set', async function () {
+      mockGasket.config.swagger.introspect = { info: { title: 'Test API', version: '1.0.0' } };
       mockGasket.config.swagger.jsdoc = { definition: { info: { title: 'Test', version: '1.0.0' } } };
       await plugin.hooks.fastify.handler(mockGasket, mockApp);
       expect(mockGasket.logger.warn).toHaveBeenCalledWith(
-        'swagger.jsdoc is ignored when swagger.mode is "introspect". ' +
+        'swagger.jsdoc is ignored when swagger.introspect is set. ' +
         'Route introspection discovers routes automatically.'
       );
     });
 
-    it('logs warning when swagger.spec is set in static mode', async function () {
-      mockGasket.config.swagger.spec = { info: { title: 'Test', version: '1.0.0' } };
+    it('introspect: throws when introspect is not a plain object', async function () {
+      mockGasket.config.swagger.introspect = true;
+      await expect(plugin.hooks.fastify.handler(mockGasket, mockApp)).rejects.toThrow(
+        'swagger.introspect must be a plain object'
+      );
+    });
+
+    it('introspect: throws when introspect is an array', async function () {
+      mockGasket.config.swagger.introspect = [];
+      await expect(plugin.hooks.fastify.handler(mockGasket, mockApp)).rejects.toThrow(
+        'swagger.introspect must be a plain object'
+      );
+    });
+
+    it('introspect: strips routes from introspectMeta before passing to @fastify/swagger', async function () {
+      const info = { title: 'Test API', version: '1.0.0' };
+      mockGasket.config.swagger.introspect = { routes: { include: ['/api/v1'] }, info };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockApp.register).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ openapi: { info } })
+      );
+      const [, opts] = mockApp.register.mock.calls[0];
+      expect(opts.openapi).not.toHaveProperty('routes');
+    });
+
+    it('introspect: adds transform when routes.include is set', async function () {
+      mockGasket.config.swagger.introspect = {
+        routes: { include: ['/api/v1'] },
+        info: { title: 'Test API', version: '1.0.0' }
+      };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      const [, opts] = mockApp.register.mock.calls[0];
+      expect(typeof opts.transform).toBe('function');
+    });
+
+    it('introspect: adds transform when routes.exclude is set', async function () {
+      mockGasket.config.swagger.introspect = {
+        routes: { exclude: ['/internal'] },
+        info: { title: 'Test API', version: '1.0.0' }
+      };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      const [, opts] = mockApp.register.mock.calls[0];
+      expect(typeof opts.transform).toBe('function');
+    });
+
+    it('introspect: does not add transform when no routes config', async function () {
+      mockGasket.config.swagger.introspect = { info: { title: 'Test API', version: '1.0.0' } };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      const [, opts] = mockApp.register.mock.calls[0];
+      expect(opts.transform).toBeUndefined();
+    });
+
+    it('introspect: transform passes through routes matching include prefix', async function () {
+      mockGasket.config.swagger.introspect = {
+        routes: { include: ['/api/v1'] },
+        info: { title: 'Test API', version: '1.0.0' }
+      };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      const [, opts] = mockApp.register.mock.calls[0];
+      const schema = { description: 'test' };
+      expect(opts.transform({ schema, url: '/api/v1/users' })).toEqual({ schema, url: '/api/v1/users' });
+    });
+
+    it('introspect: transform hides routes not matching include prefix', async function () {
+      mockGasket.config.swagger.introspect = {
+        routes: { include: ['/api/v1'] },
+        info: { title: 'Test API', version: '1.0.0' }
+      };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      const [, opts] = mockApp.register.mock.calls[0];
+      const schema = { description: 'test' };
+      expect(opts.transform({ schema, url: '/api/auth/validate' })).toEqual({
+        schema: { hide: true },
+        url: '/api/auth/validate'
+      });
+    });
+
+    it('introspect: transform hides routes matching exclude prefix', async function () {
+      mockGasket.config.swagger.introspect = {
+        routes: { exclude: ['/internal'] },
+        info: { title: 'Test API', version: '1.0.0' }
+      };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      const [, opts] = mockApp.register.mock.calls[0];
+      const schema = { description: 'test' };
+      expect(opts.transform({ schema, url: '/internal/health' })).toEqual({
+        schema: { hide: true },
+        url: '/internal/health'
+      });
+    });
+
+    it('introspect: transform passes through routes not matching exclude prefix', async function () {
+      mockGasket.config.swagger.introspect = {
+        routes: { exclude: ['/internal'] },
+        info: { title: 'Test API', version: '1.0.0' }
+      };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      const [, opts] = mockApp.register.mock.calls[0];
+      const schema = { description: 'test' };
+      expect(opts.transform({ schema, url: '/api/v1/users' })).toEqual({ schema, url: '/api/v1/users' });
+    });
+
+    it('introspect: transform applies both include and exclude', async function () {
+      mockGasket.config.swagger.introspect = {
+        routes: { include: ['/api/v1'], exclude: ['/api/v1/internal'] },
+        info: { title: 'Test API', version: '1.0.0' }
+      };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      const [, opts] = mockApp.register.mock.calls[0];
+      const schema = { description: 'test' };
+      expect(opts.transform({ schema, url: '/api/v1/users' })).toEqual({ schema, url: '/api/v1/users' });
+      expect(opts.transform({ schema, url: '/api/v1/internal/secret' })).toEqual({
+        schema: { hide: true },
+        url: '/api/v1/internal/secret'
+      });
+      expect(opts.transform({ schema, url: '/api/auth/validate' })).toEqual({
+        schema: { hide: true },
+        url: '/api/auth/validate'
+      });
+    });
+
+    it('introspect: warns when include prefix is missing leading slash', async function () {
+      mockGasket.config.swagger.introspect = {
+        routes: { include: ['api/v1'] },
+        info: { title: 'Test API', version: '1.0.0' }
+      };
       await plugin.hooks.fastify.handler(mockGasket, mockApp);
       expect(mockGasket.logger.warn).toHaveBeenCalledWith(
-        'swagger.spec is only used when swagger.mode is "introspect". ' +
-        'It has no effect in static mode.'
+        'swagger.introspect.routes.include entry "api/v1" does not start with "/" ' +
+        'and will never match a Fastify route URL.'
+      );
+    });
+
+    it('introspect: warns when exclude prefix is missing leading slash', async function () {
+      mockGasket.config.swagger.introspect = {
+        routes: { exclude: ['internal'] },
+        info: { title: 'Test API', version: '1.0.0' }
+      };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockGasket.logger.warn).toHaveBeenCalledWith(
+        'swagger.introspect.routes.exclude entry "internal" does not start with "/" ' +
+        'and will never match a Fastify route URL.'
       );
     });
 

--- a/packages/gasket-plugin-swagger/test/index.test.js
+++ b/packages/gasket-plugin-swagger/test/index.test.js
@@ -33,6 +33,15 @@ vi.mock('util', () => {
   };
 });
 
+const mockSwaggerUiServe = vi.fn();
+const mockSwaggerUiSetup = vi.fn().mockReturnValue(vi.fn());
+vi.mock('swagger-ui-express', () => ({
+  default: {
+    serve: mockSwaggerUiServe,
+    setup: mockSwaggerUiSetup
+  }
+}));
+
 vi.mock('/path/to/app/swagger.json', () => ({ data: true }), {
   virtual: true
 });
@@ -88,10 +97,21 @@ describe('Swagger Plugin', function () {
       const results = plugin.hooks.configure({}, {});
       expect(results).toEqual({
         swagger: {
+          mode: 'static',
           definitionFile: 'swagger.json',
           apiDocsRoute: '/api-docs'
         }
       });
+    });
+
+    it('defaults mode to "static" when not specified', function () {
+      const results = plugin.hooks.configure({}, { swagger: {} });
+      expect(results.swagger.mode).toEqual('static');
+    });
+
+    it('preserves mode when explicitly set', function () {
+      const results = plugin.hooks.configure({}, { swagger: { mode: 'introspect' } });
+      expect(results.swagger.mode).toEqual('introspect');
     });
 
     it('uses specified definitionFile', function () {
@@ -129,10 +149,16 @@ describe('Swagger Plugin', function () {
       expect(mockBuildSwaggerDefinition).toHaveBeenCalled();
     });
 
-    it('skips buildSwaggerDefinition when openapi is set', async function () {
-      mockGasket.config.swagger.openapi = { info: { title: 'Test', version: '1.0.0' } };
+    it('skips buildSwaggerDefinition when mode is introspect', async function () {
+      mockGasket.config.swagger.mode = 'introspect';
       await plugin.hooks.build(mockGasket);
       expect(mockBuildSwaggerDefinition).not.toHaveBeenCalled();
+    });
+
+    it('runs buildSwaggerDefinition when mode is static', async function () {
+      mockGasket.config.swagger.mode = 'static';
+      await plugin.hooks.build(mockGasket);
+      expect(mockBuildSwaggerDefinition).toHaveBeenCalled();
     });
   });
 
@@ -204,13 +230,23 @@ describe('Swagger Plugin', function () {
       expect(mockApp.use.mock.calls[0][0]).toEqual('/api-docs');
     });
 
-    it('logs warning and skips when openapi is set', async function () {
-      mockGasket.config.swagger.openapi = { info: { title: 'Test', version: '1.0.0' } };
+    it('logs warning and skips when mode is introspect', async function () {
+      mockGasket.config.swagger.mode = 'introspect';
       await plugin.hooks.express.handler(mockGasket, mockApp);
       expect(mockGasket.logger.warn).toHaveBeenCalledWith(
-        'swagger.openapi is only supported with Fastify. Skipping Express Swagger UI setup.'
+        'swagger.mode "introspect" is only supported with Fastify. ' +
+        'Skipping Swagger UI for Express. To use Swagger with Express, use mode "static".'
       );
       expect(mockApp.use).not.toHaveBeenCalled();
+    });
+
+    it('logs warning when swagger.spec is set in static mode', async function () {
+      mockGasket.config.swagger.spec = { info: { title: 'Test', version: '1.0.0' } };
+      await plugin.hooks.express.handler(mockGasket, mockApp);
+      expect(mockGasket.logger.warn).toHaveBeenCalledWith(
+        'swagger.spec is only used when swagger.mode is "introspect". ' +
+        'It has no effect in static mode.'
+      );
     });
   });
 
@@ -285,35 +321,70 @@ describe('Swagger Plugin', function () {
       });
     });
 
-    it('registers @fastify/swagger with openapi config when openapi is set', async function () {
-      const openapi = { info: { title: 'Test API', version: '1.0.0' } };
-      mockGasket.config.swagger.openapi = openapi;
+    it('introspect mode: registers @fastify/swagger with openapi key when no version in spec', async function () {
+      mockGasket.config.swagger.mode = 'introspect';
+      const spec = { info: { title: 'Test API', version: '1.0.0' } };
+      mockGasket.config.swagger.spec = spec;
       await plugin.hooks.fastify.handler(mockGasket, mockApp);
-      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { openapi });
+      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { openapi: spec });
     });
 
-    it('does not load swagger spec file when openapi is set', async function () {
-      mockGasket.config.swagger.openapi = { info: { title: 'Test API', version: '1.0.0' } };
+    it('introspect mode: registers with empty spec object when swagger.spec is not set', async function () {
+      mockGasket.config.swagger.mode = 'introspect';
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { openapi: {} });
+    });
+
+    it('introspect mode: uses swagger key when spec.swagger is set (Swagger 2.0)', async function () {
+      mockGasket.config.swagger.mode = 'introspect';
+      const spec = { swagger: '2.0', info: { title: 'Test API', version: '1.0.0' } };
+      mockGasket.config.swagger.spec = spec;
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { swagger: spec });
+    });
+
+    it('introspect mode: does not load swagger spec file', async function () {
+      mockGasket.config.swagger.mode = 'introspect';
       await plugin.hooks.fastify.handler(mockGasket, mockApp);
       expect(mockAccessStub).not.toHaveBeenCalled();
       expect(mockReadFileStub).not.toHaveBeenCalled();
     });
 
-    it('still registers @fastify/swagger-ui with apiDocsRoute when openapi is set', async function () {
-      mockGasket.config.swagger.openapi = { info: { title: 'Test API', version: '1.0.0' } };
+    it('introspect mode: still registers @fastify/swagger-ui with apiDocsRoute', async function () {
+      mockGasket.config.swagger.mode = 'introspect';
       await plugin.hooks.fastify.handler(mockGasket, mockApp);
       expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), {
         routePrefix: '/api-docs'
       });
     });
 
-    it('openapi takes precedence when both openapi and definitionFile are set', async function () {
-      const openapi = { info: { title: 'Test API', version: '1.0.0' } };
-      mockGasket.config.swagger.openapi = openapi;
-      mockGasket.config.swagger.definitionFile = 'swagger.json';
+    it('introspect mode: warns when jsdoc is also set', async function () {
+      mockGasket.config.swagger.mode = 'introspect';
+      mockGasket.config.swagger.jsdoc = { definition: { info: { title: 'Test', version: '1.0.0' } } };
       await plugin.hooks.fastify.handler(mockGasket, mockApp);
-      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), { openapi });
-      expect(mockAccessStub).not.toHaveBeenCalled();
+      expect(mockGasket.logger.warn).toHaveBeenCalledWith(
+        'swagger.jsdoc is ignored when swagger.mode is "introspect". ' +
+        'Route introspection discovers routes automatically.'
+      );
+    });
+
+    it('logs warning when swagger.spec is set in static mode', async function () {
+      mockGasket.config.swagger.spec = { info: { title: 'Test', version: '1.0.0' } };
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockGasket.logger.warn).toHaveBeenCalledWith(
+        'swagger.spec is only used when swagger.mode is "introspect". ' +
+        'It has no effect in static mode.'
+      );
+    });
+
+    it('static mode: uses openapi key when loaded file has openapi property (OpenAPI 3.x)', async function () {
+      const openapiSpec = { openapi: '3.0.0', info: { title: 'Test', version: '1.0.0' } };
+      mockYamlSafeLoadStub.mockReturnValueOnce(openapiSpec);
+      mockGasket.config.swagger.definitionFile = 'swagger.yaml';
+      await plugin.hooks.fastify.handler(mockGasket, mockApp);
+      expect(mockApp.register).toHaveBeenCalledWith(expect.any(Function), {
+        openapi: openapiSpec
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds a `swagger.openapi` config option to `@gasket/plugin-swagger` that enables runtime route introspection via `@fastify/swagger`, removing the need for a static definition file.
- The plugin's `fastify` hook now uses `timing: { first: true }` so `@fastify/swagger` is always registered before any route-defining plugins, ensuring all routes are automatically discovered without any extra configuration by consumers.
- When `swagger.openapi` is set: the `build` step is skipped, and Express warns and exits early (OpenAPI mode is Fastify-only).
- Corrects README config name drift: `uiConfig` → `uiOptions`, `apiDocs` → `apiDocsRoute`.

## Test plan

- [ ] Verify existing swagger (static file) mode still works for both Fastify and Express apps
- [ ] Verify `swagger.openapi` mode shows all routes in Swagger UI without any `after` timing declarations in route plugins
- [ ] Confirm `build` hook is skipped when `swagger.openapi` is set
- [ ] Confirm Express logs a warning and skips setup when `swagger.openapi` is set
- [ ] Run unit tests: `npx vitest run` in `packages/gasket-plugin-swagger`

Made with [Cursor](https://cursor.com)