### PR TITLE
Update types to allow actions-only plugins

### DIFF
--- a/.changeset/angry-schools-divide.md
+++ b/.changeset/angry-schools-divide.md
@@ -1,0 +1,5 @@
+---
+"@gasket/core": patch
+---
+
+Adjust types to allow actions-only plugins

--- a/docs/authoring-plugins.md
+++ b/docs/authoring-plugins.md
@@ -30,6 +30,9 @@ a prerequisite. The `hooks` map has a key for every event the plugin handles,
 with the values being either the function itself or an object specifying
 `timing` options and the `handler`.
 
+A plugin must define at least one of `hooks` or `actions` (see [Gasket Actions]).
+A plugin that only contributes actions can omit `hooks` entirely, and vice versa.
+
 ## Recommended naming convention
 
 It is recommended that the `name` property in plugins and presets adhere to the project-type prefixed naming convention.
@@ -199,3 +202,4 @@ versioned, published, and imported to your different apps.
 [here]:/packages/gasket-core/docs/gasket-engine.md
 [@gasket/plugin-docs]:/packages/gasket-plugin-docs/README.md
 [scoped packages]: https://docs.npmjs.com/about-scopes
+[Gasket Actions]:/docs/gasket-actions.md

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -49,6 +49,8 @@ With TypeScript, these plugin hooks can be directly authored in `.ts` files usin
 
 The `@gasket/core` package exports a `Plugin` type which can be used to validate your plugin definitions. If your plugin introduces additional configuration properties or lifecycles, you should extend the `GasketConfig` and `HookExecTypes` interfaces. Useful helper types can also be found in `@gasket/core`.
 
+The `Plugin` type requires at least one of `hooks` or `actions`. The example below defines `hooks`; a plugin that only exposes actions can omit `hooks` and provide `actions` instead.
+
 ```typescript
 // my-plugin.ts
 import type {

--- a/packages/gasket-core/README.md
+++ b/packages/gasket-core/README.md
@@ -56,7 +56,7 @@ export default makeGasket({
 
 ### Registered plugins
 
-A plugin is a module that exports a `name` and `hooks` object (See [Plugins Guide]).
+A plugin is a module that exports a `name` and at least one of `hooks` or `actions` (See [Plugins Guide]).
 In your `gasket.js` file, you can import plugins and add them to the `plugins`
 array of the Gasket configuration.
 
@@ -388,6 +388,6 @@ export default { name, actions, hooks };
 [ready]: #ready 
 [actions]: #actions 
 [registered plugins]: #registered-plugins
-[Plugins Guide]:/packages/gasket-cli/docs/plugins.md
+[Plugins Guide]:/docs/authoring-plugins.md
 
 [debug]:https://github.com/debug-js/debug

--- a/packages/gasket-core/lib/engine.js
+++ b/packages/gasket-core/lib/engine.js
@@ -64,14 +64,15 @@ export class GasketEngine {
         throw new Error(`Plugin ${plugin.name} must be an object`);
       }
 
-      const { name, hooks } = plugin;
+      const { name, hooks, actions } = plugin;
 
       if (!name) throw new Error('Plugin must have a name');
-      if (!hooks) throw new Error(`Plugin (${name}) must have hooks`);
+      if (!hooks && !actions) throw new Error(`Plugin (${name}) must have hooks or actions`);
 
       // Add base metadata hook if not present
-      if (!hooks.metadata) {
-        hooks.metadata = async (_, metadata) => metadata;
+      plugin.hooks ??= {};
+      if (!plugin.hooks.metadata) {
+        plugin.hooks.metadata = async (_, metadata) => metadata;
       }
 
       acc[name] = plugin;

--- a/packages/gasket-core/lib/index.d.ts
+++ b/packages/gasket-core/lib/index.d.ts
@@ -142,10 +142,7 @@ export type Hook<Id extends HookId> = HookWithTimings<Id> | HookHandler<Id>;
  *    Plugin Definition   *
  * ----------------------- */
 
-/**
- * A Gasket plugin defines hooks, optional actions, and plugin metadata.
- */
-export type Plugin = {
+type PluginBase = {
   /** Plugin name (required) */
   name: string;
 
@@ -158,19 +155,21 @@ export type Plugin = {
   /** Optional dependency plugin names */
   dependencies?: Array<string>;
 
-  /** Lifecycle hooks this plugin implements */
-  hooks: {
-    [K in HookId]?: Hook<K>;
-  };
-
-  /** Optional actions this plugin can register */
-  actions?: {
-    [K in ActionId]?: ActionHandler<K>;
-  };
-
   /** Arbitrary plugin-specific metadata */
   metadata?: Record<string, any>;
 };
+
+type PluginHooks = { [K in HookId]?: Hook<K> };
+type PluginActions = { [K in ActionId]?: ActionHandler<K> };
+
+/**
+ * A Gasket plugin defines hooks and/or actions, plus plugin metadata.
+ * At least one of `hooks` or `actions` must be provided.
+ */
+export type Plugin = PluginBase & (
+  | { hooks: PluginHooks; actions?: PluginActions }
+  | { hooks?: PluginHooks; actions: PluginActions }
+);
 
 /**
  * Preset is a plugin without any actions defined.

--- a/packages/gasket-core/test/engine/constructor.test.js
+++ b/packages/gasket-core/test/engine/constructor.test.js
@@ -42,4 +42,22 @@ describe('constructor', () => {
     const engine = new GasketEngine([mockPlugin]);
     expect(engine._pluginMap).toHaveProperty('@gasket/plugin-one', mockPlugin);
   });
+
+  it('accepts plugins with only actions', () => {
+    const actionOnlyPlugin = {
+      name: '@gasket/plugin-action-only',
+      actions: {
+        doThing: () => 'done'
+      }
+    };
+
+    const engine = new GasketEngine([actionOnlyPlugin]);
+    expect(engine._pluginMap).toHaveProperty('@gasket/plugin-action-only', actionOnlyPlugin);
+    expect(engine.actions.doThing()).toEqual('done');
+  });
+
+  it('throws when a plugin has neither hooks nor actions', () => {
+    expect(() => new GasketEngine([{ name: 'faulty' }]))
+      .toThrow('Plugin (faulty) must have hooks or actions');
+  });
 });

--- a/packages/gasket-core/test/gasket.test.js
+++ b/packages/gasket-core/test/gasket.test.js
@@ -176,7 +176,7 @@ describe('makeGasket', () => {
       plugins: [mockPlugin, nullishPlugin, emptyPlugin, dummyPlugin, faultyPlugin]
     };
 
-    expect(() => makeGasket(initConfig)).toThrow('Plugin (faulty) must have hooks');
+    expect(() => makeGasket(initConfig)).toThrow('Plugin (faulty) must have hooks or actions');
   });
 
   describe('config lifecycle', () => {

--- a/packages/gasket-typescript-tests/test/core.spec.ts
+++ b/packages/gasket-typescript-tests/test/core.spec.ts
@@ -7,6 +7,10 @@ declare module '@gasket/core' {
     example(str: string, num: number, bool: boolean): MaybeAsync<boolean>
   }
 
+  interface GasketActions {
+    exampleAction(value: string): number;
+  }
+
   interface GasketConfig {
     someConfigSection?: {
       foo: string;
@@ -71,6 +75,45 @@ describe('@gasket/core', () => {
           return true;
         }
       }
+    };
+  });
+
+  it('requires at least one of hooks or actions on a Plugin', () => {
+    const hooksOnly: Plugin = {
+      name: 'hooks-only',
+      hooks: {
+        example(gasket, a, b, c) {
+          return true;
+        }
+      }
+    };
+
+    const actionsOnly: Plugin = {
+      name: 'actions-only',
+      actions: {
+        exampleAction(gasket, value) {
+          return value.length;
+        }
+      }
+    };
+
+    const both: Plugin = {
+      name: 'both',
+      hooks: {
+        example(gasket, a, b, c) {
+          return true;
+        }
+      },
+      actions: {
+        exampleAction(gasket, value) {
+          return value.length;
+        }
+      }
+    };
+
+    // @ts-expect-error — neither hooks nor actions provided
+    const neither: Plugin = {
+      name: 'neither'
     };
   });
 


### PR DESCRIPTION
## Summary

- Change `Plugin` type so it requires at least one of `hooks` or `actions` (previously `hooks` was always required). Enables action-only plugins.
- Add TypeScript test covering hooks-only, actions-only, both, and the invalid neither case.
- Update plugin-shape wording in docs.

## Test plan

- [x] `packages/gasket-typescript-tests` typecheck passes
- [x] Existing hooks-only plugins still type-check unchanged
