### PR TITLE
feat(plugin-nextjs): add opt-in Turbopack support

### DIFF
--- a/.changeset/calm-cats-enable-turbopack.md
+++ b/.changeset/calm-cats-enable-turbopack.md
@@ -2,4 +2,9 @@
 "@gasket/plugin-nextjs": minor
 ---
 
-Add opt-in Turbopack support for Gasket plugin server dependencies.
+Add opt-in Turbopack support gated on `gasket.config.turbopack` (set via
+`makeGasket({ turbopack: true })`). When enabled, this plugin's `nextConfig`
+hook removes its Webpack callback and adds `@gasket/core` and
+`@gasket/plugin-nextjs` to Next.js `serverExternalPackages`. Other Gasket
+plugins should hook `nextConfig` to self-register additional server externals
+under this flag.

--- a/.changeset/calm-cats-enable-turbopack.md
+++ b/.changeset/calm-cats-enable-turbopack.md
@@ -1,0 +1,5 @@
+---
+"@gasket/plugin-nextjs": minor
+---
+
+Add opt-in Turbopack support for Gasket plugin server dependencies.

--- a/packages/gasket-plugin-nextjs/README.md
+++ b/packages/gasket-plugin-nextjs/README.md
@@ -64,10 +64,13 @@ export default gasket.actions.getNextConfig();
 ### Next.js 16 and the Webpack bundler
 
 This plugin requires **Next.js 16** or later and injects Webpack configuration
-into your Next app. In Next.js 16, Turbopack is the default bundler, so Gasket
-apps must use the `--webpack` flag when running the Next CLI. Generated apps
-and scripts use `next build --webpack` and `next dev --webpack` by default.
-Next.js 16 also requires **Node.js 20.9+**.
+into your Next app. Generated apps and scripts use `next build --webpack` and
+`next dev --webpack` by default. Apps can opt into Turbopack by setting
+`TURBOPACK=1` and using the `--turbopack` Next CLI flag. In this mode, the
+plugin removes its Webpack callback and externalizes loaded Gasket plugins for
+the server bundle. App-specific Webpack aliases and fallbacks must still be
+represented in the app's `turbopack` configuration. Next.js 16 also requires
+**Node.js 20.9+**.
 
 For general Webpack configurations, it is recommended to use features of the
 Gasket [Webpack plugin], which will be merged into the Next.js configuration.

--- a/packages/gasket-plugin-nextjs/README.md
+++ b/packages/gasket-plugin-nextjs/README.md
@@ -61,16 +61,34 @@ import gasket from './gasket.js';
 export default gasket.actions.getNextConfig();
 ```
 
-### Next.js 16 and the Webpack bundler
+### Next.js 16 bundlers (Webpack + opt-in Turbopack)
 
 This plugin requires **Next.js 16** or later and injects Webpack configuration
 into your Next app. Generated apps and scripts use `next build --webpack` and
-`next dev --webpack` by default. Apps can opt into Turbopack by setting
-`TURBOPACK=1` and using the `--turbopack` Next CLI flag. In this mode, the
-plugin removes its Webpack callback and externalizes loaded Gasket plugins for
-the server bundle. App-specific Webpack aliases and fallbacks must still be
-represented in the app's `turbopack` configuration. Next.js 16 also requires
-**Node.js 20.9+**.
+`next dev --webpack` by default. Next.js 16 also requires **Node.js 20.9+**.
+
+Apps opt into Turbopack by setting `turbopack: true` on the Gasket config:
+
+```js
+// gasket.js
+export default makeGasket({
+  turbopack: true,
+  plugins: [pluginNextjs]
+});
+```
+
+When `gasket.config.turbopack` is `true`, this plugin's `nextConfig` hook:
+
+- removes its Webpack callback (Turbopack ignores it), and
+- adds `@gasket/core` and `@gasket/plugin-nextjs` to
+  `serverExternalPackages` so Next loads them at runtime from `node_modules`
+  instead of tracing and bundling them.
+
+Other Gasket plugins that need Turbopack support should provide their own
+`nextConfig` hook that self-registers their package (and any server-only
+dependencies) under `gasket.config.turbopack`. App-specific Webpack aliases
+and fallbacks must still be represented in the app's own `turbopack`
+configuration (for example `turbopack.resolveAlias`).
 
 For general Webpack configurations, it is recommended to use features of the
 Gasket [Webpack plugin], which will be merged into the Next.js configuration.

--- a/packages/gasket-plugin-nextjs/lib/index.d.ts
+++ b/packages/gasket-plugin-nextjs/lib/index.d.ts
@@ -39,6 +39,16 @@ declare module '@gasket/core' {
      * @todo This should be moved to gasket/engine for next major release
      */
     basePath?: string;
+    /**
+     * Opt into Turbopack support. When true, `@gasket/plugin-nextjs`'s
+     * `nextConfig` hook removes its Webpack callback and adds `@gasket/core`
+     * plus `@gasket/plugin-nextjs` to `serverExternalPackages`. Other Gasket
+     * plugins may hook `nextConfig` to self-register additional server
+     * externals when this flag is set.
+     * @example
+     * turbopack: true
+     */
+    turbopack?: boolean;
   }
 
   export interface HookExecTypes {

--- a/packages/gasket-plugin-nextjs/lib/index.js
+++ b/packages/gasket-plugin-nextjs/lib/index.js
@@ -7,6 +7,7 @@ import * as actions from './actions.js';
 import { prompt } from './prompt.js';
 import create from './create.js';
 import { webpackConfig } from './webpack-config.js';
+import nextConfig from './next-config.js';
 import express from './express.js';
 import fastify from './fastify.js';
 import workbox from './workbox.js';
@@ -23,6 +24,7 @@ const plugin = {
   hooks: {
     configure,
     webpackConfig,
+    nextConfig,
     prompt,
     create,
     express,

--- a/packages/gasket-plugin-nextjs/lib/next-config.js
+++ b/packages/gasket-plugin-nextjs/lib/next-config.js
@@ -1,0 +1,30 @@
+/// <reference types="@gasket/core" />
+
+const GASKET_PLUGIN_NAME = /(^@gasket\/plugin-|^@[\w-]+\/gasket-plugin-)/;
+// eslint-disable-next-line no-process-env
+const processEnv = process.env;
+
+/**
+ * Configure Next.js for Turbopack when explicitly enabled.
+ * @type {import('@gasket/core').HookHandler<'nextConfig'>}
+ */
+export default function nextConfig(gasket, config) {
+  if (processEnv.TURBOPACK !== '1') return config;
+
+  const turbopackConfig = { ...config };
+  delete turbopackConfig.webpack;
+
+  const pluginNames = (gasket.config.plugins ?? []).flatMap((plugin) => (
+    typeof plugin?.name === 'string' && GASKET_PLUGIN_NAME.test(plugin.name)
+      ? [plugin.name]
+      : []
+  ));
+
+  turbopackConfig.serverExternalPackages = Array.from(new Set([
+    ...(config.serverExternalPackages ?? []),
+    '@gasket/core',
+    ...pluginNames
+  ]));
+
+  return turbopackConfig;
+}

--- a/packages/gasket-plugin-nextjs/lib/next-config.js
+++ b/packages/gasket-plugin-nextjs/lib/next-config.js
@@ -1,29 +1,30 @@
 /// <reference types="@gasket/core" />
 
-const GASKET_PLUGIN_NAME = /(^@gasket\/plugin-|^@[\w-]+\/gasket-plugin-)/;
-// eslint-disable-next-line no-process-env
-const processEnv = process.env;
-
 /**
- * Configure Next.js for Turbopack when explicitly enabled.
+ * Under Turbopack (opted into via `makeGasket({ turbopack: true })`),
+ * remove this plugin's Webpack callback (Turbopack ignores it) and add
+ * `@gasket/core` and `@gasket/plugin-nextjs` to `serverExternalPackages`
+ * so Next loads them at runtime from node_modules instead of tracing
+ * and bundling them.
+ *
+ * When `gasket.config.turbopack` is falsy, this hook is a no-op — the
+ * default Webpack path is byte-identical.
+ *
+ * Other Gasket plugins that need Turbopack support should provide their
+ * own `nextConfig` hook that self-registers their package (and any
+ * server-only dependencies) under `gasket.config.turbopack`.
  * @type {import('@gasket/core').HookHandler<'nextConfig'>}
  */
 export default function nextConfig(gasket, config) {
-  if (processEnv.TURBOPACK !== '1') return config;
+  if (!gasket.config.turbopack) return config;
 
   const turbopackConfig = { ...config };
   delete turbopackConfig.webpack;
 
-  const pluginNames = (gasket.config.plugins ?? []).flatMap((plugin) => (
-    typeof plugin?.name === 'string' && GASKET_PLUGIN_NAME.test(plugin.name)
-      ? [plugin.name]
-      : []
-  ));
-
   turbopackConfig.serverExternalPackages = Array.from(new Set([
     ...(config.serverExternalPackages ?? []),
     '@gasket/core',
-    ...pluginNames
+    '@gasket/plugin-nextjs'
   ]));
 
   return turbopackConfig;

--- a/packages/gasket-plugin-nextjs/test/index.test.js
+++ b/packages/gasket-plugin-nextjs/test/index.test.js
@@ -60,6 +60,7 @@ describe('Plugin', function () {
       'express',
       'fastify',
       'metadata',
+      'nextConfig',
       'prompt',
       'webpackConfig',
       'workbox'

--- a/packages/gasket-plugin-nextjs/test/next-config.test.js
+++ b/packages/gasket-plugin-nextjs/test/next-config.test.js
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import nextConfig from '../lib/next-config.js';
+
+// eslint-disable-next-line no-process-env
+const processEnv = process.env;
+const originalTurbopack = processEnv.TURBOPACK;
+
+describe('nextConfig', function () {
+  afterEach(function () {
+    if (typeof originalTurbopack === 'undefined') {
+      delete processEnv.TURBOPACK;
+    } else {
+      processEnv.TURBOPACK = originalTurbopack;
+    }
+  });
+
+  it('returns the existing config when Turbopack is disabled', function () {
+    delete processEnv.TURBOPACK;
+    const config = { webpack: function webpack() {} };
+
+    expect(nextConfig({ config: {} }, config)).toBe(config);
+  });
+
+  it('removes webpack configuration under Turbopack', function () {
+    processEnv.TURBOPACK = '1';
+
+    const result = nextConfig({ config: {} }, { webpack: function webpack() {} });
+
+    expect(result).not.toHaveProperty('webpack');
+  });
+
+  it('externalizes Gasket core and loaded plugins', function () {
+    processEnv.TURBOPACK = '1';
+    const gasket = {
+      config: {
+        plugins: [
+          { name: '@gasket/plugin-nextjs' },
+          { name: '@godaddy/gasket-plugin-uxp' },
+          { name: 'local-plugin' },
+          {}
+        ]
+      }
+    };
+
+    const result = nextConfig(gasket, {});
+
+    expect(result.serverExternalPackages).toEqual([
+      '@gasket/core',
+      '@gasket/plugin-nextjs',
+      '@godaddy/gasket-plugin-uxp'
+    ]);
+  });
+
+  it('preserves and deduplicates existing server externals', function () {
+    processEnv.TURBOPACK = '1';
+    const gasket = {
+      config: {
+        plugins: [{ name: '@gasket/plugin-nextjs' }]
+      }
+    };
+
+    const result = nextConfig(gasket, {
+      serverExternalPackages: ['existing-package', '@gasket/core']
+    });
+
+    expect(result.serverExternalPackages).toEqual([
+      'existing-package',
+      '@gasket/core',
+      '@gasket/plugin-nextjs'
+    ]);
+  });
+});

--- a/packages/gasket-plugin-nextjs/test/next-config.test.js
+++ b/packages/gasket-plugin-nextjs/test/next-config.test.js
@@ -1,38 +1,32 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import nextConfig from '../lib/next-config.js';
 
-// eslint-disable-next-line no-process-env
-const processEnv = process.env;
-const originalTurbopack = processEnv.TURBOPACK;
-
 describe('nextConfig', function () {
-  afterEach(function () {
-    if (typeof originalTurbopack === 'undefined') {
-      delete processEnv.TURBOPACK;
-    } else {
-      processEnv.TURBOPACK = originalTurbopack;
-    }
-  });
-
-  it('returns the existing config when Turbopack is disabled', function () {
-    delete processEnv.TURBOPACK;
+  it('returns the existing config when gasket.config.turbopack is unset', function () {
     const config = { webpack: function webpack() {} };
 
     expect(nextConfig({ config: {} }, config)).toBe(config);
   });
 
-  it('removes webpack configuration under Turbopack', function () {
-    processEnv.TURBOPACK = '1';
+  it('returns the existing config when gasket.config.turbopack is false', function () {
+    const config = { webpack: function webpack() {} };
 
-    const result = nextConfig({ config: {} }, { webpack: function webpack() {} });
+    expect(nextConfig({ config: { turbopack: false } }, config)).toBe(config);
+  });
+
+  it('removes webpack configuration under Turbopack', function () {
+    const result = nextConfig(
+      { config: { turbopack: true } },
+      { webpack: function webpack() {} }
+    );
 
     expect(result).not.toHaveProperty('webpack');
   });
 
-  it('externalizes Gasket core and loaded plugins', function () {
-    processEnv.TURBOPACK = '1';
+  it('externalizes only @gasket/core and @gasket/plugin-nextjs (does not auto-scan other plugins)', function () {
     const gasket = {
       config: {
+        turbopack: true,
         plugins: [
           { name: '@gasket/plugin-nextjs' },
           { name: '@godaddy/gasket-plugin-uxp' },
@@ -46,22 +40,15 @@ describe('nextConfig', function () {
 
     expect(result.serverExternalPackages).toEqual([
       '@gasket/core',
-      '@gasket/plugin-nextjs',
-      '@godaddy/gasket-plugin-uxp'
+      '@gasket/plugin-nextjs'
     ]);
   });
 
   it('preserves and deduplicates existing server externals', function () {
-    processEnv.TURBOPACK = '1';
-    const gasket = {
-      config: {
-        plugins: [{ name: '@gasket/plugin-nextjs' }]
-      }
-    };
-
-    const result = nextConfig(gasket, {
-      serverExternalPackages: ['existing-package', '@gasket/core']
-    });
+    const result = nextConfig(
+      { config: { turbopack: true } },
+      { serverExternalPackages: ['existing-package', '@gasket/core'] }
+    );
 
     expect(result.serverExternalPackages).toEqual([
       'existing-package',


### PR DESCRIPTION
## Summary

Adds opt-in Turbopack handling to `@gasket/plugin-nextjs` while preserving the existing Webpack behavior byte-for-byte by default.

Next.js 16 defaults to Turbopack, but the plugin currently relies on a Webpack callback and `NormalModuleReplacementPlugin` rules for server-only Gasket files. Consumers can now opt in via `makeGasket({ turbopack: true })`.

## Design (config-driven, plugin-self-externalizing)

Two design decisions (per review feedback on the initial version of this PR):

**1. Config-driven, not env-driven.** The `nextConfig` hook gates on `gasket.config.turbopack` — set via `makeGasket({ turbopack: true })`. Plugin code never reads env vars; the app boundary owns the decision (e.g. compute from `--turbopack` / `TURBOPACK=1` and set the flag).

**2. Each plugin owns its own externals.** This hook only contributes `@gasket/core` and `@gasket/plugin-nextjs` itself to `serverExternalPackages`. It no longer auto-scans loaded `@gasket/plugin-*` / `@*/gasket-plugin-*` packages. Other Gasket plugins that need Turbopack support should provide their own `nextConfig` hook that self-registers under `gasket.config.turbopack`. See gdcorp-uxp/gasket#2261 for a sibling implementation.

## Changes

- Add `nextConfig` hook in `lib/next-config.js` gated on `gasket.config.turbopack`.
- Under Turbopack: remove the plugin's Webpack callback (Turbopack ignores it) and add `@gasket/core` + `@gasket/plugin-nextjs` to `serverExternalPackages`, preserving + deduplicating any existing consumer entries.
- Augment `GasketConfig` in `lib/index.d.ts` with `turbopack?: boolean` so `makeGasket({ turbopack: true })` is type-checked.
- Register the hook in `lib/index.js`.
- Document the opt-in mechanism, the self-only externalization scope, and the guidance for other plugin authors in the README.
- Add a minor changeset.
- Add regression coverage in `test/next-config.test.js`, including a test that explicitly proves the auto-scan is gone (a fixture with sibling plugins produces exactly `[@gasket/core, @gasket/plugin-nextjs]`).

## Validation

- `pnpm --filter @gasket/plugin-nextjs test`: 168 tests passed (5 turbopack tests + 163 pre-existing).
- `pnpm --filter @gasket/plugin-nextjs typecheck` passed.
- Package lint passed with six pre-existing `lib/index.d.ts` warnings (unchanged from this PR).
- `pnpm --filter @gasket/plugin-nextjs build` passed; CJS mirror in `cjs/next-config.cjs` regenerated (gitignored).
- Direct config probes confirmed:
  - `gasket.config.turbopack` unset or `false` → returns the original config with Webpack intact (identity).
  - `gasket.config.turbopack = true` → removes Webpack and adds `[@gasket/core, @gasket/plugin-nextjs]` to `serverExternalPackages`, deduplicated with any existing entries.
  - Sibling `@gasket/plugin-*` fixtures in `gasket.config.plugins` are NOT externalized by this hook (regression protection).

## Downstream validation

This behavior was exercised in a Next.js 16.2.6 App Router application using Turbopack, including server routes, Presentation Central, and a full browser smoke test. The downstream integration remains opt-in; app-specific Webpack aliases/fallbacks still need equivalent `turbopack.resolveAlias` configuration.

## Related

- gdcorp-uxp/gasket#2261 — the sibling refactor for `@godaddy/gasket-plugin-uxp`, which uses this hook's new pattern to self-register `@godaddy/gasket-plugin-uxp` + `@ux/presentation-central`.
- gdcorp-partners/airo-app-builder#6674 — downstream consumer using this API via pnpm patch, with a local migration-shim plugin covering the ~11 not-yet-migrated Gasket plugins in that stack. Documented per-plugin migration path in that PR's ticket.
