### PR TITLE
Fix docs deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Available lifecycles
 | [docsGenerate]                                             | Generate graphs for display in documation                     |
 | [docsSetup]                                                | Set up what docs are captured and how to transform them       |
 | [docsView]                                                 | View the collated documentation                               |
-| [errorMiddleware]                                          | Add Express style middleware for handling errors with Fastify |
-| [errorMiddleware][2]                                       | Add Express style middleware for handling errors              |
+| [errorMiddleware]                                          | Add Express style middleware for handling errors              |
+| [errorMiddleware][2]                                       | Add Express style middleware for handling errors with Fastify |
 | [express]                                                  | Modify the Express instance to for adding endpoints           |
 | [fastify]                                                  | Modify the Fastify instance to for adding endpoints           |
 | [gasketData]                                               | Adjust app level data after merged for the env                |
@@ -161,8 +161,8 @@ Available presets
 
 | Name                    | Version | Description                          |
 | ----------------------- | ------- | ------------------------------------ |
-| [@gasket/preset-api]    | 7.5.5   | Create Express-based API with Gasket |
-| [@gasket/preset-nextjs] | 7.5.6   | Basic NextJS Framework               |
+| [@gasket/preset-api]    | 7.6.10  | Create Express-based API with Gasket |
+| [@gasket/preset-nextjs] | 7.6.10  | Basic NextJS Framework               |
 
 ## Templates
 
@@ -170,11 +170,11 @@ Available templates
 
 | Name                              | Version | Description                                       |
 | --------------------------------- | ------- | ------------------------------------------------- |
-| [@gasket/template-api-express]    | 7.0.1   | Gasket API template for Express                   |
-| [@gasket/template-api-fastify]    | 7.0.1   | Gasket API template for Fastify                   |
-| [@gasket/template-nextjs-app]     | 7.0.1   | Gasket Next.js App Router template                |
-| [@gasket/template-nextjs-express] | 7.0.1   | Gasket Next.js Pages Router template with Express |
-| [@gasket/template-nextjs-pages]   | 7.0.1   | Gasket Next.js Pages Router template              |
+| [@gasket/template-api-express]    | 7.0.9   | Gasket API template for Express                   |
+| [@gasket/template-api-fastify]    | 7.0.9   | Gasket API template for Fastify                   |
+| [@gasket/template-nextjs-app]     | 7.0.10  | Gasket Next.js App Router template                |
+| [@gasket/template-nextjs-express] | 7.0.10  | Gasket Next.js Pages Router template with Express |
+| [@gasket/template-nextjs-pages]   | 7.0.10  | Gasket Next.js Pages Router template              |
 
 ## Plugins
 
@@ -182,38 +182,38 @@ Available plugins
 
 | Name                             | Version | Description                                                               |
 | -------------------------------- | ------- | ------------------------------------------------------------------------- |
-| [@gasket/plugin-analyze]         | 7.3.8   | Gasket Analyzer Plugin                                                    |
-| [@gasket/plugin-command]         | 7.5.3   | Plugin to enable other plugins to inject new gasket commands              |
-| [@gasket/plugin-cypress]         | 7.5.3   | Integrates Cypress based testing into your Gasket application             |
-| [@gasket/plugin-data]            | 7.4.11  | Supports application-specific settings and configurations                 |
-| [@gasket/plugin-docs]            | 7.4.8   | Centralize doc files from plugins and modules                             |
-| [@gasket/plugin-docs-graphs]     | 7.3.7   | Generate mermaid graphs of an applications gasket lifecycles              |
-| [@gasket/plugin-docusaurus]      | 7.4.6   | Gasket plugin for docusaurus                                              |
-| [@gasket/plugin-dynamic-plugins] | 7.4.2   |                                                                           |
-| [@gasket/plugin-elastic-apm]     | 7.4.9   | Adds Elastic APM instrumentation to your application                      |
-| [@gasket/plugin-express]         | 7.4.4   | Adds express support to your application                                  |
-| [@gasket/plugin-fastify]         | 7.4.6   | Adds fastify support to your application                                  |
-| [@gasket/plugin-git]             | 7.4.7   | Adds git support to your application                                      |
-| [@gasket/plugin-happyfeet]       | 7.3.7   | A gasket plugin to enable happyfeet healthchecks                          |
-| [@gasket/plugin-https]           | 7.3.12  | Create http/s servers with graceful termination                           |
-| [@gasket/plugin-https-proxy]     | 7.4.2   | Adds support for running an https proxy                                   |
-| [@gasket/plugin-intl]            | 7.5.10  | NodeJS script to build localization files.                                |
-| [@gasket/plugin-jest]            | 7.5.5   | Integrated jest into your application.                                    |
+| [@gasket/plugin-analyze]         | 7.4.4   | Gasket Analyzer Plugin                                                    |
+| [@gasket/plugin-command]         | 7.6.6   | Plugin to enable other plugins to inject new gasket commands              |
+| [@gasket/plugin-cypress]         | 7.5.4   | Integrates Cypress based testing into your Gasket application             |
+| [@gasket/plugin-data]            | 7.5.3   | Supports application-specific settings and configurations                 |
+| [@gasket/plugin-docs]            | 7.5.6   | Centralize doc files from plugins and modules                             |
+| [@gasket/plugin-docs-graphs]     | 7.4.2   | Generate mermaid graphs of an applications gasket lifecycles              |
+| [@gasket/plugin-docusaurus]      | 7.5.2   | Gasket plugin for docusaurus                                              |
+| [@gasket/plugin-dynamic-plugins] | 7.5.2   |                                                                           |
+| [@gasket/plugin-elastic-apm]     | 7.5.1   | Adds Elastic APM instrumentation to your application                      |
+| [@gasket/plugin-express]         | 7.5.2   | Adds express support to your application                                  |
+| [@gasket/plugin-fastify]         | 7.5.6   | Adds fastify support to your application                                  |
+| [@gasket/plugin-git]             | 7.4.10  | Adds git support to your application                                      |
+| [@gasket/plugin-happyfeet]       | 7.4.0   | A gasket plugin to enable happyfeet healthchecks                          |
+| [@gasket/plugin-https]           | 7.4.2   | Create http/s servers with graceful termination                           |
+| [@gasket/plugin-https-proxy]     | 7.5.1   | Adds support for running an https proxy                                   |
+| [@gasket/plugin-intl]            | 7.6.6   | NodeJS script to build localization files.                                |
+| [@gasket/plugin-jest]            | 7.5.10  | Integrated jest into your application.                                    |
 | [@gasket/plugin-lint]            | 7.4.4   | Adds GoDaddy standard linting to your application                         |
-| [@gasket/plugin-logger]          | 7.3.8   | Gasket plugin for logging                                                 |
-| [@gasket/plugin-manifest]        | 7.3.9   | The web app manifest for progressive Gasket applications                  |
-| [@gasket/plugin-metadata]        | 7.5.4   | Adds metadata to gasket lifecycles                                        |
-| [@gasket/plugin-middleware]      | 7.4.7   | Handles common server engine setups for routing and executing lifecycles. |
-| [@gasket/plugin-mocha]           | 7.5.4   | Integrates mocha based testing in to your Gasket application              |
-| [@gasket/plugin-morgan]          | 7.3.7   | Adds morgan request logger to your app                                    |
-| [@gasket/plugin-nextjs]          | 7.6.4   | Adds Next support to your application                                     |
-| [@gasket/plugin-redux]           | 7.4.3   | DEPRECATED Gasket Redux Setup                                             |
-| [@gasket/plugin-service-worker]  | 7.5.0   | DEPRECATED Gasket Service Worker Plugin                                   |
-| [@gasket/plugin-swagger]         | 7.3.10  | Generate and serve swagger docs                                           |
+| [@gasket/plugin-logger]          | 7.4.0   | Gasket plugin for logging                                                 |
+| [@gasket/plugin-manifest]        | 7.3.10  | The web app manifest for progressive Gasket applications                  |
+| [@gasket/plugin-metadata]        | 7.5.11  | Adds metadata to gasket lifecycles                                        |
+| [@gasket/plugin-middleware]      | 7.5.5   | Handles common server engine setups for routing and executing lifecycles. |
+| [@gasket/plugin-mocha]           | 7.5.7   | Integrates mocha based testing in to your Gasket application              |
+| [@gasket/plugin-morgan]          | 7.4.0   | Adds morgan request logger to your app                                    |
+| [@gasket/plugin-nextjs]          | 7.7.7   | Adds Next support to your application                                     |
+| [@gasket/plugin-redux]           | 7.4.5   | DEPRECATED Gasket Redux Setup                                             |
+| [@gasket/plugin-service-worker]  | 7.5.2   | DEPRECATED Gasket Service Worker Plugin                                   |
+| [@gasket/plugin-swagger]         | 7.4.2   | Generate and serve swagger docs                                           |
 | [@gasket/plugin-typescript]      | 7.4.6   | Gasket plugin for TypeScript support                                      |
-| [@gasket/plugin-vitest]          | 7.1.2   | Integrates Vitest based testing in to your Gasket application             |
-| [@gasket/plugin-webpack]         | 7.3.9   | Adds webpack support to your application                                  |
-| [@gasket/plugin-winston]         | 7.3.8   | Gasket logger based on Winston                                            |
+| [@gasket/plugin-vitest]          | 7.2.2   | Integrates Vitest based testing in to your Gasket application             |
+| [@gasket/plugin-webpack]         | 7.4.1   | Adds webpack support to your application                                  |
+| [@gasket/plugin-winston]         | 7.4.0   | Gasket logger based on Winston                                            |
 | [@gasket/plugin-workbox]         | 7.4.0   | DEPRECATED Gasket Workbox Plugin                                          |
 
 
@@ -224,17 +224,17 @@ Supporting modules
 
 | Name                 | Version | Description                                                              |
 | -------------------- | ------- | ------------------------------------------------------------------------ |
-| [@gasket/assets]     | 7.4.4   | Gasket assets                                                            |
-| [@gasket/cjs]        | 7.0.2   | Utility for transpiling ESM to CJS with .cjs extensions                  |
-| [@gasket/core]       | 7.6.3   | Entry point to setting up Gasket instances                               |
-| [@gasket/data]       | 7.5.4   | Helper package for accessing embedded Gasket Data in the browser         |
+| [@gasket/assets]     | 7.5.2   | Gasket assets                                                            |
+| [@gasket/cjs]        | 7.1.2   | Utility for transpiling ESM to CJS with .cjs extensions                  |
+| [@gasket/core]       | 7.7.5   | Entry point to setting up Gasket instances                               |
+| [@gasket/data]       | 7.5.5   | Helper package for accessing embedded Gasket Data in the browser         |
 | [@gasket/intl]       | 7.5.3   | Internationalization managers for translation files and locale handling. |
-| [@gasket/nextjs]     | 7.6.5   | Gasket integrations for Next.js apps                                     |
-| [@gasket/react-intl] | 7.6.4   | React component library to enable localization for gasket apps.          |
-| [@gasket/redux]      | 7.3.7   | Gasket Redux Configuration                                               |
-| [@gasket/request]    | 7.5.4   | Utilities for working with request objects in Gasket                     |
-| [@gasket/utils]      | 7.6.3   | Reusable utilities for Gasket internals                                  |
-| [create-gasket-app]  | 7.4.13  | starter pack for creating a gasket app                                   |
+| [@gasket/nextjs]     | 7.6.11  | Gasket integrations for Next.js apps                                     |
+| [@gasket/react-intl] | 7.7.2   | React component library to enable localization for gasket apps.          |
+| [@gasket/redux]      | 7.4.1   | DEPRECATED Gasket Redux Configuration                                    |
+| [@gasket/request]    | 7.5.5   | Utilities for working with request objects in Gasket                     |
+| [@gasket/utils]      | 7.6.6   | Reusable utilities for Gasket internals                                  |
+| [create-gasket-app]  | 7.4.22  | starter pack for creating a gasket app                                   |
 
 ## Configurations
 
@@ -340,8 +340,8 @@ Available configuration options in the `gasket.js`
 [docsGenerate]:/packages/gasket-plugin-docs/README.md#docsGenerate
 [docsSetup]:/packages/gasket-plugin-docs/README.md#docsSetup
 [docsView]:/packages/gasket-plugin-docs/README.md#docsView
-[errorMiddleware]:/packages/gasket-plugin-fastify/README.md#errorMiddleware
-[2]:/packages/gasket-plugin-express/README.md#errorMiddleware
+[errorMiddleware]:/packages/gasket-plugin-express/README.md#errorMiddleware
+[2]:/packages/gasket-plugin-fastify/README.md#errorMiddleware
 [express]:/packages/gasket-plugin-express/README.md#express
 [fastify]:/packages/gasket-plugin-fastify/README.md#express
 [gasketData]:/packages/gasket-plugin-data/README.md#gasketData

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
   "packageManager": "pnpm@10.4.1",
   "pnpm": {
     "overrides": {
-      "react-json-view-lite": "^2.3.0"
+      "react-json-view-lite": "^2.3.0",
+      "webpackbar": "^7.0.0"
     }
   },
   "workspaces": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   react-json-view-lite: ^2.3.0
+  webpackbar: ^7.0.0
 
 importers:
 
@@ -5626,6 +5627,10 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  ansis@3.17.0:
+    resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
+    engines: {node: '>=14'}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -8746,9 +8751,6 @@ packages:
   markdown-table@1.1.3:
     resolution: {integrity: sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==}
 
-  markdown-table@2.0.0:
-    resolution: {integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==}
-
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -10314,10 +10316,6 @@ packages:
   renderkid@3.0.0:
     resolution: {integrity: sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==}
 
-  repeat-string@1.6.1:
-    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
-    engines: {node: '>=0.10'}
-
   request-progress@3.0.0:
     resolution: {integrity: sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==}
 
@@ -11701,11 +11699,17 @@ packages:
       webpack-cli:
         optional: true
 
-  webpackbar@6.0.1:
-    resolution: {integrity: sha512-TnErZpmuKdwWBdMoexjio3KKX6ZtoKHRVvLIU0A47R0VVBDtx3ZyOJDktgYixhoJokZTYTt1Z37OkO9pnGJa9Q==}
+  webpackbar@7.0.0:
+    resolution: {integrity: sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
+      '@rspack/core': '*'
       webpack: 3 || 4 || 5
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
 
   websocket-driver@0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
@@ -14272,7 +14276,7 @@ snapshots:
       tslib: 2.8.1
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.98.0(@swc/core@1.10.18(@swc/helpers@0.5.15))))(webpack@5.106.2(@swc/core@1.10.18(@swc/helpers@0.5.15)))
       webpack: 5.106.2(@swc/core@1.10.18(@swc/helpers@0.5.15))
-      webpackbar: 6.0.1(webpack@5.106.2(@swc/core@1.10.18(@swc/helpers@0.5.15)))
+      webpackbar: 7.0.0(webpack@5.106.2(@swc/core@1.10.18(@swc/helpers@0.5.15)))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -17476,6 +17480,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
+
+  ansis@3.17.0: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -21522,10 +21528,6 @@ snapshots:
 
   markdown-table@1.1.3: {}
 
-  markdown-table@2.0.0:
-    dependencies:
-      repeat-string: 1.6.1
-
   markdown-table@3.0.4: {}
 
   math-intrinsics@1.1.0: {}
@@ -23499,8 +23501,6 @@ snapshots:
       lodash: 4.17.21
       strip-ansi: 6.0.1
 
-  repeat-string@1.6.1: {}
-
   request-progress@3.0.0:
     dependencies:
       throttleit: 1.0.1
@@ -25132,17 +25132,14 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@6.0.1(webpack@5.106.2(@swc/core@1.10.18(@swc/helpers@0.5.15))):
+  webpackbar@7.0.0(webpack@5.106.2(@swc/core@1.10.18(@swc/helpers@0.5.15))):
     dependencies:
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
+      ansis: 3.17.0
       consola: 3.4.0
-      figures: 3.2.0
-      markdown-table: 2.0.0
       pretty-time: 1.1.0
       std-env: 3.9.0
+    optionalDependencies:
       webpack: 5.106.2(@swc/core@1.10.18(@swc/helpers@0.5.15))
-      wrap-ansi: 7.0.0
 
   websocket-driver@0.7.4:
     dependencies:


### PR DESCRIPTION
## Summary

Fix `docs-deploy` workflow failing at `pnpm run build` (site).

## Root cause

Dependabot consolidation (#1415) bumped `webpack` transitively from `5.98.0` → `5.106.2` under `@docusaurus/bundler@3.8.1`. Webpack's stricter `ProgressPlugin` schema validation rejects the `name` option that `webpackbar@6.0.1` passes, crashing the Docusaurus build:

```
ValidationError: Progress Plugin ... options has an unknown property 'name'
```

## Fix

Add a `pnpm.overrides` entry pinning `webpackbar` to `^7.0.0`, which removed the offending `name` option upstream. Smaller blast radius than pinning webpack itself (which conflicts with `webpack-inject-plugin`'s peer dep under `strict-peer-dependencies`).

## Test plan

- [x] `cd site && pnpm run build` succeeds locally
- [x] `docs-deploy` workflow passes on this PR ([working run](https://github.com/godaddy/gasket/actions/runs/25820486896/job/75860383605))
