### PR TITLE
Security: Potential prototype pollution via Object.assign

### DIFF
--- a/packages/create-gasket-app/lib/scaffold/utils.js
+++ b/packages/create-gasket-app/lib/scaffold/utils.js
@@ -2,13 +2,22 @@ import path from 'path';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 
+function sanitize(obj) {
+  return Object.keys(obj).reduce((acc, key) => {
+    if (key !== '__proto__' && key !== 'constructor' && key !== 'prototype') {
+      acc[key] = obj[key];
+    }
+    return acc;
+  }, {});
+}
+
 /** @type {import('../internal.js').readConfig} */
 export function readConfig(context, { config, configFile }) {
   if (config) {
     const parsedConfig = JSON.parse(config);
-    Object.assign(context, parsedConfig);
+    Object.assign(context, sanitize(parsedConfig));
   } else if (configFile) {
     const parsedConfigFile = require(path.resolve(context.cwd, configFile));
-    Object.assign(context, parsedConfigFile);
+    Object.assign(context, sanitize(parsedConfigFile));
   }
 }


### PR DESCRIPTION
## Summary

Security: Potential prototype pollution via Object.assign

## Problem

**Severity**: `High` | **File**: `packages/create-gasket-app/lib/scaffold/utils.js:L8`

In `readConfig`, user-provided JSON configurations (via CLI flags or config files) are merged directly into the `context` object using `Object.assign`. If the parsed JSON contains `__proto__` or `constructor.prototype` keys, it can lead to prototype pollution, allowing an attacker to manipulate object prototypes and potentially execute arbitrary code or alter application behavior.

## Solution

Sanitize the parsed configuration objects before merging them into `context` to remove dangerous keys like `__proto__` and `constructor`. Alternatively, use a safe merge utility or `Object.create(null)`.

## Changes

- `packages/create-gasket-app/lib/scaffold/utils.js` (modified)