### PR TITLE
fix: resolve fallow unresolved imports

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -5,7 +5,12 @@
   },
   "ignorePatterns": [
     "**/generator/**",
-    "site/**"
+    "**/template/**",
+    "site/**",
+    "index.html"
+  ],
+  "ignoreUnresolvedImports": [
+    "/path/to/app/**"
   ],
   "dynamicallyLoaded": [
     "scripts/generate-docs-index/**",

--- a/packages/create-gasket-app/lib/commands/create.js
+++ b/packages/create-gasket-app/lib/commands/create.js
@@ -9,10 +9,7 @@ import mkDir from '../scaffold/actions/mkdir.js';
 import printReport from '../scaffold/actions/print-report.js';
 import gitInit from '../scaffold/actions/git-init.js';
 
-/**
- * Parses comma separated option input to array
- * @type {import('../internal.js').commasToArray}
- */
+/** @type {import('../internal.d.ts').commasToArray} */
 const commasToArray = input => input.split(',').map(name => name.trim());
 
 const createCommand = {
@@ -75,9 +72,8 @@ const createCommand = {
 };
 
 /**
- * validateOption - We require at least one of the options to be provided
- * @param {import('../internal.js').PartialCreateContext} context - Create context
- * @returns {import('../internal.js').PartialCreateContext} Validated context
+ * We require at least one of the options to be provided
+ * @type {import('../internal.d.ts').validateOptions}
  */
 function validateOptions(context) {
   const hasOption = (context) => Boolean(context.template || context.templatePath);
@@ -90,11 +86,7 @@ function validateOptions(context) {
   return context;
 }
 
-/**
- * handleTemplate - Handles the template creation
- * @param {import('../internal.js').PartialCreateContext} context - Create context
- * @returns {Promise<void>} Promise that resolves when template is created
- */
+/** @type {import('../internal.d.ts').handleTemplate} */
 async function handleTemplate(context) {
   await mkDir({ context });
   await loadTemplate({ context });
@@ -106,10 +98,7 @@ async function handleTemplate(context) {
   return;
 }
 
-/**
- * createCommand action
- * @type {import('../index.js').createCommandAction}
- */
+/** @type {import('../index.d.ts').createCommandAction} */
 // eslint-disable-next-line no-unused-vars
 createCommand.action = async function run(appname, options, command) {
   // eslint-disable-next-line no-process-env

--- a/packages/create-gasket-app/lib/internal.d.ts
+++ b/packages/create-gasket-app/lib/internal.d.ts
@@ -16,6 +16,10 @@ export type PartialCreateContext = Partial<CreateContext>;
 
 export function commasToArray(value: string): string[];
 
+export function validateOptions(context: PartialCreateContext): PartialCreateContext;
+
+export function handleTemplate(context: PartialCreateContext): Promise<void>;
+
 /** scaffold */
 
 export function readConfig(
@@ -144,6 +148,8 @@ export function replaceInjectionAssignments(content: string, assignments: (objec
 export function installModules(params: { context: PartialCreateContext }): Promise<void>;
 
 export function linkModules(params: { context: CreateContext, spinner: Ora }): Promise<void>;
+
+export function runScript(script: string): Promise<{ stdout: string }>;
 
 export function postCreateHooks(params: { gasket?: Gasket, context: PartialCreateContext }): Promise<void>;
 

--- a/packages/create-gasket-app/lib/scaffold/actions/create-hooks.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/create-hooks.js
@@ -3,11 +3,7 @@ import { ConfigBuilder } from '../config-builder.js';
 import { Files } from '../files.js';
 import Readme from '../readme.js';
 
-/**
- * Executes the `create` hook for all registered plugins.
- * Adds `files` to context for plugins to add their files and templates.
- * @type {import('../../internal.js').createHooks}
- */
+/** @type {import('../../internal.d.ts').createHooks} */
 async function createHooks({ gasket, context }) {
   const { warnings } = context;
   const files = new Files();

--- a/packages/create-gasket-app/lib/scaffold/actions/generate-files.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/generate-files.js
@@ -15,10 +15,8 @@ const joinSep = pthArr => pthArr.join(path.sep);
 const splitSep = pthStr => pthStr.split(reSep);
 
 /**
- * Find all duplicate target files and reduce to single descriptor.
- * Keeps track of overrides.
  * Last in wins.
- * @type {import('../../internal.js').reduceDescriptors}
+ * @type {import('../../internal.d.ts').reduceDescriptors}
  */
 function reduceDescriptors(descriptors) {
   const reduced = descriptors.reduce((acc, desc) => {
@@ -37,10 +35,7 @@ function reduceDescriptors(descriptors) {
   return Array.from(reduced.values());
 }
 
-/**
- * Assemble the description objects from glob results
- * @type {import('../../internal.js').assembleDescriptors}
- */
+/** @type {import('../../internal.d.ts').assembleDescriptors} */
 function assembleDescriptors(dest, from, pattern, srcPaths) {
   const output = joinSep(splitSep(dest));
   const baseParts = splitSep(path.resolve(pattern.replace(/[/\\]+\.?\*.*$/, '')));
@@ -60,10 +55,7 @@ function assembleDescriptors(dest, from, pattern, srcPaths) {
   });
 }
 
-/**
- * Build a list of descriptions of all files we want to generate
- * @type {import('../../internal.js').getDescriptors}
- */
+/** @type {import('../../internal.d.ts').getDescriptors} */
 async function getDescriptors(context) {
   const { dest, files } = context;
   const descriptors = (
@@ -81,10 +73,7 @@ async function getDescriptors(context) {
   return reduceDescriptors(descriptors);
 }
 
-/**
- * Read file content, apply templating, then write out target file.
- * @type {import('../../internal.js').performGenerate}
- */
+/** @type {import('../../internal.d.ts').performGenerate} */
 async function performGenerate(context, descriptors) {
   const { warnings, errors, generatedFiles } = context;
   let hasWarning = false;
@@ -147,10 +136,7 @@ async function performGenerate(context, descriptors) {
   return [hasWarning, hasError];
 }
 
-/**
- * Generate the app files and templates using context
- * @type {import('../../internal.js').generateFiles}
- */
+/** @type {import('../../internal.d.ts').generateFiles} */
 async function generateFiles({ context, spinner }) {
   const { files } = context;
 

--- a/packages/create-gasket-app/lib/scaffold/actions/generate-files.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/generate-files.js
@@ -15,7 +15,7 @@ const joinSep = pthArr => pthArr.join(path.sep);
 const splitSep = pthStr => pthStr.split(reSep);
 
 /**
- * Last in wins.
+ * Deduplicates target files, tracking overrides. Last in wins.
  * @type {import('../../internal.d.ts').reduceDescriptors}
  */
 function reduceDescriptors(descriptors) {

--- a/packages/create-gasket-app/lib/scaffold/actions/git-init.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/git-init.js
@@ -3,7 +3,7 @@ import { runShellCommand } from '@gasket/utils';
 
 /**
  * Initialize git repository, create main branch, and make initial commit
- * @type {import('../../internal.d.js').gitInit}
+ * @type {import('../../internal.d.ts').gitInit}
  */
 async function gitInit({ context }) {
   try {

--- a/packages/create-gasket-app/lib/scaffold/actions/global-prompts.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/global-prompts.js
@@ -1,10 +1,7 @@
 import inquirer from 'inquirer';
 import { withSpinner } from '../with-spinner.js';
 
-/**
- * What is your app description?
- * @type {import('../../internal.js').chooseAppDescription}
- */
+/** @type {import('../../internal.d.ts').chooseAppDescription} */
 async function chooseAppDescription(context, prompt) {
   if (!('appDescription' in context)) {
     const { appDescription } = await prompt([
@@ -20,10 +17,7 @@ async function chooseAppDescription(context, prompt) {
   }
 }
 
-/**
- * What package manager do you want to use?
- * @type {import('../../internal.js').choosePackageManager}
- */
+/** @type {import('../../internal.d.ts').choosePackageManager} */
 async function choosePackageManager(context, prompt) {
   const packageManager =
     context.packageManager ||
@@ -57,7 +51,7 @@ async function choosePackageManager(context, prompt) {
 /**
  * Given that gasket is creating in an already existing directory, it should
  * confirm with the user that it's intentionally overwriting that directory
- * @type {import('../../internal.js').allowExtantOverwriting}
+ * @type {import('../../internal.d.ts').allowExtantOverwriting}
  */
 async function allowExtantOverwriting(context, prompt) {
   const { dest, extant } = context;
@@ -81,10 +75,7 @@ export const questions = [
   allowExtantOverwriting
 ];
 
-/**
- * Fire off prompts for user input
- * @type {import('../../internal.js').globalPrompts}
- */
+/** @type {import('../../internal.d.ts').globalPrompts} */
 async function globalPrompts({ context }) {
   const prompt = context.prompts ? inquirer.createPromptModule() : () => ({});
 

--- a/packages/create-gasket-app/lib/scaffold/actions/install-modules.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/install-modules.js
@@ -1,9 +1,6 @@
 import { withSpinner } from '../with-spinner.js';
 
-/**
- * Installs node_modules using the selected package manager
- * @type {import('../../internal.js').installModules}
- */
+/** @type {import('../../internal.d.ts').installModules} */
 async function installModules({ context }) {
   const { pkgManager } = context;
 

--- a/packages/create-gasket-app/lib/scaffold/actions/link-modules.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/link-modules.js
@@ -1,9 +1,6 @@
 import { withSpinner } from '../with-spinner.js';
 
-/**
- * Links local packages using the selected package manager
- * @type {import('../../internal.js').linkModules}
- */
+/** @type {import('../../internal.d.ts').linkModules} */
 async function linkModules({ context, spinner }) {
   const { pkgLinks, pkgManager } = context;
 

--- a/packages/create-gasket-app/lib/scaffold/actions/mkdir.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/mkdir.js
@@ -5,7 +5,7 @@ import { withSpinner } from '../with-spinner.js';
  * Validates this instance can execute without common blockers:
  * - Target destination on disk is available. Validate by acquiring
  * a lock through `mkdir`.
- * @type {import('../../internal.js').mkDir}
+ * @type {import('../../internal.d.ts').mkDir}
  */
 async function mkDir({ context, spinner }) {
   const { dest, relDest, extant, destOverride } = context;

--- a/packages/create-gasket-app/lib/scaffold/actions/post-create-hooks.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/post-create-hooks.js
@@ -1,18 +1,11 @@
 import { withGasketSpinner } from '../with-spinner.js';
 import { runShellCommand } from '@gasket/utils';
 
-/**
- * Executes the `postCreate` hook for all registered plugins.
- * @type {import('../../internal.js').postCreateHooks}
- */
+/** @type {import('../../internal.d.ts').postCreateHooks} */
 async function postCreateHooks({ gasket, context }) {
   const { dest, packageManager } = context;
 
-  /**
-   * Determines the correct command for running scripts based on the package manager.
-   * @param {string} script - The name of the script to run.
-   * @returns {Promise} A promise that resolves if the script runs successfully.
-   */
+  /** @type {import('../../internal.d.ts').runScript} */
   async function runScript(script) {
     let cmd;
 
@@ -32,9 +25,6 @@ async function postCreateHooks({ gasket, context }) {
     return await runShellCommand(cmd, ['run', script], { cwd: dest });
   }
 
-  /**
-   * An object with one value for now, so adding more utilities in future is easy.
-   */
   const utils = { runScript };
   await gasket.exec('postCreate', context, utils);
 }

--- a/packages/create-gasket-app/lib/scaffold/actions/post-create-hooks.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/post-create-hooks.js
@@ -25,6 +25,7 @@ async function postCreateHooks({ gasket, context }) {
     return await runShellCommand(cmd, ['run', script], { cwd: dest });
   }
 
+  // Object so future utilities can be added without breaking the hook signature
   const utils = { runScript };
   await gasket.exec('postCreate', context, utils);
 }

--- a/packages/create-gasket-app/lib/scaffold/actions/print-report.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/print-report.js
@@ -3,29 +3,15 @@ const { bold } = pkg;
 import { withSpinner } from '../with-spinner.js';
 import { logo } from '../../utils/index.js';
 
-/**
- * Logs a new line in the console
- * @private
- */
 const newline = () => {
   console.log('');
 };
 
-/**
- * Converts a camelCase string to Space Case
- * https://stackoverflow.com/questions/4149276/javascript-camelcase-to-regular-form?answertab=active#tab-top
- * @param {string} str - camelCase string to fixup
- * @returns {string} result
- * @private
- */
+// https://stackoverflow.com/questions/4149276/javascript-camelcase-to-regular-form?answertab=active#tab-top
 const toSpaceCase = str => str.replace(/([A-Z])/g, ' $1')
   .replace(/^./, s => s.toUpperCase());
 
-/**
- * Builds the report object from context
- * @type {import('../../internal.js').buildReport}
- * @private
- */
+/** @type {import('../../internal.d.ts').buildReport} */
 function buildReport(context) {
   const {
     appName,
@@ -50,10 +36,7 @@ function buildReport(context) {
   };
 }
 
-/**
- * Outputs create command details to the console
- * @type {import('../../internal.js').printReport}
- */
+/** @type {import('../../internal.d.ts').printReport} */
 async function printReport({ context }) {
   const report = buildReport(context);
   const { warnings, errors } = context;

--- a/packages/create-gasket-app/lib/scaffold/actions/prompt-hooks.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/prompt-hooks.js
@@ -1,11 +1,7 @@
 import inquirer from 'inquirer';
 import { withGasketSpinner } from '../with-spinner.js';
 
-/**
- * Initializes engine with provided plugins
- * to execute their prompt lifecycle hooks.
- * @type {import('../../internal.js').execPluginPrompts}
- */
+/** @type {import('../../internal.d.ts').execPluginPrompts} */
 async function execPluginPrompts(gasket, context) {
   //
   // @see: https://github.com/SBoudrias/Inquirer.js/#inquirercreatepromptmodule---prompt-function
@@ -18,11 +14,7 @@ async function execPluginPrompts(gasket, context) {
   Object.assign(context, nextContext);
 }
 
-/**
- * Executes the `prompt` hook for all registered plugins.
- * Adds `prompt` util function for prompting features.
- * @type {import('../../internal.js').promptHooks}
- */
+/** @type {import('../../internal.d.ts').promptHooks} */
 async function promptHooks({ gasket, context }) {
   //
   // Because `execPluginPrompts` is recursive, we need to start it

--- a/packages/create-gasket-app/lib/scaffold/actions/setup-pkg.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/setup-pkg.js
@@ -5,10 +5,7 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const { dependencies } = require('../../../package.json');
 
-/**
- * Initializes the ConfigBuilder builder and adds to context.
- * @type {import('../../internal.js').setupPkg}
- */
+/** @type {import('../../internal.d.ts').setupPkg} */
 async function setupPkg({ context }) {
   const { appName, appDescription, warnings } = context;
 

--- a/packages/create-gasket-app/lib/scaffold/actions/write-gasket-config.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/write-gasket-config.js
@@ -3,10 +3,7 @@ import path from 'path';
 import { writeFile } from 'fs/promises';
 import { withSpinner } from '../with-spinner.js';
 
-/**
- * writePluginImports - Write string imports as value(s)
- * @type {import('../../internal.js').writePluginImports}
- */
+/** @type {import('../../internal.d.ts').writePluginImports} */
 function writePluginImports(plugins) {
   return plugins.reduce((acc, cur, index) => {
     acc += `\t\t${cur}${index < plugins.length - 1 ? ',\n' : ''}`;
@@ -14,19 +11,14 @@ function writePluginImports(plugins) {
   }, '');
 }
 
-/**
- * writeImports - Write imports to file using key value pairs
- * @type {import('../../internal.js').writeImports}
- */
+/** @type {import('../../internal.d.ts').writeImports} */
 function writeImports(imports) {
   if (!imports) return '';
   return `${Object.entries(imports).map(([importDef, importPath]) => `import ${importDef} from '${importPath}';`).join('\n')}\n`;
 }
 
-/**
- * createInjectionAssignments - replace object path with a temp string value
- * @type {import('../../internal.js').createInjectionAssignments}
- */
+// Placeholder strings let raw JS expressions survive JSON5.stringify
+/** @type {import('../../internal.d.ts').createInjectionAssignments} */
 function createInjectionAssignments(config, assignments) {
   if (!assignments) return '';
   Object.keys(assignments).forEach((key) => {
@@ -42,10 +34,7 @@ function createInjectionAssignments(config, assignments) {
   });
 }
 
-/**
- * replaceInjectionAssignments - replace temp string value with actual value
- * @type {import('../../internal.js').replaceInjectionAssignments}
- */
+/** @type {import('../../internal.d.ts').replaceInjectionAssignments} */
 function replaceInjectionAssignments(content, assignments) {
   if (!assignments) return content;
   Object.keys(assignments).forEach((key) => {
@@ -55,19 +44,13 @@ function replaceInjectionAssignments(content, assignments) {
   return content;
 }
 
-/**
- * writeExpressions - Write expressions to file
- * @type {import('../../internal.js').writeExpressions}
- */
+/** @type {import('../../internal.d.ts').writeExpressions} */
 function writeExpressions(expressions) {
   if (!expressions) return '';
   return `${expressions.map((expression) => `${expression}`).join('\n')}\n`;
 }
 
-/**
- * cleanupFields - Remove fields from config object
- * @type {import('../../internal.js').cleanupFields}
- */
+/** @type {import('../../internal.d.ts').cleanupFields} */
 function cleanupFields(config) {
   delete config.fields.imports;
   delete config.fields.pluginImports;
@@ -75,10 +58,7 @@ function cleanupFields(config) {
   delete config.fields.injectionAssignments;
 }
 
-/**
- * Writes the contents of `pkg` to the app's package.json.
- * @type {import('../../internal.js').writeGasketConfig}
- */
+/** @type {import('../../internal.d.ts').writeGasketConfig} */
 async function writeGasketConfig({ context }) {
   const { dest, gasketConfig, generatedFiles, typescript } = context;
   const fileName = typescript ? 'gasket.ts' : 'gasket.js';

--- a/packages/create-gasket-app/lib/scaffold/actions/write-pkg.js
+++ b/packages/create-gasket-app/lib/scaffold/actions/write-pkg.js
@@ -2,10 +2,7 @@ import path from 'path';
 import { writeFile } from 'fs/promises';
 import { withSpinner } from '../with-spinner.js';
 
-/**
- * Writes the contents of `pkg` to the app's package.json.
- * @type {import('../../internal.js').writePkg}
- */
+/** @type {import('../../internal.d.ts').writePkg} */
 async function writePkg({ context }) {
   const { dest, pkg, generatedFiles } = context;
   const fileName = 'package.json';

--- a/packages/create-gasket-app/lib/scaffold/config-builder.js
+++ b/packages/create-gasket-app/lib/scaffold/config-builder.js
@@ -52,7 +52,7 @@ function isValidVersion(v) {
 /**
  * ConfigBuilder is an extensible data structure for **specifically**
  * managing `package.json` data.
- * @type {import('../index.js').ConfigBuilder}
+ * @type {import('../index.d.ts').ConfigBuilder}
  */
 export class ConfigBuilder {
   /**

--- a/packages/create-gasket-app/lib/scaffold/create-context.js
+++ b/packages/create-gasket-app/lib/scaffold/create-context.js
@@ -6,7 +6,7 @@ import { readConfig } from '../scaffold/utils.js';
  * The CreateRuntime represents a shallow proxy to a CreateContext
  * that automatically adds transactional information for providing
  * CLI users with blame information in the event of conflicts.
- * @type {import('../internal.js').makeCreateRuntime}
+ * @type {import('../internal.d.ts').makeCreateRuntime}
  */
 function makeCreateRuntime(context, source) {
   //
@@ -68,7 +68,7 @@ export class CreateContext {
   }
 }
 
-/** @type {import('../internal.js').makeCreateContext} */
+/** @type {import('../internal.d.ts').makeCreateContext} */
 export function makeCreateContext(argv = [], options = {}) {
   const appName = argv[0] || 'templated-app';
   const {
@@ -92,7 +92,7 @@ export function makeCreateContext(argv = [], options = {}) {
 
   /**
    * Input context which will be appended by prompts and passed to create hooks
-   * @type {import('../index.js').CreateContext}
+   * @type {import('../index.d.ts').CreateContext}
    */
   // @ts-ignore - some properties not defined in constructor will be added later
   const context = new CreateContext({

--- a/packages/create-gasket-app/lib/scaffold/dump-error-context.js
+++ b/packages/create-gasket-app/lib/scaffold/dump-error-context.js
@@ -4,7 +4,7 @@ import { writeFile } from 'fs/promises';
 /**
  * If an error occurs during create, dump the context for debugging.
  * The error which cause the exit is also included in the log.
- * @type {import('../internal.js').dumpErrorContext}
+ * @type {import('../internal.d.ts').dumpErrorContext}
  */
 export async function dumpErrorContext(context, error) {
   const { cwd } = context;

--- a/packages/create-gasket-app/lib/scaffold/files.js
+++ b/packages/create-gasket-app/lib/scaffold/files.js
@@ -1,6 +1,6 @@
 /**
  * Utility for plugins to add files and templates for generating
- * @type {import('../index.js').Files}
+ * @type {import('../index.d.ts').Files}
  */
 export class Files {
   constructor() {

--- a/packages/create-gasket-app/lib/scaffold/readme.js
+++ b/packages/create-gasket-app/lib/scaffold/readme.js
@@ -1,6 +1,6 @@
 import { readFile } from 'fs/promises';
 
-/** @type {import('../index.js').Readme} */
+/** @type {import('../index.d.ts').Readme} */
 export default class Readme {
   constructor() {
     this.markdown = [];

--- a/packages/create-gasket-app/lib/scaffold/utils.js
+++ b/packages/create-gasket-app/lib/scaffold/utils.js
@@ -2,7 +2,7 @@ import path from 'path';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 
-/** @type {import('../internal.js').readConfig} */
+/** @type {import('../internal.d.ts').readConfig} */
 export function readConfig(context, { config, configFile }) {
   if (config) {
     const parsedConfig = JSON.parse(config);

--- a/packages/create-gasket-app/lib/scaffold/with-spinner.js
+++ b/packages/create-gasket-app/lib/scaffold/with-spinner.js
@@ -1,11 +1,8 @@
 import ora from 'ora';
 
-/**
- * Base function to handle spinner logic
- * @type {import('../internal.js').wrapWithSpinner}
- */
+/** @type {import('../internal.d.ts').wrapWithSpinner} */
 function wrapWithSpinner(label, task, { startSpinner = true } = {}) {
-  /** @type {import('../internal.js').execute} */
+  /** @type {import('../internal.d.ts').execute} */
   async function execute(args) {
     const { context } = args;
     const spinner = ora(label);
@@ -26,10 +23,7 @@ function wrapWithSpinner(label, task, { startSpinner = true } = {}) {
   return execute;
 }
 
-/**
- * Wrap a task with a spinner, including gasket and context.
- * @type {import('../internal.js').withGasketSpinner}
- */
+/** @type {import('../internal.d.ts').withGasketSpinner} */
 export function withGasketSpinner(label, task, options) {
   return wrapWithSpinner(label, ({ gasket, context, spinner }) =>
     task({ gasket, context, spinner }),
@@ -37,10 +31,7 @@ export function withGasketSpinner(label, task, options) {
   );
 }
 
-/**
- * Wrap a task with a spinner, using only context.
- * @type {import('../internal.js').withSpinner}
- */
+/** @type {import('../internal.d.ts').withSpinner} */
 export function withSpinner(label, task, options) {
   return wrapWithSpinner(label, ({ context, spinner }) =>
     task({ context, spinner }),

--- a/packages/create-gasket-app/lib/utils/create-option.js
+++ b/packages/create-gasket-app/lib/utils/create-option.js
@@ -1,9 +1,6 @@
 import { Option } from 'commander';
 
-/**
- * createOption - Create a commander option
- * @type {import('../internal.js').createOption}
- */
+/** @type {import('../internal.d.ts').createOption} */
 export function createOption(definition) {
   const option = new Option(...definition.options);
   const { defaultValue, conflicts, parse, hidden, required } = definition;

--- a/packages/create-gasket-app/lib/utils/process-args.js
+++ b/packages/create-gasket-app/lib/utils/process-args.js
@@ -1,7 +1,4 @@
-/**
- * isValidArg - Validates the argument configuration
- * @type {import('../internal.js').isValidArg}
- */
+/** @type {import('../internal.d.ts').isValidArg} */
 function isValidArg(arg) {
   const keys = Object.keys(arg);
   if (arg.required && arg.default) return false;
@@ -10,10 +7,7 @@ function isValidArg(arg) {
     !!arg.name && !!arg.description;
 }
 
-/**
- * processArgs - Process the arguments configuration
- * @type {import('../internal.js').processArgs}
- */
+/** @type {import('../internal.d.ts').processArgs} */
 export function processArgs(args) {
   if (!Array.isArray(args) || !args.every(isValidArg)) throw new Error('Invalid argument(s) configuration');
 

--- a/packages/create-gasket-app/lib/utils/process-command.js
+++ b/packages/create-gasket-app/lib/utils/process-command.js
@@ -4,10 +4,7 @@ import { processOptions } from './process-options.js';
 import { createOption } from './create-option.js';
 const program = new Command();
 
-/**
- * isValidCommand - Validates the command configuration
- * @type {import('../internal.js').isValidCommand}
- */
+/** @type {import('../internal.d.ts').isValidCommand} */
 function isValidCommand(command) {
   const keys = Object.keys(command);
   return keys.length &&
@@ -19,10 +16,7 @@ function isValidCommand(command) {
     typeof command.action === 'function';
 }
 
-/**
- * processCommand - Process the command configuration
- * @type {import('../internal.js').processCommand}
- */
+/** @type {import('../internal.d.ts').processCommand} */
 export function processCommand(command) {
   if (!isValidCommand(command)) throw new Error('Invalid command configuration');
   const { id, description, action, args, options, hidden = false, default: isDefault = false } = command;

--- a/packages/create-gasket-app/lib/utils/process-options.js
+++ b/packages/create-gasket-app/lib/utils/process-options.js
@@ -1,7 +1,4 @@
-/**
- * isValidOption - Validate the option
- * @type {import('../internal.js').isValidOption}
- */
+/** @type {import('../internal.d.ts').isValidOption} */
 function isValidOption(option) {
   const keys = Object.keys(option);
   return !!keys.length &&
@@ -10,10 +7,7 @@ function isValidOption(option) {
     !!option.description;
 }
 
-/**
- * processOptions - Process the options configuration
- * @type {import('../internal.js').processOptions}
- */
+/** @type {import('../internal.d.ts').processOptions} */
 export function processOptions(options) {
   if (!Array.isArray(options) || !options.every(isValidOption)) throw new Error('Invalid option(s) configuration');
 

--- a/packages/gasket-nextjs/lib/document/index.js
+++ b/packages/gasket-nextjs/lib/document/index.js
@@ -6,7 +6,7 @@ import { injectGasketData } from '../inject-gasket-data.js';
 
 const reClass = /^class\s/;
 
-/** @type {import('./internal.js').isDocumentClass} */
+/** @type {import('./internal.d.ts').isDocumentClass} */
 function isDocumentClass(maybeClass) {
   return typeof maybeClass === 'function' && reClass.test(Function.prototype.toString.call(maybeClass));
 }
@@ -14,11 +14,7 @@ function isDocumentClass(maybeClass) {
 /**
  * To avoid polluting <head/>, we want to render our JSON in the <body/>
  * but before our other scripts so that it is available to query.
- * In a basic Next.js app, this is between the Main and NextScript tags.*
- * @param {Array} bodyChildren - Children of body element
- * @param {number} index - Element index
- * @returns {number} index
- * @private
+ * In a basic Next.js app, this is between the Main and NextScript tags.
  */
 function lookupIndex(bodyChildren, index = -1) {
   const lookups = [
@@ -32,11 +28,7 @@ function lookupIndex(bodyChildren, index = -1) {
   return lookups.reduce((acc, cur) => acc !== -1 ? acc : cur(), index);
 }
 
-/**
- * Make a wrapper to extend the Next.js Document, injecting a script with the
- * `gasketData` from the response object.
- * @type {import('./index.d.ts').withGasketData}
- */
+/** @type {import('./index.d.ts').withGasketData} */
 export function withGasketData(
   gasket,
   options = {}

--- a/packages/gasket-nextjs/lib/document/index.js
+++ b/packages/gasket-nextjs/lib/document/index.js
@@ -15,6 +15,7 @@ function isDocumentClass(maybeClass) {
  * To avoid polluting <head/>, we want to render our JSON in the <body/>
  * but before our other scripts so that it is available to query.
  * In a basic Next.js app, this is between the Main and NextScript tags.
+ * @type {import('./internal.d.ts').lookupIndex}
  */
 function lookupIndex(bodyChildren, index = -1) {
   const lookups = [

--- a/packages/gasket-nextjs/lib/document/internal.d.ts
+++ b/packages/gasket-nextjs/lib/document/internal.d.ts
@@ -3,4 +3,6 @@ import type { ReactElement, ReactNode } from 'react';
 
 export function isDocumentClass(maybeClass: any): maybeClass is typeof Document;
 
+export function lookupIndex(bodyChildren: ReactElement[], index?: number): number;
+
 export function selectBody(children: ReactElement[]): [ReactElement, number];

--- a/packages/gasket-plugin-command/lib/index.d.ts
+++ b/packages/gasket-plugin-command/lib/index.d.ts
@@ -2,7 +2,7 @@ import type { Plugin, MaybeAsync } from '@gasket/core';
 import type {
   GasketArgDefinition,
   GasketOptionDefinition
-} from './internal.js';
+} from './internal.d.ts';
 
 export interface GasketCommandDefinition {
   /* Command id/name */


### PR DESCRIPTION
- Fix 58+ fallow unresolved import findings by correcting JSDoc `@type` import specifiers from `.js` to `.d.ts`
- Add `**/template/**` and `index.html` to fallow ignorePatterns (false positives from scaffold templates and deleted docsify plugin)
- Add `/path/to/app/**` to ignoreUnresolvedImports (fake paths in swagger test mocks)
- Remove unnecessary comments and `@param`/`@returns` from JS files
- Add missing types to `internal.d.ts` for `validateOptions`, `handleTemplate`, `runScript`, `lookupIndex`