### PR TITLE
feat(plugin-intl): add preboot hook to await locale loading before server opens port

### DIFF
--- a/.changeset/light-badgers-unite.md
+++ b/.changeset/light-badgers-unite.md
@@ -1,0 +1,5 @@
+---
+"@gasket/plugin-intl": patch
+---
+
+add preboot hook to await locale loading before server opens port

--- a/packages/gasket-plugin-intl/lib/index.js
+++ b/packages/gasket-plugin-intl/lib/index.js
@@ -1,4 +1,5 @@
 /// <reference types="@gasket/plugin-metadata" />
+/// <reference types="@gasket/plugin-https" />
 
 import packageJson from '../package.json' with { type: 'json' };
 import actions from './actions.js';

--- a/packages/gasket-plugin-intl/lib/index.js
+++ b/packages/gasket-plugin-intl/lib/index.js
@@ -12,6 +12,7 @@ import create from './create.js';
 import postCreate from './post-create.js';
 import prompt from './prompt.js';
 import build from './build.js';
+import preboot from './preboot.js';
 const { name, version, description } = packageJson;
 
 /** @type {import('@gasket/core').Plugin} */
@@ -23,6 +24,7 @@ const plugin = {
   hooks: {
     init,
     configure,
+    preboot,
     create,
     postCreate,
     prompt,

--- a/packages/gasket-plugin-intl/lib/index.js
+++ b/packages/gasket-plugin-intl/lib/index.js
@@ -1,5 +1,4 @@
 /// <reference types="@gasket/plugin-metadata" />
-/// <reference types="@gasket/plugin-https" />
 
 import packageJson from '../package.json' with { type: 'json' };
 import actions from './actions.js';

--- a/packages/gasket-plugin-intl/lib/preboot.js
+++ b/packages/gasket-plugin-intl/lib/preboot.js
@@ -1,0 +1,24 @@
+// @ts-nocheck - preboot is typed by @gasket/plugin-https which is not a direct dependency
+/// <reference types="@gasket/plugin-https" />
+
+/**
+ * Preboot lifecycle hook - waits for all locale files to finish loading
+ * before the server opens its port.
+ *
+ * InternalIntlManager.init() kicks off locale preloading asynchronously
+ * (fire-and-forget) when the manager is first imported. Without this hook,
+ * requests that arrive before preloading completes receive an empty messages
+ * object and render i18n keys instead of translated strings.
+ *
+ * LocaleHandler.load() returns the already in-flight promise from
+ * promisesRegister (debounced), so this does not trigger extra I/O.
+ * @type {import('@gasket/core').HookHandler<'preboot'>}
+ */
+export default async function preboot(gasket) {
+  if (gasket.config.intl?.experimentalImportAttributes) {
+    const intlMgr = await gasket.actions.getIntlManager();
+    await Promise.all(
+      intlMgr.locales.map(locale => intlMgr.handleLocale(locale).load())
+    );
+  }
+}

--- a/packages/gasket-plugin-intl/lib/preboot.js
+++ b/packages/gasket-plugin-intl/lib/preboot.js
@@ -1,4 +1,3 @@
-// @ts-nocheck - preboot is typed by @gasket/plugin-https which is not a direct dependency
 /// <reference types="@gasket/plugin-https" />
 
 /**

--- a/packages/gasket-plugin-intl/package.json
+++ b/packages/gasket-plugin-intl/package.json
@@ -60,6 +60,7 @@
     "@gasket/plugin-data": "workspace:^",
     "@gasket/plugin-elastic-apm": "workspace:^",
     "@gasket/plugin-logger": "workspace:^",
+    "@gasket/plugin-https": "workspace:^",
     "@gasket/plugin-metadata": "workspace:^",
     "@gasket/plugin-nextjs": "workspace:^",
     "@gasket/plugin-service-worker": "workspace:^",

--- a/packages/gasket-plugin-intl/test/index.test.js
+++ b/packages/gasket-plugin-intl/test/index.test.js
@@ -27,6 +27,7 @@ describe('Plugin', function () {
       'publicGasketData',
       'init',
       'metadata',
+      'preboot',
       'serviceWorkerCacheKey'
     ];
 

--- a/packages/gasket-plugin-intl/test/preboot.test.js
+++ b/packages/gasket-plugin-intl/test/preboot.test.js
@@ -1,0 +1,52 @@
+import preboot from '../lib/preboot.js';
+
+describe('preboot', () => {
+  let mockGasket, mockLoad, mockHandler, mockIntlMgr;
+
+  beforeEach(() => {
+    mockLoad = vi.fn().mockResolvedValue();
+    mockHandler = { load: mockLoad };
+    mockIntlMgr = {
+      locales: ['en-US', 'fr', 'de'],
+      handleLocale: vi.fn().mockReturnValue(mockHandler)
+    };
+    mockGasket = {
+      config: {
+        intl: { experimentalImportAttributes: true }
+      },
+      actions: {
+        getIntlManager: vi.fn().mockResolvedValue(mockIntlMgr)
+      }
+    };
+  });
+
+  it('calls load for every locale', async () => {
+    await preboot(mockGasket);
+    expect(mockIntlMgr.handleLocale).toHaveBeenCalledTimes(3);
+    expect(mockLoad).toHaveBeenCalledTimes(3);
+  });
+
+  it('awaits all locale loads before resolving', async () => {
+    let resolveLoad;
+    mockLoad.mockReturnValueOnce(new Promise(res => { resolveLoad = res; }));
+
+    const done = preboot(mockGasket).then(() => 'resolved');
+    await Promise.resolve();
+    expect(await Promise.race([done, Promise.resolve('pending')])).toBe('pending');
+
+    resolveLoad();
+    expect(await done).toBe('resolved');
+  });
+
+  it('does nothing when experimentalImportAttributes is not set', async () => {
+    delete mockGasket.config.intl.experimentalImportAttributes;
+    await preboot(mockGasket);
+    expect(mockGasket.actions.getIntlManager).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when intl config is absent', async () => {
+    delete mockGasket.config.intl;
+    await preboot(mockGasket);
+    expect(mockGasket.actions.getIntlManager).not.toHaveBeenCalled();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -946,6 +946,9 @@ importers:
       '@gasket/plugin-elastic-apm':
         specifier: workspace:^
         version: link:../gasket-plugin-elastic-apm
+      '@gasket/plugin-https':
+        specifier: workspace:^
+        version: link:../gasket-plugin-https
       '@gasket/plugin-logger':
         specifier: workspace:^
         version: link:../gasket-plugin-logger
@@ -15206,7 +15209,7 @@ snapshots:
 
   '@docusaurus/react-loadable@6.0.0(react@19.2.4)':
     dependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.7
       react: 19.2.4
 
   '@docusaurus/theme-classic@3.8.1(@swc/core@1.10.18(@swc/helpers@0.5.15))(@types/react@19.0.12)(acorn@8.15.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.2)':
@@ -16950,7 +16953,7 @@ snapshots:
   '@types/react-router-dom@5.3.3':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.2.14
+      '@types/react': 19.2.7
       '@types/react-router': 5.1.20
 
   '@types/react-router@5.1.20':
@@ -23372,7 +23375,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.28.6
 
   regexp-tree@0.1.27: {}
 


### PR DESCRIPTION
## Summary

- Adds a `preboot` lifecycle hook to `gasket-plugin-intl` that waits for all locale files to finish loading before the server opens its port
- Moves the `@gasket/plugin-https` type reference to `preboot.js` (where it is actually needed) and removes the stray `@ts-nocheck` suppression
- Registers the new hook in `index.js`
- Adds full test coverage in `preboot.test.js` and updates the hook list assertion in `index.test.js`

## Problem

`InternalIntlManager.init()` kicks off locale preloading asynchronously (fire-and-forget) when the manager is first imported. Without this hook, requests that arrive before preloading completes receive an empty messages object and render i18n keys instead of translated strings.

## Solution

The `preboot` hook calls `intlMgr.handleLocale(locale).load()` for every locale and awaits all of them via `Promise.all`. `LocaleHandler.load()` returns the already-in-flight promise (debounced via `promisesRegister`), so this adds no extra I/O — it just ensures the server waits for the work that's already happening.

The hook is gated behind `intl.experimentalImportAttributes` so it has zero impact on existing setups.

## Test plan

- [ ] `preboot` calls `load()` for every configured locale
- [ ] Server does not open until all locale loads settle
- [ ] No-ops when `experimentalImportAttributes` is not set
- [ ] No-ops when `intl` config is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)