### PR TITLE
feat(plugin-logger): add overrideConsole opt-in config

### DIFF
--- a/.changeset/plugin-logger-override-console.md
+++ b/.changeset/plugin-logger-override-console.md
@@ -1,0 +1,5 @@
+---
+"@gasket/plugin-logger": minor
+---
+
+Add opt-in `logger.overrideConsole` configuration. When enabled, patches the global `console` methods during the `init` lifecycle and routes them through `gasket.logger`. Because all output now passes through the logger's configured pipeline (formatters, transports, metadata), third-party dependencies that previously called `console.*` directly will automatically produce structured, consistently formatted log entries. Only takes effect when a custom logger is registered via `createLogger`.

--- a/packages/gasket-plugin-logger/README.md
+++ b/packages/gasket-plugin-logger/README.md
@@ -17,7 +17,7 @@ Configuration for `@gasket/plugin-logger` lives under the `logger` key in `gaske
 
 ### overrideConsole
 
->  **Note:** `overrideConsole` only takes effect when a custom logger is registered via the `createLogger` lifecycle; it has no effect when the default console-based fallback logger is in us
+>  **Note:** `overrideConsole` only takes effect when a custom logger is registered via the `createLogger` lifecycle; it has no effect when the default console-based fallback logger is in use.
 
 Some third-party packages (e.g. SDKs, component libraries) call `console.*` directly and bypass the configured logger pipeline entirely. This causes issues such as multi-line plain-text output appearing in structured log aggregators (e.g. Elastic) instead of properly formatted log entries, because the formatting, transport, and metadata configuration in `gasket.logger` is never applied.
 

--- a/packages/gasket-plugin-logger/README.md
+++ b/packages/gasket-plugin-logger/README.md
@@ -7,6 +7,33 @@ Gasket applications.
 At this time, there is only one plugin which implements a
 custom logger: `@gasket/plugin-winston`.
 
+## Configuration
+
+Configuration for `@gasket/plugin-logger` lives under the `logger` key in `gasket.config`.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `overrideConsole` | `boolean` | `false` | When `true`, replaces the global `console` methods (`log`, `info`, `warn`, `error`, `debug`) with calls to `gasket.logger`. |
+
+### overrideConsole
+
+>  **Note:** `overrideConsole` only takes effect when a custom logger is registered via the `createLogger` lifecycle; it has no effect when the default console-based fallback logger is in us
+
+Some third-party packages (e.g. SDKs, component libraries) call `console.*` directly and bypass the configured logger pipeline entirely. This causes issues such as multi-line plain-text output appearing in structured log aggregators (e.g. Elastic) instead of properly formatted log entries, because the formatting, transport, and metadata configuration in `gasket.logger` is never applied.
+
+Enabling `overrideConsole` patches the global `console` methods during the `init` lifecycle — early enough to capture all subsequent output — and routes them through `gasket.logger`, so log levels, structured metadata, and transports work consistently across the entire app.
+
+```js
+// gasket.config.js
+export default {
+  logger: {
+    overrideConsole: true
+  }
+};
+```
+
+> **Note:** This is an opt-in stop-gap for apps where third-party dependencies cannot be updated to accept a custom logger instance. The preferred long-term solution is to update those libraries to accept a logger instance so that `gasket.logger` can be passed down directly.
+
 ## Installation
 
 This plugin is only used by presets for `create-gasket-app` and is not installed for apps.

--- a/packages/gasket-plugin-logger/lib/index.d.ts
+++ b/packages/gasket-plugin-logger/lib/index.d.ts
@@ -24,6 +24,17 @@ declare module '@gasket/core' {
     logger: Logger;
   }
 
+  export interface GasketConfig {
+    logger?: {
+      /**
+       * When true, overrides the global console methods (log, info, warn, error, debug)
+       * to route all output through gasket.logger. Useful for capturing third-party
+       * dependencies that call console.* directly.
+       */
+      overrideConsole?: boolean;
+    };
+  }
+
   export interface HookExecTypes {
     createLogger(): Logger;
   }

--- a/packages/gasket-plugin-logger/lib/index.js
+++ b/packages/gasket-plugin-logger/lib/index.js
@@ -5,7 +5,7 @@
 /* eslint-disable no-console */
 import packageJson from '../package.json' with { type: 'json' };
 const { name, version, description } = packageJson;
-import { createChildLogger, verifyLoggerLevels } from './utils.js';
+import { createChildLogger, overrideConsole, verifyLoggerLevels } from './utils.js';
 
 /** @type {import('@gasket/core').Plugin} */
 const plugin = {
@@ -24,6 +24,7 @@ const plugin = {
     },
     init(gasket) {
       const loggers = gasket.execSync('createLogger');
+      let hasCustomLogger = false;
 
       if (
         loggers &&
@@ -48,6 +49,11 @@ const plugin = {
       } else {
         verifyLoggerLevels(loggers[0]);
         gasket.logger = loggers[0];
+        hasCustomLogger = true;
+      }
+
+      if (hasCustomLogger && gasket.config?.logger?.overrideConsole) {
+        overrideConsole(gasket.logger);
       }
     },
     async onSignal(gasket) {

--- a/packages/gasket-plugin-logger/lib/utils.js
+++ b/packages/gasket-plugin-logger/lib/utils.js
@@ -29,7 +29,21 @@ function verifyLoggerLevels(logger) {
   });
 }
 
+/**
+ * Override global console methods to route output through the provided logger.
+ * @param {import('./index.d.ts').Logger} logger - The gasket logger instance to route console calls through.
+ */
+function overrideConsole(logger) {
+  console.error = (...args) => logger.error(...args);
+  console.warn = (...args) => logger.warn(...args);
+  console.log = (...args) => logger.info(...args);
+  console.info = (...args) => logger.info(...args);
+  console.debug = (...args) => logger.debug(...args);
+  logger.info('[gasket-plugin-logger] console overridden to use gasket.logger');
+}
+
 export {
   createChildLogger,
+  overrideConsole,
   verifyLoggerLevels
 };

--- a/packages/gasket-plugin-logger/test/index.test.js
+++ b/packages/gasket-plugin-logger/test/index.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import plugin from '../lib/index.js';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
@@ -34,12 +34,30 @@ describe('@gasket/plugin-logger', () => {
 
   describe('plugin.hooks', () => {
     let gasket;
+    let originalConsole;
 
     beforeEach(() => {
       gasket = {
         execSync: vi.fn(),
-        logger: null
+        logger: null,
+        config: {}
       };
+
+      originalConsole = {
+        error: console.error,
+        warn: console.warn,
+        log: console.log,
+        info: console.info,
+        debug: console.debug
+      };
+    });
+
+    afterEach(() => {
+      console.error = originalConsole.error;
+      console.warn = originalConsole.warn;
+      console.log = originalConsole.log;
+      console.info = originalConsole.info;
+      console.debug = originalConsole.debug;
     });
 
     describe('init', () => {
@@ -88,6 +106,119 @@ describe('@gasket/plugin-logger', () => {
         // eslint-disable-next-line max-nested-callbacks
         expect(() => plugin.hooks.init(gasket)).toThrow(
           'Multiple plugins are hooking createLogger. Only one logger is supported.'
+        );
+      });
+    });
+
+    describe('init - overrideConsole', () => {
+      let fakeLogger;
+
+      beforeEach(() => {
+        fakeLogger = { ...mockLogger };
+        gasket.execSync.mockReturnValue([fakeLogger]);
+      });
+
+      it('should not override console methods when overrideConsole is not set', () => {
+        const originalLog = console.log;
+        gasket.config = {};
+
+        plugin.hooks.init(gasket);
+
+        expect(console.log).toBe(originalLog);
+      });
+
+      it('should not override console methods when overrideConsole is false', () => {
+        const originalLog = console.log;
+        gasket.config = { logger: { overrideConsole: false } };
+
+        plugin.hooks.init(gasket);
+
+        expect(console.log).toBe(originalLog);
+      });
+
+      it('should not override console methods when no custom logger is hooked', () => {
+        const originalLog = console.log;
+        gasket.config = { logger: { overrideConsole: true } };
+        gasket.execSync.mockReturnValue([]);
+
+        plugin.hooks.init(gasket);
+
+        expect(console.log).toBe(originalLog);
+      });
+
+      it('should override console methods when overrideConsole is true and a custom logger is hooked', () => {
+        const originalLog = console.log;
+        gasket.config = { logger: { overrideConsole: true } };
+
+        plugin.hooks.init(gasket);
+
+        expect(console.log).not.toBe(originalLog);
+        expect(console.info).not.toBe(originalConsole.info);
+        expect(console.error).not.toBe(originalConsole.error);
+        expect(console.warn).not.toBe(originalConsole.warn);
+        expect(console.debug).not.toBe(originalConsole.debug);
+      });
+
+      it('should route console.log to logger.info when overrideConsole is true', () => {
+        gasket.config = { logger: { overrideConsole: true } };
+        plugin.hooks.init(gasket);
+
+        console.log('log message', { extra: 1 });
+
+        expect(fakeLogger.info).toHaveBeenCalledWith('log message', { extra: 1 });
+      });
+
+      it('should route console.info to logger.info when overrideConsole is true', () => {
+        gasket.config = { logger: { overrideConsole: true } };
+        plugin.hooks.init(gasket);
+
+        console.info('info message');
+
+        expect(fakeLogger.info).toHaveBeenCalledWith('info message');
+      });
+
+      it('should route console.error to logger.error when overrideConsole is true', () => {
+        gasket.config = { logger: { overrideConsole: true } };
+        plugin.hooks.init(gasket);
+
+        console.error('error message');
+
+        expect(fakeLogger.error).toHaveBeenCalledWith('error message');
+      });
+
+      it('should route console.warn to logger.warn when overrideConsole is true', () => {
+        gasket.config = { logger: { overrideConsole: true } };
+        plugin.hooks.init(gasket);
+
+        console.warn('warn message');
+
+        expect(fakeLogger.warn).toHaveBeenCalledWith('warn message');
+      });
+
+      it('should route console.debug to logger.debug when overrideConsole is true', () => {
+        gasket.config = { logger: { overrideConsole: true } };
+        plugin.hooks.init(gasket);
+
+        console.debug('debug message');
+
+        expect(fakeLogger.debug).toHaveBeenCalledWith('debug message');
+      });
+
+      it('should forward multiple arguments through the overridden console methods', () => {
+        gasket.config = { logger: { overrideConsole: true } };
+        plugin.hooks.init(gasket);
+
+        console.error('msg', 'extra', { key: 'value' });
+
+        expect(fakeLogger.error).toHaveBeenCalledWith('msg', 'extra', { key: 'value' });
+      });
+
+      it('should log a confirmation message after overriding console', () => {
+        gasket.config = { logger: { overrideConsole: true } };
+        plugin.hooks.init(gasket);
+
+        expect(fakeLogger.info).toHaveBeenCalledWith(
+          '[gasket-plugin-logger] console overridden to use gasket.logger'
         );
       });
     });


### PR DESCRIPTION
## Summary

Some third-party packages (e.g. SDKs, component libraries) call `console.*` directly and bypass the configured logger pipeline entirely. This causes issues such as multi-line plain-text output appearing in structured log aggregators (e.g. Elastic) instead of properly formatted log entries, because the formatting, transport, and metadata configuration in `gasket.logger` is never applied.

To address this, `overrideConsole` patches the global `console` methods during the `init` lifecycle — early enough to capture all subsequent output — and routes them through `gasket.logger`, so log levels, structured metadata, and transports work consistently across the entire app.

## Changes
- Update plugin-logger config options to allow `overrideConsole` 
- core logic to patch direct console.log calls and route them to the gasket.logger, ensuring all logs respect the structured format, log levels, and metadata configuration already in place. Note that `overrideConsole` only takes effect when a custom logger is registered via the `createLogger` lifecycle; it has no effect when the default console-based fallback logger is in use.
- doc update to reflect usage and new config options

## Test Plan

[] Run a Gasket app with some dependency that invoke/call console.log directly and uses some custom formattter (e.g winston)
[] Update logger config with `override.console: true`
[] Verify log is respecting the expected Winston formatting setup

<!--
Demonstrate the code is solid. Example: Unit tests, screenshots from an app showing
the change in the module.
-->
